### PR TITLE
Consolidation and refactoring of ROMS repositories to GitHub

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,14 @@
 
 ![roms-jedi logo](https://www.myroms.org/trac/roms_src_600px.png)
 
+**ROMS** solves the free-surface, hydrostatic, flux form of the primitive
+equations over variable bathymetry using stretched terrain-following in the
+vertical and orthogonal curvilinear coordinates in the horizontal. The finite
+volume grid is discretized on a staggered Arakawa C-grid. Detailed information
+about its governing equations, numerical discretization, algorithms, usage, and
+tutorials is available in the **WikiROMS** documentation portal at
+**`www.myroms.org/wiki`**.
+
 The dynamical kernel of **ROMS** is comprised of four separate models, including
 the nonlinear (**NLM**), perturbation tangent linear (**TLM**), finite amplitude
 tangent linear (**RPM**), and adjoint (**ADM**). They are located in the
@@ -12,44 +20,59 @@ its dynamical and numerical kernels will affect the symmetry of the **TLM** and
 **ADM** operators. The discrete adjoint is exact and is defined relative to
 the inner product that prescribes the L2-norm.
 
-**ROMS** solves the free-surface, hydrostatic, flux form of the primitive
-equations over variable bathymetry using stretched terrain-following in the
-vertical and orthogonal curvilinear coordinates in the horizontal. The finite
-volume grid is discretized on a staggered Arakawa C-grid. Detailed information
-about its governing equation, numerical discretization, algorithms, usage, and
-tutorials is available in the **WikiROMS** documentation portal at
-**`www.myroms.org/wiki`**.
-
-The official community version of **ROMS** is developed and maintained at Rutgers,
+This official community version of ROMS is developed and maintained at Rutgers,
 The State University of New Jersey, New Brunswick, New Jersey, USA. The scarlet
-flag in the above logo indicates the location of our institution. This GitHub
-version is mirrored from the community repositories at **`www.myroms.org`**
-for usage within the **JCSDA-JEDI** Project and does not require registration on
-the **ROMS** website, and can be checkout from:
+flag in the above logo indicates the location of our institution. Currently, it
+contains the following branches:
+
+- **master**: Tagged versions and the latest stable release version of **ROMS**
+- **develop**: Main developing branch of **ROMS**. Not recommended for public
+ consumption but passes the internal tests. It is intended for ROMS superusers
+ and beta testers.
+- **feature branches**: Research and new development branches recommended to
+superusers and beta testers.
+
+The **ROMS**  framework is intended for users interested in ocean modeling. It
+requires an extensive background in ocean dynamics, numerical modeling, and
+computers to configure, run, and analyze the results to ensure you get the
+correct solution for your application. Therefore, **we highly recommend** users
+register at https://www.myroms.org and set up a **username** and **password** to
+access the **ROMS** forum, email notifications for bugs/updates, technical
+support from the community, **trac** code maintenance, tutorials, workshops, and
+publications. The user's ROMS forum has over 24,000 posts with helpful
+information. Technical support is limited to registered users. We **do not**
+provide user technical support, usage, or answers in **GitHub**.  
+
+This **GitHub** version becomes the official **git** repository for downloading,
+updating, improving, and correcting defects/bugs to the **ROMS** source code.
+Also, it is the version used in the **ROMS-JEDI** interface hosted at
+https://github.com/JCSDA-internal, which is currently private. Use the following
+command to download the **ROMS** source code:
 ```
-git clone https://github.com/JCSDA-internal/roms_src.git                 (default)
-git clone https://github.com/JCSDA-internal/roms_src.git <source_dir>
+git clone https://github.com/myroms/roms_src.git                 (default)
+git clone https://github.com/myroms/roms_src.git <source_dir>
+```
+The idealized and realistic **ROMS** Test Cases and the Matlab processing
+software can be downloaded from:
+```
+git clone https://github.com/myroms/roms_test.git
+git clone https://github.com/myroms/roms_matlab.git
 ```
 The **doxygen** version of **ROMS** is available at:
 ```
 https://www.myroms.org/doxygen
 ```
-
 Registered users of **ROMS** have access to:
-
-- Official **svn** and **git** repositories
-  ```
-  svn checkout --username joe_roms https://www.myroms.org/svn/src/trunk <source_dir>
-
-  git clone https://joe_roms@www.myroms.org/git/src <source_dir>
-  ```
-
-- Idealized and Realistic test cases repository
-  ```
-  svn checkout https://www.myroms.org/svn/src/test <test_dir>
-  ```
 
 - **ROMS** User's Forum:
   ```
   https://www.myroms.org/forum
+  ```
+- **Trac** source code maintenance and evolution:
+  ```
+  https://www.myroms.org/projects/src
+  ```
+- **WikiROMS** documentation and tutorials plus editing:
+  ```
+  https://www.myroms.org/wiki
   ```


### PR DESCRIPTION
## Description

We started the process of consolidating our **ROMS** repositories. We have too many research **git** and **svn** repositories. In a few days, we will host the **git** repository on **GitHub** and will have several branches when cloning the **ROMS** source code:

- **`master`**: Tagged versions and the latest stable release version of **ROMS**
- **`develop:`** Main developing branch of **ROMS**. Not recommended for public consumption but passes the internal tests. It is recommended for **ROMS** superusers and beta testers.
- **`feature branches`**: Research and new development branches recommended to superusers and beta testers:
  -   **`feature/kernels`**: Major update to **ROMS** numerical kernels (**omega.F** and **step2d.F**).
  -  **`feature/seaice`**: Native ROMS sea-ice model refactoring and development.
  - **`feature/wec`**: Wave Effects on Currents algorithms adopted from **COAWST**.

We suggest waiting until we are done with the refactoring and the regular and novice user to focus on either the master or develop branches. The restructuring facilitates the maintenance of ROMS source code, the development of new algorithms, and updating of the **COAWST** system.

We still recommend users interact via [​https://www.myroms.org/forum](https://www.myroms.org/forum) for discussions and problems. There is plenty of information at [​https://www.myroms.org/wiki](https://www.myroms.org/wiki).

## Issue(s) addressed

None.