### PR TITLE
CMake build scripts and output variables statistics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # git $Id$
-# svn $Id: CMakeLists.txt 1186 2023-08-02 01:08:21Z arango $
+# svn $Id: CMakeLists.txt 1189 2023-08-15 21:26:58Z arango $
 #:::::::::::::::::::::::::::::::::::::::::::::::::::::: David Robertson :::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
@@ -8,11 +8,42 @@
 #
 # Top-Level CMake File Definitions.
 
-cmake_minimum_required( VERSION 3.12.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.13.0 FATAL_ERROR )
 
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Compilers)
 Message( STATUS "module path = ${CMAKE_MODULE_PATH}" )
 set( CMAKE_DIRECTORY_LABELS ${PROJECT_NAME} )
+
+find_package( Git )
+if( GIT_FOUND )
+  if( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git )
+    message( STATUS "Getting and setting GIT_URL and GIT_REV" )
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} config --get remote.origin.url
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      OUTPUT_VARIABLE GITURL
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} rev-parse --verify HEAD
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      OUTPUT_VARIABLE GITREV
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    add_compile_definitions( GIT_URL="${GITURL}" GIT_REV="${GITREV}" SVN_URL="https://www.myroms.org/svn/src" )
+  endif()
+endif()
+
+find_package( Subversion )
+if( SUBVERSION_FOUND )
+  if( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.svn )
+    message( STATUS "Getting and setting SVN_URL and SVN_REV" )
+    Subversion_WC_INFO(${CMAKE_CURRENT_SOURCE_DIR} roms IGNORE_SVN_FAILURE)
+    add_compile_definitions( SVN_URL="${roms_WC_URL}" SVN_REV="${roms_WC_REVISION}" )
+  endif()
+endif()
 
 # Figure out if we are using ecbuild.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # git $Id$
-# svn $Id: CMakeLists.txt 1189 2023-08-15 21:26:58Z arango $
+# svn $Id: CMakeLists.txt 1192 2023-08-23 18:33:57Z arango $
 #:::::::::::::::::::::::::::::::::::::::::::::::::::::: David Robertson :::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
@@ -71,6 +71,25 @@ endif()
 include( roms_functions )
 include( roms_compiler_flags )
 include( roms_config )
+
+# Set MYDEFS to list of Compiling defeinition to check for options that require
+# cmake configuration adjustments
+
+get_directory_property( MYDEFS COMPILE_DEFINITIONS )
+
+# Check if we need to include ESMF
+
+if( MYDEFS MATCHES "ESMF_LIB" )
+  find_package( ESMF REQUIRED )
+  if( ESMF_FOUND )
+    message( STATUS "ESMF_INCLUDE_DIRECTORIES = ${ESMF_INCLUDE_DIRECTORIES}" )
+    message( STATUS "ESMF_LIBRARY_LOCATION = ${ESMF_LIBRARY_LOCATION}" )
+    message( STATUS "ESMF_INTERFACE_LINK_LIBRARIES = ${ESMF_INTERFACE_LINK_LIBRARIES}" )
+    include_directories( ${ESMF_INCLUDE_DIRECTORIES} )
+  else()
+    message( FATAL "ESMF NOT FOUND" )
+  endif()
+endif()
 
 ###########################################################################
 # Project
@@ -416,6 +435,12 @@ else()
 
     if( ARPACK )
       target_link_libraries( "${BIN}" parpack arpack )
+    endif()
+
+    # if ESMF is requested, add to linking library list
+
+    if( MYDEFS MATCHES "ESMF_LIB" )
+      target_link_libraries( "${BIN}" ESMF )
     endif()
 
     # If parallel I/O with SCORPIO is requested, add to linking library list.

--- a/Compilers/FindESMF.cmake
+++ b/Compilers/FindESMF.cmake
@@ -1,0 +1,138 @@
+# - Try to find ESMF
+#
+# Uses ESMFMKFILE to find the filepath of esmf.mk. If this is NOT set, then this
+# module will attempt to find esmf.mk. If ESMFMKFILE exists, then
+# ESMF_FOUND=TRUE and all ESMF makefile variables will be set in the global
+# scope. Optionally, set ESMF_MKGLOBALS to a string list to filter makefile
+# variables. For example, to globally scope only ESMF_LIBSDIR and ESMF_APPSDIR
+# variables, use this CMake command in CMakeLists.txt:
+#
+#   set(ESMF_MKGLOBALS "LIBSDIR" "APPSDIR")
+
+# Set ESMFMKFILE as defined by system env variable. If it's not explicitly set
+# try to find esmf.mk file in default locations (ESMF_ROOT, CMAKE_PREFIX_PATH,
+# etc)
+if(NOT DEFINED ESMFMKFILE)
+  if(NOT DEFINED ENV{ESMFMKFILE})
+    find_path(ESMFMKFILE_PATH esmf.mk PATH_SUFFIXES lib lib64)
+    if(ESMFMKFILE_PATH)
+      set(ESMFMKFILE ${ESMFMKFILE_PATH}/esmf.mk)
+      message(STATUS "Found esmf.mk file ${ESMFMKFILE}")
+    endif()
+  else()
+    set(ESMFMKFILE $ENV{ESMFMKFILE})
+  endif()
+endif()
+
+# Only parse the mk file if it is found
+if(EXISTS ${ESMFMKFILE})
+  set(ESMFMKFILE ${ESMFMKFILE} CACHE FILEPATH "Path to esmf.mk file")
+  set(ESMF_FOUND TRUE CACHE BOOL "esmf.mk file found" FORCE)
+
+  # Read the mk file
+  file(STRINGS "${ESMFMKFILE}" esmfmkfile_contents)
+  # Parse each line in the mk file
+  foreach(str ${esmfmkfile_contents})
+    # Only consider uncommented lines
+    string(REGEX MATCH "^[^#]" def ${str})
+    # Line is not commented
+    if(def)
+      # Extract the variable name
+      string(REGEX MATCH "^[^=]+" esmf_varname ${str})
+      # Extract the variable's value
+      string(REGEX MATCH "=.+$" esmf_vardef ${str})
+      # Only for variables with a defined value
+      if(esmf_vardef)
+        # Get rid of the assignment string
+        string(SUBSTRING ${esmf_vardef} 1 -1 esmf_vardef)
+        # Remove whitespace
+        string(STRIP ${esmf_vardef} esmf_vardef)
+        # A string or single-valued list
+        if(NOT DEFINED ESMF_MKGLOBALS)
+          # Set in global scope
+          set(${esmf_varname} ${esmf_vardef})
+          # Don't display by default in GUI
+          mark_as_advanced(esmf_varname)
+        else() # Need to filter global promotion
+          foreach(m ${ESMF_MKGLOBALS})
+            string(FIND ${esmf_varname} ${m} match)
+            # Found the string
+            if(NOT ${match} EQUAL -1)
+              # Promote to global scope
+              set(${esmf_varname} ${esmf_vardef})
+              # Don't display by default in the GUI
+              mark_as_advanced(esmf_varname)
+              # No need to search for the current string filter
+              break()
+            endif()
+          endforeach()
+        endif()
+      endif()
+    endif()
+  endforeach()
+
+  # Construct ESMF_VERSION from ESMF_VERSION_STRING_GIT
+  # ESMF_VERSION_MAJOR and ESMF_VERSION_MINOR are defined in ESMFMKFILE
+  set(ESMF_VERSION 0)
+  set(ESMF_VERSION_PATCH ${ESMF_VERSION_REVISION})
+  set(ESMF_BETA_RELEASE FALSE)
+  if(ESMF_VERSION_BETASNAPSHOT MATCHES "^('T')$")
+    set(ESMF_BETA_RELEASE TRUE)
+    if(ESMF_VERSION_STRING_GIT MATCHES "^ESMF.*beta_snapshot_[0-9]")
+      string(REGEX REPLACE "^ESMF.*beta_snapshot_\([0-9]*\).*" "\\1" ESMF_BETA_SNAPSHOT "${ESMF_VERSION_STRING_GIT}")
+    elseif(ESMF_VERSION_STRING_GIT MATCHES "^v.*b[0-9]")
+      string(REGEX REPLACE "^v.*b\([0-9]*\).*" "\\1" ESMF_BETA_SNAPSHOT "${ESMF_VERSION_STRING_GIT}")
+    else()
+      set(ESMF_BETA_SNAPSHOT 0)
+    endif()
+    message(STATUS "Detected ESMF Beta snapshot ${ESMF_BETA_SNAPSHOT}")
+  endif()
+  set(ESMF_VERSION "${ESMF_VERSION_MAJOR}.${ESMF_VERSION_MINOR}.${ESMF_VERSION_PATCH}")
+
+  # Find the ESMF library
+  if(USE_ESMF_STATIC_LIBS)
+    find_library(ESMF_LIBRARY_LOCATION NAMES libesmf.a PATHS ${ESMF_LIBSDIR} NO_DEFAULT_PATH)
+    if(ESMF_LIBRARY_LOCATION MATCHES "ESMF_LIBRARY_LOCATION-NOTFOUND")
+      message(WARNING "Static ESMF library (libesmf.a) not found in \
+                       ${ESMF_LIBSDIR}. Try setting USE_ESMF_STATIC_LIBS=OFF")
+    endif()
+    add_library(ESMF STATIC IMPORTED)
+  else()
+    find_library(ESMF_LIBRARY_LOCATION NAMES esmf PATHS ${ESMF_LIBSDIR} NO_DEFAULT_PATH)
+    if(ESMF_LIBRARY_LOCATION MATCHES "ESMF_LIBRARY_LOCATION-NOTFOUND")
+      message(WARNING "ESMF library not found in ${ESMF_LIBSDIR}.")
+    endif()
+    add_library(ESMF UNKNOWN IMPORTED)
+  endif()
+
+  # Add ESMF include directories
+  set(ESMF_INCLUDE_DIRECTORIES "")
+  separate_arguments(_ESMF_F90COMPILEPATHS NATIVE_COMMAND ${ESMF_F90COMPILEPATHS})
+  foreach(_ITEM ${_ESMF_F90COMPILEPATHS})
+    string(REGEX REPLACE "^-I" "" _ITEM "${_ITEM}")
+    list(APPEND ESMF_INCLUDE_DIRECTORIES ${_ITEM})
+  endforeach()
+
+  # Add ESMF link libraries
+  string(STRIP "${ESMF_F90ESMFLINKRPATHS} ${ESMF_F90ESMFLINKPATHS} ${ESMF_F90LINKPATHS} ${ESMF_F90LINKLIBS} ${ESMF_F90LINKOPTS}" ESMF_INTERFACE_LINK_LIBRARIES)
+
+  # Finalize find_package
+  include(FindPackageHandleStandardArgs)
+
+  find_package_handle_standard_args(
+        ${CMAKE_FIND_PACKAGE_NAME}
+        REQUIRED_VARS ESMF_LIBRARY_LOCATION
+                      ESMF_INTERFACE_LINK_LIBRARIES
+                      ESMF_F90COMPILEPATHS
+        VERSION_VAR ESMF_VERSION)
+
+  set_target_properties(ESMF PROPERTIES
+        IMPORTED_LOCATION "${ESMF_LIBRARY_LOCATION}"
+        INTERFACE_INCLUDE_DIRECTORIES "${ESMF_INCLUDE_DIRECTORIES}"
+        INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")
+
+else()
+  set(ESMF_FOUND FALSE CACHE BOOL "esmf.mk file NOT found" FORCE)
+  message(WARNING "ESMFMKFILE ${ESMFMKFILE} not found. Try setting ESMFMKFILE \
+                   to esmf.mk location.")
+endif()

--- a/Compilers/roms_compiler_flags.cmake
+++ b/Compilers/roms_compiler_flags.cmake
@@ -1,5 +1,5 @@
 # git $Id$
-# svn $Id: roms_compiler_flags.cmake 1178 2023-07-11 17:50:57Z arango $
+# svn $Id: roms_compiler_flags.cmake 1189 2023-08-15 21:26:58Z arango $
 #:::::::::::::::::::::::::::::::::::::::::::::::::::::: David Robertson :::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
@@ -44,5 +44,5 @@ endif()
 string( TOUPPER ${my_os} OS )
 string( TOUPPER ${my_cpu} CPU )
 string( TOUPPER ${my_fort} FORT )
-add_definitions ( -D${OS} -D${CPU} -D${FORT} )
+add_compile_definitions ( ${OS} ${CPU} ${FORT} )
 

--- a/Compilers/roms_config.cmake
+++ b/Compilers/roms_config.cmake
@@ -1,5 +1,5 @@
 # git $Id$
-# svn $Id: roms_config.cmake 1166 2023-05-17 20:11:58Z arango $
+# svn $Id: roms_config.cmake 1189 2023-08-15 21:26:58Z arango $
 #:::::::::::::::::::::::::::::::::::::::::::::::::::::: David Robertson :::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
@@ -9,7 +9,7 @@
 # CMake configuration for any ROMS application.
 
 string( TOLOWER "${ROMS_APP}.h" ROMS_APP_HEADER )
-add_definitions( -DROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}" -D${ROMS_APP} -DHEADER="${ROMS_APP_HEADER}" )
+add_compile_definitions( ROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}" ${ROMS_APP} HEADER="${ROMS_APP_HEADER}" )
 
 # Do you want a shared or static library?
 
@@ -57,13 +57,12 @@ set( HEADER_DIR  ${MY_HEADER_DIR} )
 
 # Any custom analytical files?
 
-if( NOT DEFINED MY_ANALYTICAL_DIR )
+if( NOT DEFINED ENV{MY_ANALYTICAL_DIR} )
   set( ANALYTICAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ROMS/Functionals" )
-  add_definitions( -DANALYTICAL_DIR="${ANALYTICAL_DIR}" )
+  add_compile_definitions( ANALYTICAL_DIR="${ANALYTICAL_DIR}" )
   # no need for "include_directories" since it is already included
 else()
-  add_definitions( -DANALYTICAL_DIR="${MY_ANALYTICAL_DIR}" )
-  include_directories( ${MY_ANALYTICAL_DIR} )
+  include_directories( $ENV{MY_ANALYTICAL_DIR} )
 endif()
 
 # Location(s) of ARPACK/PARPACK libraries. If both libarpack.a and libparpack.a
@@ -111,38 +110,27 @@ else()
   set( PIO_INCDIR "" )
 endif()
 
-
-
-# Set ROMS SVN repository information.
-
-set( SVN_URL "${MY_SVN_URL}" )
-set( SVN_REV "${MY_SVN_REV}" )
-
 set( ROMS_HEADER ${HEADER_DIR}/${ROMS_APP_HEADER} )
 
-add_definitions(
-  -DROMS_HEADER="${ROMS_HEADER}"
-  -DSVN_URL="${SVN_URL}"
-  -DSVN_REV="${SVN_REV}"
-)
+add_compile_definitions( ROMS_HEADER="${ROMS_HEADER}" )
 
 # Set ROMS Executable Name.
 
 if( ${CMAKE_BUILD_TYPE} MATCHES "Debug" )
   set( BIN "romsG" )
   if( MPI )
-    add_definitions( -DMPI )
+    add_compile_definitions( MPI )
   endif()
 elseif( MPI )
   set( BIN "romsM" )
-  add_definitions( -DMPI )
+  add_compile_definitions( MPI )
 else()
   set( BIN "romsS" )
 endif()
 
 if( MY_CPP_FLAGS )
   foreach( flag ${MY_CPP_FLAGS} )
-    add_definitions( -D${flag} )
+    add_compile_definitions( ${flag} )
   endforeach()
   get_options( ${ROMS_HEADER} ${MY_CPP_FLAGS} )
 else()

--- a/Master/CMakeLists.txt
+++ b/Master/CMakeLists.txt
@@ -1,17 +1,25 @@
 # git $Id$
-# svn $Id: CMakeLists.txt 1166 2023-05-17 20:11:58Z arango $
+# svn $Id: CMakeLists.txt 1192 2023-08-23 18:33:57Z arango $
 #:::::::::::::::::::::::::::::::::::::::::::::::::::::: David Robertson :::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
 #   See License_ROMS.txt                                                :::
 #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 #
-# Source code list for sub-directory "Master"
+# Source code list for sub-directory "Master". We cannot add "master.F" to
+# list because it is needed to define the ROMS executable in the main
+# CMakeList.txt.
 
 list( APPEND _files
       Master/cmeps_roms.F
       Master/coupler.F
+      Master/esmf_atm.F
+      Master/esmf_data.F
+      Master/esmf_esm.F
+      Master/esmf_ice.F
       Master/esmf_roms.F
+      Master/esmf_wav.F
+      Master/mod_esmf_esm.F
       Master/propagator.F
       Master/roms_kernel.F
 )

--- a/ROMS/Adjoint/ad_wrt_his.F
+++ b/ROMS/Adjoint/ad_wrt_his.F
@@ -3,7 +3,7 @@
 #ifdef ADJOINT
 !
 !git $Id$
-!svn $Id: ad_wrt_his.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: ad_wrt_his.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -210,6 +210,22 @@
       Fcount=ADM(ng)%load
       ADM(ng)%Nrec(Fcount)=ADM(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+# ifdef SOLVE3D
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, nout, ADM(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) kout, nout, ADM(ng)%Rindex
+#  endif
+# else
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, ADM(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) kout, ADM(ng)%Rindex
+#  endif
+# endif
+!
 !  If requested, set time index to recycle time records in the adjoint
 !  file.
 !
@@ -245,7 +261,8 @@
 !
       scale=1.0_dp                          ! m2/s2
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, ADM(ng)%Vid(idUsms),   &
+      status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idUsms,                &
+     &                   ADM(ng)%Vid(idUsms),                           &
      &                   ADM(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -254,7 +271,7 @@
      &                   FORCES(ng) % ad_ustr(:,:,:,Lfout(ng)))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), Lfout(ng)
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), Lfout(ng)
         END IF
         exit_flag=3
         ioerror=status
@@ -265,7 +282,8 @@
 !
       scale=1.0_dp                          ! m2/s2
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, ADM(ng)%Vid(idVsms),   &
+      status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idVsms,                &
+     &                   ADM(ng)%Vid(idVsms),                           &
      &                   ADM(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -274,7 +292,7 @@
      &                   FORCES(ng) % ad_vstr(:,:,:,Lfout(ng)))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), Lfout(ng)
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), Lfout(ng)
         END IF
         exit_flag=3
         ioerror=status
@@ -291,7 +309,7 @@
         IF (Lstflux(itrc,ng)) THEN
           scale=1.0_dp                      ! kinematic flux units
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idTsur(itrc),      &
      &                       ADM(ng)%Vid(idTsur(itrc)),                 &
      &                       ADM(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -301,7 +319,7 @@
      &                       FORCES(ng)% ad_tflux(:,:,:,Lfout(ng),itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))), Lfout(ng)
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))), Lfout(ng)
             END IF
             exit_flag=3
             ioerror=status
@@ -316,7 +334,8 @@
       IF (Hout(idbath,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, ADM(ng)%Vid(idbath), &
+        status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idbath,              &
+     &                     ADM(ng)%Vid(idbath),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 # ifdef MASKING
@@ -326,7 +345,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idbath)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idbath)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -341,7 +360,7 @@
         IF (WRTforce(ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r2dvar
-          status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid,                    &
+          status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idFsur,            &
      &                       ADM(ng)%Vid(idFsur),                       &
      &                       ADM(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -351,7 +370,7 @@
      &                       OCEAN(ng)% f_zetaG(:,:,kfout))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idFsur)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idFsur)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -362,7 +381,7 @@
           scale=1.0_dp
           gtype=gfactor*r2dvar
           IF (LwrtState2d(ng)) THEN
-            status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid,                  &
+            status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idFsur,          &
      &                         ADM(ng)%Vid(idFsur),                     &
      &                         ADM(ng)%Rindex, gtype,                   &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -376,7 +395,7 @@
      &                         OCEAN(ng)% ad_zeta(:,:,kout))
 # endif
           ELSE
-            status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid,                  &
+            status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idFsur,          &
      &                         ADM(ng)%Vid(idFsur),                     &
      &                         ADM(ng)%Rindex, gtype,                   &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -392,7 +411,7 @@
           ENDIF
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idFsur)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idFsur)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -418,7 +437,7 @@
      &                                                    Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))),            &
      &                        ADM(ng)%Rindex
           END IF
           exit_flag=3
@@ -435,7 +454,7 @@
         IF (WRTforce(ng)) THEN
           scale=1.0_dp
           gtype=gfactor*u2dvar
-          status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid,                    &
+          status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idUbar,            &
      &                       ADM(ng)%Vid(idUbar),                       &
      &                       ADM(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -445,7 +464,7 @@
      &                       OCEAN(ng) % f_ubarG(:,:,kfout))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idUbar)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idUbar)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -456,7 +475,7 @@
           scale=1.0_dp
           gtype=gfactor*u2dvar
           IF (LwrtState2d(ng)) THEN
-            status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid,                  &
+            status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idUbar,          &
      &                         ADM(ng)%Vid(idUbar),                     &
      &                         ADM(ng)%Rindex, gtype,                   &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -465,7 +484,7 @@
 # endif
      &                         OCEAN(ng) % ad_ubar(:,:,kout))
           ELSE
-            status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid,                  &
+            status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idUbar,          &
      &                         ADM(ng)%Vid(idUbar),                     &
      &                         ADM(ng)%Rindex, gtype,                   &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -476,7 +495,7 @@
           END IF
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idUbar)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idUbar)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -502,7 +521,7 @@
      &                                                    Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))),            &
      &                        ADM(ng)%Rindex
           END IF
           exit_flag=3
@@ -519,7 +538,7 @@
         IF (WRTforce(ng)) THEN
           scale=1.0_dp
           gtype=gfactor*v2dvar
-          status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid,                    &
+          status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idVbar,            &
      &                       ADM(ng)%Vid(idVbar),                       &
      &                       ADM(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -529,7 +548,7 @@
      &                       OCEAN(ng) % f_vbarG(:,:,kfout))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idVbar)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idVbar)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -540,7 +559,7 @@
           scale=1.0_dp
           gtype=gfactor*v2dvar
           IF (LwrtState2d(ng)) THEN
-            status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid,                  &
+            status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idVbar,          &
      &                         ADM(ng)%Vid(idVbar),                     &
      &                         ADM(ng)%Rindex, gtype,                   &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -549,7 +568,7 @@
 # endif
      &                         OCEAN(ng) % ad_vbar(:,:,kout))
           ELSE
-            status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid,                  &
+            status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idVbar,          &
      &                         ADM(ng)%Vid(idVbar),                     &
      &                         ADM(ng)%Rindex, gtype,                   &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -560,7 +579,7 @@
           END IF
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idVbar)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idVbar)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -586,7 +605,7 @@
      &                                                    Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))),            &
      &                        ADM(ng)%Rindex
           END IF
           exit_flag=3
@@ -605,7 +624,7 @@
         IF (WRTforce(ng)) THEN
           scale=1.0_dp
           gtype=gfactor*u3dvar
-          status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idUvel,            &
      &                       ADM(ng)%Vid(idUvel),                       &
      &                       ADM(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -615,7 +634,7 @@
      &                       OCEAN(ng) % f_uG(:,:,:,kfout))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idUvel)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idUvel)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -628,7 +647,7 @@
 #  ifdef AD_OUTPUT_STATE
           IF (LwrtState3d(ng)) THEN
 #  endif
-            status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid,                  &
+            status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idUvel,          &
      &                         ADM(ng)%Vid(idUvel),                     &
      &                         ADM(ng)%Rindex, gtype,                   &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
@@ -638,7 +657,7 @@
      &                         OCEAN(ng) % ad_u(:,:,:,nout))
 #  ifdef AD_OUTPUT_STATE
           ELSE
-            status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid,                  &
+            status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idUvel,          &
      &                         ADM(ng)%Vid(idUvel),                     &
      &                         ADM(ng)%Rindex, gtype,                   &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
@@ -650,7 +669,7 @@
 #  endif
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idUvel)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idUvel)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -676,7 +695,7 @@
      &                                                 Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))),            &
      &                        ADM(ng)%Rindex
           END IF
           exit_flag=3
@@ -693,7 +712,7 @@
         IF (WRTforce(ng)) THEN
           scale=1.0_dp
           gtype=gfactor*v3dvar
-          status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idVvel,            &
      &                       ADM(ng)%Vid(idVvel),                       &
      &                       ADM(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -703,7 +722,7 @@
      &                       OCEAN(ng) % f_vG(:,:,:,kfout))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idVvel)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idVvel)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -716,7 +735,7 @@
 #  ifdef AD_OUTPUT_STATE
           IF (LwrtState3d(ng)) THEN
 #  endif
-            status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid,                  &
+            status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idVvel,          &
      &                         ADM(ng)%Vid(idVvel),                     &
      &                         ADM(ng)%Rindex, gtype,                   &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
@@ -726,7 +745,7 @@
      &                         OCEAN(ng) % ad_v(:,:,:,nout))
 #  ifdef AD_OUTPUT_STATE
           ELSE
-            status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid,                  &
+            status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idVvel,          &
      &                         ADM(ng)%Vid(idVvel),                     &
      &                         ADM(ng)%Rindex, gtype,                   &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
@@ -738,7 +757,7 @@
 #  endif
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idVvel)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idVvel)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -764,7 +783,7 @@
      &                                                 Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))),            &
      &                        ADM(ng)%Rindex
           END IF
           exit_flag=3
@@ -788,7 +807,7 @@
      &                    GRID(ng) % pn,                                &
      &                    OCEAN(ng) % ad_W_sol,                         &
      &                    Wr3d)
-        status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid,                      &
+        status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idOvel,              &
      &                     ADM(ng)%Vid(idOvel),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -798,7 +817,7 @@
      &                     Wr3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idOvel)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idOvel)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -815,7 +834,7 @@
           IF (WRTforce(ng)) THEN
             scale=1.0_dp
             gtype=gfactor*r3dvar
-            status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid,                  &
+            status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idTvar(itrc),    &
      &                         ADM(ng)%Tid(itrc),                       &
      &                         ADM(ng)%Rindex, gtype,                   &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
@@ -825,7 +844,7 @@
      &                         OCEAN(ng) % f_tG(:,:,:,kfout,itrc))
             IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
               IF (Master) THEN
-                WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),          &
+                WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),          &
      &                            ADM(ng)%Rindex
               END IF
               exit_flag=3
@@ -839,7 +858,7 @@
 #  ifdef AD_OUTPUT_STATE
             IF (LwrtState3d(ng)) THEN
 #  endif
-              status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid,                &
+              status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idTvar(itrc),  &
      &                           ADM(ng)%Tid(itrc),                     &
      &                           ADM(ng)%Rindex, gtype,                 &
      &                           LBi, UBi, LBj, UBj, 1, N(ng), scale,   &
@@ -849,7 +868,7 @@
      &                           OCEAN(ng) % ad_t(:,:,:,nout,itrc))
 #  ifdef AD_OUTPUT_STATE
             ELSE
-              status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid,                &
+              status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idTvar(itrc),  &
      &                           ADM(ng)%Tid(itrc),                     &
      &                           ADM(ng)%Rindex, gtype,                 &
      &                           LBi, UBi, LBj, UBj, 1, N(ng), scale,   &
@@ -861,7 +880,7 @@
 #  endif
             IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
               IF (Master) THEN
-                WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),          &
+                WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),          &
      &                            ADM(ng)%Rindex
               END IF
               exit_flag=3
@@ -891,7 +910,7 @@
      &                                                 Lbout(ng),itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
+              WRITE (stdout,20) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
      &                          ADM(ng)%Rindex
             END IF
             exit_flag=3
@@ -907,7 +926,8 @@
       IF (Hout(idDano,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, ADM(ng)%Vid(idDano), &
+        status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idDano,              &
+     &                     ADM(ng)%Vid(idDano),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -916,7 +936,7 @@
      &                     OCEAN(ng) % ad_rho)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idDano)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idDano)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -929,7 +949,8 @@
       IF (Hout(idVvis,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, ADM(ng)%Vid(idVvis), &
+        status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idVvis,              &
+     &                     ADM(ng)%Vid(idVvis),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
 #  ifdef MASKING
@@ -939,7 +960,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvis)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvis)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -952,7 +973,8 @@
       IF (Hout(idTdif,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, ADM(ng)%Vid(idTdif), &
+        status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idTdif,              &
+     &                     ADM(ng)%Vid(idTdif),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
 #  ifdef MASKING
@@ -962,7 +984,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTdif)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTdif)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -976,7 +998,8 @@
       IF (Hout(idSdif,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, ADM(ng)%Vid(idSdif), &
+        status=nf_fwrite3d(ng, iADM, ADM(ng)%ncid, idSdif,              &
+     &                     ADM(ng)%Vid(idSdif),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
 #   ifdef MASKING
@@ -986,7 +1009,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSdif)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSdif)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1012,7 +1035,7 @@
           scale=1.0_dp
 #   endif
           gtype=gfactor*r2dvar
-          status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid,                    &
+          status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idTsur(itrc),      &
      &                       ADM(ng)%Vid(idTsur(itrc)),                 &
      &                       ADM(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1022,7 +1045,7 @@
      &                       FORCES(ng) % ad_stflx(:,:,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          ADM(ng)%Rindex
             END IF
             exit_flag=3
@@ -1046,7 +1069,8 @@
         scale=1.0_dp
 #  endif
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, ADM(ng)%Vid(idUsms), &
+        status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idUsms,              &
+     &                     ADM(ng)%Vid(idUsms),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -1055,7 +1079,7 @@
      &                     FORCES(ng) % ad_sustr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUsms)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUsms)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1074,7 +1098,8 @@
         scale=1.0_dp
 #  endif
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, ADM(ng)%Vid(idVsms), &
+        status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idVsms,              &
+     &                     ADM(ng)%Vid(idVsms),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -1083,7 +1108,7 @@
      &                     FORCES(ng) % ad_svstr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVsms)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVsms)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1098,7 +1123,8 @@
 !!      scale=-rho0
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, ADM(ng)%Vid(idUbms), &
+        status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idUbms,              &
+     &                     ADM(ng)%Vid(idUbms),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 # ifdef MASKING
@@ -1107,7 +1133,7 @@
      &                     FORCES(ng) % ad_bustr_sol)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbms)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbms)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1121,7 +1147,8 @@
 !!      scale=-rho0
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, ADM(ng)%Vid(idVbms), &
+        status=nf_fwrite2d(ng, iADM, ADM(ng)%ncid, idVbms,              &
+     &                     ADM(ng)%Vid(idVbms),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 # ifdef MASKING
@@ -1130,7 +1157,7 @@
      &                     FORCES(ng) % ad_bvstr_sol)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbms)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbms)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1146,23 +1173,7 @@
       CALL netcdf_sync (ng, iADM, ADM(ng)%name, ADM(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-# ifdef SOLVE3D
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, nout, ADM(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) kout, nout, ADM(ng)%Rindex
-#  endif
-# else
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, ADM(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) kout, ADM(ng)%Rindex
-#  endif
-# endif
-!
-  10  FORMAT (/,' AD_WRT_HIS_NF90 - error while writing variable: ',a,  &
-     &        /,19x,'into adjoint NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'AD_WRT_HIS_NF90  - wrote adjoint', t40,               &
+  10  FORMAT (2x,'AD_WRT_HIS_NF90  - writing adjoint', t42,             &
 # ifdef SOLVE3D
 #  ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
@@ -1176,6 +1187,8 @@
      &        'fields (Index=',i1,')   in record = ',i0)
 #  endif
 # endif
+  20  FORMAT (/,' AD_WRT_HIS_NF90 - error while writing variable: ',a,  &
+     &        /,19x,'into adjoint NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE ad_wrt_his_nf90
@@ -1264,6 +1277,22 @@
       Fcount=ADM(ng)%load
       ADM(ng)%Nrec(Fcount)=ADM(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+#  ifdef SOLVE3D
+#   ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, nout, ADM(ng)%Rindex, ng
+#   else
+      IF (Master) WRITE (stdout,10) kout, nout, ADM(ng)%Rindex
+#   endif
+#  else
+#   ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, ADM(ng)%Rindex, ng
+#   else
+      IF (Master) WRITE (stdout,10) kout, ADM(ng)%Rindex
+#   endif
+#  endif
+!
 !  If requested, set time index to recycle time records in the adjoint
 !  file.
 !
@@ -1304,7 +1333,7 @@
         ioDesc => ioDesc_sp_u2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idUsms,             &
      &                   ADM(ng)%pioVar(idUsms),                        &
      &                   ADM(ng)%Rindex, ioDesc,                        &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
@@ -1314,7 +1343,7 @@
      &                   FORCES(ng) % ad_ustr(:,:,:,Lfout(ng)))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), Lfout(ng)
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), Lfout(ng)
         END IF
         exit_flag=3
         ioerror=status
@@ -1330,7 +1359,7 @@
         ioDesc => ioDesc_sp_v2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idVsms,             &
      &                   ADM(ng)%pioVar(idVsms),                        &
      &                   ADM(ng)%Rindex, ioDesc,                        &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
@@ -1340,7 +1369,7 @@
      &                   FORCES(ng) % ad_vstr(:,:,:,Lfout(ng)))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), Lfout(ng)
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), Lfout(ng)
         END IF
         exit_flag=3
         ioerror=status
@@ -1362,7 +1391,7 @@
             ioDesc => ioDesc_sp_r2dfrc(ng)
           END IF
 !
-          status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idTsur(itrc),   &
      &                       ADM(ng)%pioVar(idTsur(itrc)),              &
      &                       ADM(ng)%Rindex, ioDesc,                    &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -1372,7 +1401,7 @@
      &                       FORCES(ng)% ad_tflux(:,:,:,Lfout(ng),itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))), Lfout(ng)
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))), Lfout(ng)
             END IF
             exit_flag=3
             ioerror=status
@@ -1392,7 +1421,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
 !
-        status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idbath,           &
      &                     ADM(ng)%pioVar(idbath),                      &
      &                     ADM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1403,7 +1432,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idbath)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idbath)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1423,7 +1452,7 @@
       IF (Hout(idFsur,ng)) THEN
 #  ifdef WEAK_CONSTRAINT
         IF (WRTforce(ng)) THEN
-          status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,                 &
+          status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idFsur,         &
      &                       ADM(ng)%pioVar(idFsur),                    &
      &                       ADM(ng)%Rindex, ioDesc,                    &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1433,7 +1462,7 @@
      &                       OCEAN(ng)% f_zetaG(:,:,kfout))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idFsur)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idFsur)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1442,7 +1471,7 @@
         ELSE
 #  endif
           IF (LwrtState2d(ng)) THEN
-            status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,               &
+            status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idFsur,       &
      &                         ADM(ng)%pioVar(idFsur),                  &
      &                         ADM(ng)%Rindex, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -1456,7 +1485,7 @@
      &                         OCEAN(ng)% ad_zeta(:,:,kout))
 #  endif
           ELSE
-            status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,               &
+            status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idFsur,       &
      &                         ADM(ng)%pioVar(idFsur),                  &
      &                         ADM(ng)%Rindex, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -1472,7 +1501,7 @@
           ENDIF
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idFsur)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idFsur)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1505,7 +1534,7 @@
      &                                                    Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))),            &
      &                        ADM(ng)%Rindex
           END IF
           exit_flag=3
@@ -1527,7 +1556,7 @@
       IF (Hout(idUbar,ng)) THEN
 #  ifdef WEAK_CONSTRAINT
         IF (WRTforce(ng)) THEN
-          status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,                 &
+          status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idUbar,         &
      &                       ADM(ng)%pioVar(idUbar),                    &
      &                       ADM(ng)%Rindex, ioDesc,                    &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1537,7 +1566,7 @@
      &                       OCEAN(ng) % f_ubarG(:,:,kfout))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idUbar)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idUbar)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1546,7 +1575,7 @@
         ELSE
 #  endif
           IF (LwrtState2d(ng)) THEN
-            status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,               &
+            status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idUbar,       &
      &                         ADM(ng)%pioVar(idUbar),                  &
      &                         ADM(ng)%Rindex, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -1555,7 +1584,7 @@
 #  endif
      &                         OCEAN(ng) % ad_ubar(:,:,kout))
           ELSE
-            status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,               &
+            status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idUbar,       &
      &                         ADM(ng)%pioVar(idUbar),                  &
      &                         ADM(ng)%Rindex, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -1566,7 +1595,7 @@
           END IF
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idUbar)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idUbar)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1599,7 +1628,7 @@
      &                                                    Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))),            &
      &                        ADM(ng)%Rindex
           END IF
           exit_flag=3
@@ -1622,7 +1651,7 @@
 
 #  ifdef WEAK_CONSTRAINT
         IF (WRTforce(ng)) THEN
-          status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,                 &
+          status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idVbar,         &
      &                       ADM(ng)%pioVar(idVbar),                    &
      &                       ADM(ng)%Rindex, ioDesc,                    &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1632,7 +1661,7 @@
      &                       OCEAN(ng) % f_vbarG(:,:,kfout))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idVbar)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idVbar)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1641,7 +1670,7 @@
         ELSE
 #  endif
           IF (LwrtState2d(ng)) THEN
-            status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,               &
+            status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idVbar,       &
      &                         ADM(ng)%pioVar(idVbar),                  &
      &                         ADM(ng)%Rindex, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -1650,7 +1679,7 @@
 #  endif
      &                         OCEAN(ng) % ad_vbar(:,:,kout))
           ELSE
-            status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,               &
+            status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idVbar,       &
      &                         ADM(ng)%pioVar(idVbar),                  &
      &                         ADM(ng)%Rindex, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -1661,7 +1690,7 @@
           END IF
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idVbar)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idVbar)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1694,7 +1723,7 @@
      &                                                    Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))),            &
      &                        ADM(ng)%Rindex
           END IF
           exit_flag=3
@@ -1718,7 +1747,7 @@
       IF (Hout(idUvel,ng)) THEN
 #   ifdef WEAK_CONSTRAINT
         IF (WRTforce(ng)) THEN
-          status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idUvel,         &
      &                       ADM(ng)%pioVar(idUvel),                    &
      &                       ADM(ng)%Rindex, ioDesc,                    &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1728,7 +1757,7 @@
      &                       OCEAN(ng) % f_uG(:,:,:,kfout))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idUvel)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idUvel)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1739,7 +1768,7 @@
 #   ifdef AD_OUTPUT_STATE
           IF (LwrtState3d(ng)) THEN
 #   endif
-            status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,               &
+            status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idUvel,       &
      &                         ADM(ng)%pioVar(idUvel),                  &
      &                         ADM(ng)%Rindex, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
@@ -1749,7 +1778,7 @@
      &                         OCEAN(ng) % ad_u(:,:,:,nout))
 #   ifdef AD_OUTPUT_STATE
           ELSE
-            status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,               &
+            status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idUvel,       &
      &                         ADM(ng)%pioVar(idUvel),                  &
      &                         ADM(ng)%Rindex, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
@@ -1761,7 +1790,7 @@
 #   endif
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idUvel)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idUvel)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1794,7 +1823,7 @@
      &                                                 Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))),            &
      &                        ADM(ng)%Rindex
           END IF
           exit_flag=3
@@ -1816,7 +1845,7 @@
       IF (Hout(idVvel,ng)) THEN
 #   ifdef WEAK_CONSTRAINT
         IF (WRTforce(ng)) THEN
-          status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idVvel,         &
      &                       ADM(ng)%pioVar(idVvel),                    &
      &                       ADM(ng)%Rindex, ioDesc,                    &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1826,7 +1855,7 @@
      &                       OCEAN(ng) % f_vG(:,:,:,kfout))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idVvel)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idVvel)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1837,7 +1866,7 @@
 #   ifdef AD_OUTPUT_STATE
           IF (LwrtState3d(ng)) THEN
 #   endif
-            status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,               &
+            status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idVvel,       &
      &                         ADM(ng)%pioVar(idVvel),                  &
      &                         ADM(ng)%Rindex, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
@@ -1847,7 +1876,7 @@
      &                         OCEAN(ng) % ad_v(:,:,:,nout))
 #   ifdef AD_OUTPUT_STATE
           ELSE
-            status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,               &
+            status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idVvel,       &
      &                         ADM(ng)%pioVar(idVvel),                  &
      &                         ADM(ng)%Rindex, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
@@ -1859,7 +1888,7 @@
 #   endif
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idVvel)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idVvel)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1892,7 +1921,7 @@
      &                                                 Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))),            &
      &                        ADM(ng)%Rindex
           END IF
           exit_flag=3
@@ -1921,7 +1950,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idOvel,           &
      &                     ADM(ng)%pioVar(idOvel),                      &
      &                     ADM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1931,7 +1960,7 @@
      &                     Wr3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idOvel)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idOvel)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1954,7 +1983,7 @@
 
 #   ifdef WEAK_CONSTRAINT
           IF (WRTforce(ng)) THEN
-            status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,               &
+            status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idTvar(itrc), &
      &                         ADM(ng)%pioTrc(itrc),                    &
      &                         ADM(ng)%Rindex, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
@@ -1964,7 +1993,7 @@
      &                         OCEAN(ng) % f_tG(:,:,:,kfout,itrc))
             IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
               IF (Master) THEN
-                WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),          &
+                WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),          &
      &                            ADM(ng)%Rindex
               END IF
               exit_flag=3
@@ -1977,7 +2006,7 @@
             IF (LwrtState3d(ng)) THEN
 #   endif
               status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,             &
-     &                           ADM(ng)%pioTrc(itrc),                  &
+     &                           idTvar(itrc), ADM(ng)%pioTrc(itrc),    &
      &                           ADM(ng)%Rindex, ioDesc,                &
      &                           LBi, UBi, LBj, UBj, 1, N(ng), scale,   &
 #    ifdef MASKING
@@ -1987,7 +2016,7 @@
 #   ifdef AD_OUTPUT_STATE
             ELSE
               status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,             &
-     &                           ADM(ng)%pioTrc(itrc),                  &
+     &                           idTvar(itrc), ADM(ng)%pioTrc(itrc),    &
      &                           ADM(ng)%Rindex, ioDesc,                &
      &                           LBi, UBi, LBj, UBj, 1, N(ng), scale,   &
 #    ifdef MASKING
@@ -1998,7 +2027,7 @@
 #   endif
             IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
               IF (Master) THEN
-                WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),          &
+                WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),          &
      &                            ADM(ng)%Rindex
               END IF
               exit_flag=3
@@ -2036,7 +2065,7 @@
      &                                                 Lbout(ng),itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), ADM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), ADM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -2056,7 +2085,7 @@
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idDano,           &
      &                     ADM(ng)%pioVar(idDano),                      &
      &                     ADM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -2066,7 +2095,7 @@
      &                     OCEAN(ng) % ad_rho)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idDano)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idDano)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2084,7 +2113,7 @@
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idVvis,           &
      &                     ADM(ng)%pioVar(idVvis),                      &
      &                     ADM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -2095,7 +2124,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvis)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvis)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2113,7 +2142,7 @@
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idTdif,           &
      &                     ADM(ng)%pioVar(idTdif),                      &
      &                     ADM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -2124,7 +2153,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTdif)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTdif)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2144,7 +2173,7 @@
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iADM, ADM(ng)%pioFile, idSdif,           &
      &                     ADM(ng)%pioVar(idSdif),                      &
      &                     ADM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -2155,7 +2184,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSdif)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSdif)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2186,7 +2215,7 @@
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
 !
-          status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,                 &
+          status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idTsur(itrc),   &
      &                       ADM(ng)%pioVar(idTsur(itrc)),              &
      &                       ADM(ng)%Rindex, ioDesc,                    &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2196,7 +2225,7 @@
      &                       FORCES(ng) % ad_stflx(:,:,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          ADM(ng)%Rindex
             END IF
             exit_flag=3
@@ -2225,7 +2254,7 @@
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
 !
-        status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idUsms,           &
      &                     ADM(ng)%pioVar(idUsms),                      &
      &                     ADM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -2235,7 +2264,7 @@
      &                     FORCES(ng) % ad_sustr)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUsms)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUsms)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2259,7 +2288,7 @@
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
 !
-        status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idVsms,           &
      &                     ADM(ng)%pioVar(idVsms),                      &
      &                     ADM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -2269,7 +2298,7 @@
      &                     FORCES(ng) % ad_svstr)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVsms)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVsms)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2289,7 +2318,7 @@
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
 !
-        status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idUbms,           &
      &                     ADM(ng)%pioVar(idUbms),                      &
      &                     ADM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -2299,7 +2328,7 @@
      &                     FORCES(ng) % ad_bustr_sol)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbms)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbms)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2318,7 +2347,7 @@
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
 !
-        status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iADM, ADM(ng)%pioFile, idVbms,           &
      &                     ADM(ng)%pioVar(idVbms),                      &
      &                     ADM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -2328,7 +2357,7 @@
      &                     FORCES(ng) % ad_bvstr_sol)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbms)), ADM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbms)), ADM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2344,37 +2373,22 @@
       CALL pio_netcdf_sync (ng, iADM, ADM(ng)%name, ADM(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
+  10  FORMAT (2x,'AD_WRT_HIS_PIO   - writing adjoint', t42,             &
 #  ifdef SOLVE3D
-#   ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, nout, ADM(ng)%Rindex, ng
-#   else
-      IF (Master) WRITE (stdout,20) kout, nout, ADM(ng)%Rindex
-#   endif
-#  else
-#   ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, ADM(ng)%Rindex, ng
-#   else
-      IF (Master) WRITE (stdout,20) kout, ADM(ng)%Rindex
-#   endif
-#  endif
-!
-  10  FORMAT (/,' AD_WRT_HIS_PIO - error while writing variable: ',a,   &
-     &        /,18x,'into adjoint NetCDF file for time record: ',i0)
-#  ifdef SOLVE3D
-  20  FORMAT (2x,'AD_WRT_HIS_PIO   - wrote adjoint', t40,               &
 #   ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
 #   else
      &        'fields (Index=',i1,',',i1,') in record = ',i0)
 #   endif
 #  else
-  20  FORMAT (2x,'AD_WRT_HIS_PIO   - wrote adjoint', t40,               &
 #   ifdef NESTING
      &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
 #   else
      &        'fields (Index=',i1,')   in record = ',i0)
 #   endif
 #  endif
+  20  FORMAT (/,' AD_WRT_HIS_PIO - error while writing variable: ',a,   &
+     &        /,18x,'into adjoint NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE ad_wrt_his_pio

--- a/ROMS/Bin/build_roms.csh
+++ b/ROMS/Bin/build_roms.csh
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # git $Id$
-# svn $Id: build_roms.csh 1184 2023-07-27 20:28:19Z arango $
+# svn $Id: build_roms.csh 1191 2023-08-18 21:58:31Z arango $
 #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
@@ -147,7 +147,7 @@ else
   setenv MY_ROOT_DIR         ${HOME}/ocean/repository/git
 endif
 
-setenv   MY_PROJECT_DIR      ${PWD}n
+setenv   MY_PROJECT_DIR      ${PWD}
 
 # The path to the user's local current ROMS source code.
 #
@@ -327,6 +327,11 @@ else
     setenv BUILD_DIR        ${MY_PROJECT_DIR}/Build_roms
   endif
 endif
+
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
 
 # If necessary, create ROMS build directory.
 

--- a/ROMS/Bin/build_roms.csh
+++ b/ROMS/Bin/build_roms.csh
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 #
 # git $Id$
-# svn $Id: build_roms.csh 1191 2023-08-18 21:58:31Z arango $
+# svn $Id: build_roms.csh 1192 2023-08-23 18:33:57Z arango $
 #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
@@ -254,7 +254,7 @@ setenv   MY_PROJECT_DIR      ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/ROMS/Bin/build_roms.sh
+++ b/ROMS/Bin/build_roms.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # git $Id$
-# svn $Id: build_roms.sh 1191 2023-08-18 21:58:31Z arango $
+# svn $Id: build_roms.sh 1192 2023-08-23 18:33:57Z arango $
 #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
@@ -99,12 +99,12 @@ do
       branch=1
       branch_name=`echo $1 | grep -v '^-'`
       if [ "$branch_name" == "" ]; then
-	echo "Please enter a ROMS GitHub branch name."
-	exit 1
+        echo "Please enter a ROMS GitHub branch name."
+        exit 1
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -255,7 +255,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/ROMS/Bin/build_roms.sh
+++ b/ROMS/Bin/build_roms.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # git $Id$
-# svn $Id: build_roms.sh 1184 2023-07-27 20:28:19Z arango $
+# svn $Id: build_roms.sh 1191 2023-08-18 21:58:31Z arango $
 #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
@@ -328,6 +328,11 @@ else
     export      BUILD_DIR=${MY_PROJECT_DIR}/Build_roms
   fi
 fi
+
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
 
 # If necessary, create ROMS build directory.
 

--- a/ROMS/Bin/cbuild_roms.csh
+++ b/ROMS/Bin/cbuild_roms.csh
@@ -1,7 +1,7 @@
 #!/bin/csh -ef
 #
 # git $Id$
-# svn $Id: cbuild_roms.csh 1189 2023-08-15 21:26:58Z arango $
+# svn $Id: cbuild_roms.csh 1191 2023-08-18 21:58:31Z arango $
 #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
@@ -297,6 +297,11 @@ else if ($?USE_MPI) then
 else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
+
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
 
 # If necessary, create ROMS build directory.
 

--- a/ROMS/Bin/cbuild_roms.csh
+++ b/ROMS/Bin/cbuild_roms.csh
@@ -1,7 +1,7 @@
 #!/bin/csh -ef
 #
 # git $Id$
-# svn $Id: cbuild_roms.csh 1191 2023-08-18 21:58:31Z arango $
+# svn $Id: cbuild_roms.csh 1192 2023-08-23 18:33:57Z arango $
 #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
@@ -250,6 +250,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 
@@ -346,10 +374,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif

--- a/ROMS/Bin/cbuild_roms.sh
+++ b/ROMS/Bin/cbuild_roms.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # git $Id$
-# svn $Id: cbuild_roms.sh 1189 2023-08-15 21:26:58Z arango $
+# svn $Id: cbuild_roms.sh 1191 2023-08-18 21:58:31Z arango $
 #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
@@ -283,6 +283,11 @@ else
     export      BUILD_DIR=${MY_PROJECT_DIR}/CBuild_roms
   fi
 fi
+
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
 
 # If necessary, create ROMS build directory.
 

--- a/ROMS/Bin/cbuild_roms.sh
+++ b/ROMS/Bin/cbuild_roms.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # git $Id$
-# svn $Id: cbuild_roms.sh 1191 2023-08-18 21:58:31Z arango $
+# svn $Id: cbuild_roms.sh 1192 2023-08-23 18:33:57Z arango $
 #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 # Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
 #   Licensed under a MIT/X style license                                :::
@@ -248,6 +248,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 
@@ -335,7 +363,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi

--- a/ROMS/External/varinfo.yaml
+++ b/ROMS/External/varinfo.yaml
@@ -1,7 +1,7 @@
 # ROMS I/O NetCDF Metadata Dictionary
 #
 #git $Id$
-#svn $Id: varinfo.yaml 1182 2023-07-27 03:34:41Z arango $
+#svn $Id: varinfo.yaml 1189 2023-08-15 21:26:58Z arango $
 #========================================================= Hernan G. Arango ==#
 #  Copyright (c) 2002-2023 The ROMS/TOMS Group                                #
 #    Licensed under a MIT/X style license                                     #
@@ -68,17 +68,6 @@ metadata:
     time:           ocean_time
     index_code:     idtime
     type:           nulvar
-    add_offset:     0.0d0
-    scale:          1.0d0
-
-  - variable:       bath                                             # Input/Output
-    standard_name:  sea_floor_depth
-    long_name:      bathymetry
-    units:          meter                                            # [m]
-    field:          bathymetry
-    time:           ocean_time
-    index_code:     idbath
-    type:           r2dvar
     add_offset:     0.0d0
     scale:          1.0d0
 
@@ -313,10 +302,333 @@ metadata:
     add_offset:     0.0d0
     scale:          1.0d0
 
+  #######################
+  ###  Grid Geometry  ###
+  #######################
+
+  - variable:       angle                                            # Input
+    standard_name:  grid_angle_of_rotation_from_east_to_y
+    long_name:      angle between XI-axis and EAST
+    units:          radians                                          # [rafians]
+    field:          angle
+    time:           nulvar
+    index_code:     idangR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       bath                                             # Input/Output
+    standard_name:  sea_floor_depth
+    long_name:      time-dependent bathymetry
+    units:          meter                                            # [m; positive]
+    field:          bathymetry
+    time:           ocean_time
+    index_code:     idbath
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       f                                                # Input
+    standard_name:  coriolis_parameter
+    long_name:      Coriolis parameter
+    units:          second-1                                         # [1/s]
+    field:          coriolis
+    time:           nulvar
+    index_code:     idfcor
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       h                                                # Input
+    standard_name:  sea_floor_depth
+    long_name:      time-independent bathymetry
+    units:          meter                                            # [m; positive]
+    field:          bathymetry
+    time:           nulvar
+    index_code:     idtopo
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lat_psi                                          # Input
+    standard_name:  grid_latitude_at_cell_corners
+    long_name:      latitude of PSI-points
+    units:          degree_north                                     # [degree_north]
+    field:          lat_psi
+    time:           nulvar
+    index_code:     idLatP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lat_rho                                          # Input
+    standard_name:  grid_latitude_at_cell_center
+    long_name:      latitude of RHO-points
+    units:          degree_north                                     # [degree_north]
+    field:          lat_rho
+    time:           nulvar
+    index_code:     idLatR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lat_u                                            # Input
+    standard_name:  grid_latitude_at_cell_y_edges
+    long_name:      latitude of U-points
+    units:          degree_north                                     # [degree_north]
+    field:          lat_u
+    time:           nulvar
+    index_code:     idLatU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lat_v                                            # Input
+    standard_name:  grid_latitude_at_cell_x_edges
+    long_name:      latitude of V-points
+    units:          degree_north                                     # [degree_north]
+    field:          lat_v
+    time:           nulvar
+    index_code:     idLatV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lon_psi                                          # Input
+    standard_name:  grid_longitude_at_cell_corners
+    long_name:      longitude of PSI-points
+    units:          degree_east                                      # [degree_east]
+    field:          lon_psi
+    time:           nulvar
+    index_code:     idLonP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lon_rho                                          # Input
+    standard_name:  grid_longitude_at_cell_center
+    long_name:      longitude of RHO-points
+    units:          degree_east                                      # [degree_east]
+    field:          lon_rho
+    time:           nulvar
+    index_code:     idLonR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lon_u                                            # Input
+    standard_name:  grid_longitude_at_cell_y_edges
+    long_name:      longitude of U-points
+    units:          degree_east                                      # [degree_east]
+    field:          lon_u
+    time:           nulvar
+    index_code:     idLonU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lon_v                                            # Input
+    standard_name:  grid_longitude_at_cell_x_edges
+    long_name:      longitude of V-points
+    units:          degree_east                                      # [degree_east]
+    field:          lon_v
+    time:           nulvar
+    index_code:     idLonV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       mask_psi                                         # Input
+    standard_name:  land_sea_mask_at_cell_corners
+    long_name:      mask on PSI-points
+    units:          nondimensional
+    field:          mask_psi
+    time:           nulvar
+    index_code:     idmskP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       mask_rho                                         # Input
+    standard_name:  land_sea_mask_at_cell_center
+    long_name:      mask on RHO-points
+    units:          nondimensional
+    field:          mask_rho
+    time:           nulvar
+    index_code:     idmskR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       mask_u                                           # Input
+    standard_name:  land_sea_mask_at_cell_y_edges
+    long_name:      mask on U-points
+    units:          nondimensional
+    field:          mask_u
+    time:           nulvar
+    index_code:     idmskU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       mask_v                                           # Input
+    standard_name:  land_sea_mask_at_cell_x_edges
+    long_name:      mask on V-points
+    units:          nondimensional
+    field:          mask_v
+    time:           nulvar
+    index_code:     idmskV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       pm                                               # Input
+    standard_name:  inverse_grid_x_spacing
+    long_name:      curvilinear coordinate metric in XI
+    units:          meter-1                                          # [1/m]
+    field:          pm
+    time:           nulvar
+    index_code:     idpmdx
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       pn                                               # Input
+    standard_name:  inverse_grid_y_spacing
+    long_name:      curvilinear coordinate metric in ETA
+    units:          meter-1                                          # [1/m]
+    field:          pn
+    time:           nulvar
+    index_code:     idpndy
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       scope_rho                                        # Input
+    standard_name:  adjoint_sensitivity_scope_mask_at_cell_center
+    long_name:      adjoint sensitivity spatial scope on RHO-points
+    units:          nondimensional
+    field:          scope_rho
+    time:           nulvar
+    index_code:     idscoR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       scope_u                                          # Input
+    standard_name:  adjoint_sensitivity_scope_mask_at_cell_y_edges
+    long_name:      adjoint sensitivity spatial scope on U-points
+    units:          nondimensional
+    field:          scope_u
+    time:           nulvar
+    index_code:     idscoU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       scope_v                                          # Input
+    standard_name:  adjoint_sensitivity_scope_mask_at_cell_x_edges
+    long_name:      adjoint sensitivity spatial scope on V-points
+    units:          nondimensional
+    field:          scope_v
+    time:           nulvar
+    index_code:     idscoV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       x_psi                                            # Input
+    standard_name:  grid_x_location_at_cell_corners
+    long_name:      x-locations of PSI-points
+    units:          meter                                            # [m]
+    field:          Xp
+    time:           nulvar
+    index_code:     idXgrP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       x_rho                                            # Input
+    standard_name:  grid_x_location_at_cell_center
+    long_name:      x-locations of RHO-points
+    units:          meter                                            # [m]
+    field:          Xr
+    time:           nulvar
+    index_code:     idXgrR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       x_u                                              # Input
+    standard_name:  grid_x_location_at_cell_y_edges
+    long_name:      x-locations of U-points
+    units:          meter                                            # [m]
+    field:          Xu
+    time:           nulvar
+    index_code:     idXgrU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       x_v                                              # Input
+    standard_name:  grid_x_location_at_cell_x_edges
+    long_name:      x-locations of V-points
+    units:          meter                                            # [m]
+    field:          Xv
+    time:           nulvar
+    index_code:     idXgrV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       y_psi                                            # Input
+    standard_name:  grid_y_location_at_cell_corners
+    long_name:      y-locations of PSI-points
+    units:          meter                                            # [m]
+    field:          Yp
+    time:           nulvar
+    index_code:     idYgrP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       y_rho                                            # Input
+    standard_name:  grid_y_location_at_cell_center
+    long_name:      y-locations of RHO-points
+    units:          meter                                            # [m]
+    field:          Yr
+    time:           nulvar
+    index_code:     idYgrR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       y_u                                              # Input
+    standard_name:  grid_y_location_at_cell_y_edges
+    long_name:      y-locations of U-points
+    units:          meter                                            # [m]
+    field:          Yu
+    time:           nulvar
+    index_code:     idYgrU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       y_v                                              # Input
+    standard_name:  grid_y_location_at_cell_x_edges
+    long_name:      y-locations of V-points
+    units:          meter                                            # [m]
+    field:          Yv
+    time:           nulvar
+    index_code:     idYgrV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
   - variable:       z_rho                                            # Output
     standard_name:  model_level_depth_at_cell_center
     long_name:      depth of RHO-points
-    units:          meter                                            # [m]
+    units:          meter                                            # [m; negative]
     field:          Zr
     time:           ocean_time
     index_code:     idpthR
@@ -327,7 +639,7 @@ metadata:
   - variable:       z_u                                              # Output
     standard_name:  model_level_depth_at_cell_y_edges
     long_name:      depth of U-points
-    units:          meter                                            # [m]
+    units:          meter                                            # [m; negative]
     field:          Zu
     time:           ocean_time
     index_code:     idpthU
@@ -338,7 +650,7 @@ metadata:
   - variable:       z_v                                              # Output
     standard_name:  model_level_depth_at_cell_x_edges
     long_name:      depth of V-points
-    units:          meter                                            # [m]
+    units:          meter                                            # [m; negative]
     field:          Zv
     time:           ocean_time
     index_code:     idpthV
@@ -348,7 +660,7 @@ metadata:
 
   - variable:       z_w                                              # Output
     standard_name:  model_level_depth_at_cell_top_face
-    long_name:      depth of W-points                                # [m]
+    long_name:      depth of W-points                                # [m; negative]
     units:          meter
     field:          Zw
     time:           ocean_time

--- a/ROMS/Functionals/ana_drag.h
+++ b/ROMS/Functionals/ana_drag.h
@@ -2,7 +2,7 @@
       SUBROUTINE ana_drag (ng, tile, model)
 !
 !! git $Id$
-!! svn $Id: ana_drag.h 1151 2023-02-09 03:08:53Z arango $
+!! svn $Id: ana_drag.h 1189 2023-08-15 21:26:58Z arango $
 !!======================================================================
 !! Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !!   Licensed under a MIT/X style license                              !
@@ -152,7 +152,8 @@
 !
       IF (first) THEN
         first=.FALSE.
-        Stats % count=0.0_r8
+        Stats % checksum=0_i8b
+        Stats % count=0
         Stats % min=Large
         Stats % max=-Large
         Stats % avg=0.0_r8

--- a/ROMS/Functionals/ana_grid.h
+++ b/ROMS/Functionals/ana_grid.h
@@ -2,7 +2,7 @@
       SUBROUTINE ana_grid (ng, tile, model)
 !
 !! git $Id$
-!! svn $Id: ana_grid.h 1180 2023-07-13 02:42:10Z arango $
+!! svn $Id: ana_grid.h 1189 2023-08-15 21:26:58Z arango $
 !!======================================================================
 !! Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !!   Licensed under a MIT/X style license                              !
@@ -420,7 +420,8 @@
       IF (first) THEN
         first=.FALSE.
         DO i=1,SIZE(Stats,1)
-          Stats(i) % count=0.0_r8
+          Stats(i) % checksum=0_i8b
+          Stats(i) % count=0
           Stats(i) % min=Large
           Stats(i) % max=-Large
           Stats(i) % avg=0.0_r8

--- a/ROMS/Functionals/ana_initial.h
+++ b/ROMS/Functionals/ana_initial.h
@@ -2,7 +2,7 @@
       SUBROUTINE ana_initial (ng, tile, model)
 !
 !! git $Id$
-!! svn $Id: ana_initial.h 1180 2023-07-13 02:42:10Z arango $
+!! svn $Id: ana_initial.h 1189 2023-08-15 21:26:58Z arango $
 !!======================================================================
 !! Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !!   Licensed under a MIT/X style license                              !
@@ -203,7 +203,8 @@
       IF (first) THEN
         first=.FALSE.
         DO i=1,SIZE(Stats,1)
-          Stats(i) % count=0.0_r8
+          Stats(i) % checksum=0_i8b
+          Stats(i) % count=0
           Stats(i) % min=Large
           Stats(i) % max=-Large
           Stats(i) % avg=0.0_r8

--- a/ROMS/Functionals/ana_mask.h
+++ b/ROMS/Functionals/ana_mask.h
@@ -2,7 +2,7 @@
       SUBROUTINE ana_mask (ng, tile, model)
 !
 !! git $Id$
-!! svn $Id: ana_mask.h 1151 2023-02-09 03:08:53Z arango $
+!! svn $Id: ana_mask.h 1189 2023-08-15 21:26:58Z arango $
 !!======================================================================
 !! Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !!   Licensed under a MIT/X style license                              !
@@ -106,7 +106,8 @@
       IF (first) THEN
         first=.FALSE.
         DO i=1,SIZE(Stats,1)
-          Stats(i) % count=0.0_r8
+          Stats(i) % checksum=0_i8b
+          Stats(i) % count=0
           Stats(i) % min=Large
           Stats(i) % max=-Large
           Stats(i) % avg=0.0_r8

--- a/ROMS/Functionals/ana_wtype.h
+++ b/ROMS/Functionals/ana_wtype.h
@@ -2,7 +2,7 @@
       SUBROUTINE ana_wtype (ng, tile, model)
 !
 !! git $Id$
-!! svn $Id: ana_wtype.h 1151 2023-02-09 03:08:53Z arango $
+!! svn $Id: ana_wtype.h 1189 2023-08-15 21:26:58Z arango $
 !!======================================================================
 !! Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !!   Licensed under a MIT/X style license                              !
@@ -124,7 +124,8 @@
 !
       IF (first) THEN
         first=.FALSE.
-        Stats % count=0.0_r8
+        Stats % checksum=0_i8b
+        Stats % count=0
         Stats % min=Large
         Stats % max=-Large
         Stats % avg=0.0_r8

--- a/ROMS/Include/cppdefs.h
+++ b/ROMS/Include/cppdefs.h
@@ -2,7 +2,7 @@
 ** Include file "cppdefs.h"
 **
 ** git $Id$
-** svn $Id: cppdefs.h 1184 2023-07-27 20:28:19Z arango $
+** svn $Id: cppdefs.h 1189 2023-08-15 21:26:58Z arango $
 ********************************************************** Hernan G. Arango ***
 ** Copyright (c) 2002-2023 The ROMS/TOMS Group                               **
 **   Licensed under a MIT/X style license                                    **
@@ -604,6 +604,7 @@
 ** NO_READ_GHOST           to not include ghost points during read/scatter   **
 ** NO_WRITE_GRID           if not writing grid arrays                        **
 ** OUT_DOUBLE              if writing double precision output fields         **
+** OUTPUT_STATS            to report NetCDF output fields statistics         **
 ** PARALLEL_IO             if parallel I/O via HDF5 or pnetcdf libraries     **
 ** PERFECT_RESTART         to include perfect restart variables              **
 ** PIO_LIB                 to include Parallel-IO from the PIO library       **

--- a/ROMS/Modules/mod_fourdvar.F
+++ b/ROMS/Modules/mod_fourdvar.F
@@ -4,7 +4,7 @@
 #if defined FOUR_DVAR || defined VERIFICATION
 !
 !git $Id$
-!svn $Id: mod_fourdvar.F 1165 2023-04-10 01:59:07Z arango $
+!svn $Id: mod_fourdvar.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -1695,7 +1695,16 @@
         size2d=REAL((UBi-LBi+1)*(UBj-LBj+1),r8)
 #  endif
 #  ifdef SOLVE3D
-        NstateVar(ng)=5+NT(ng)
+        NstateVar(ng)=6+NT(ng)
+#   if defined GLS_MIXING || defined MY25_MIXING
+        NstateVar(ng)=NstateVar(ng)+1
+#   endif
+#   ifdef WEC
+        NstateVar(ng)=NstateVar(ng)+2
+#    if defined SOLVE3D
+        NstateVar(ng)=NstateVar(ng)+2
+#    endif
+#   endif
 #   ifdef ADJUST_STFLUX
         NstateVar(ng)=NstateVar(ng)+NT(ng)
 #   endif

--- a/ROMS/Modules/mod_ncparam.F
+++ b/ROMS/Modules/mod_ncparam.F
@@ -2,7 +2,7 @@
       MODULE mod_ncparam
 !
 !git $Id$
-!svn $Id: mod_ncparam.F 1189 2023-08-15 21:26:58Z arango $
+!svn $Id: mod_ncparam.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -1251,7 +1251,7 @@
       END DO
 #endif
 !
-!  Set IDs for state some state variables.
+!  Set indices for state some state variables.
 !
       ic=5
 #ifdef SOLVE3D

--- a/ROMS/Modules/mod_ncparam.F
+++ b/ROMS/Modules/mod_ncparam.F
@@ -2,7 +2,7 @@
       MODULE mod_ncparam
 !
 !git $Id$
-!svn $Id: mod_ncparam.F 1178 2023-07-11 17:50:57Z arango $
+!svn $Id: mod_ncparam.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -191,9 +191,10 @@
 !
 !  Input/output identification indices.
 !
-      integer  :: idbath        ! bathymetry
-      integer  :: idBgEr        ! Background error at observations
-      integer  :: idBgTh        ! Threshold for BQC check
+      integer  :: idangR        ! angle between XI-axis and EAST
+      integer  :: idbath        ! time-dependent bathymetry
+      integer  :: idBgEr        ! background error at observations
+      integer  :: idBgTh        ! threshold for BQC check
       integer  :: idCfra        ! cloud fraction
       integer  :: idCosW        ! COS(omega(k)*t)
       integer  :: idCos2        ! COS(omega(k)*t)*COS(omega(l)*t)
@@ -202,6 +203,7 @@
       integer  :: iddQdT        ! heat flux sensitivity to SST
       integer  :: idEmPf        ! E-P from bulk_flux.F
       integer  :: idevap        ! evaporation rate
+      integer  :: idfcor        ! Coriolis parameter
       integer  :: idFsur        ! free-surface
       integer  :: idFsuD        ! detided free-surface
       integer  :: idFsuH        ! free-surface tide harmonics
@@ -214,12 +216,24 @@
       integer  :: idInno        ! 4D-Var innovation vector
       integer  :: idKhor        ! convolution horizontal diffusion
       integer  :: idKver        ! convolution vertical diffusion
+      integer  :: idLatP        ! latitude of PSI-points
+      integer  :: idLatR        ! latitude of RHO-points
+      integer  :: idLatU        ! latitude of U-points
+      integer  :: idLatV        ! latitude of V-points
       integer  :: idLdwn        ! downwelling longwave radiation flux
+      integer  :: idLonP        ! longitude of PSI-points
+      integer  :: idLonR        ! longitude of RHO-points
+      integer  :: idLonU        ! longitude of U-points
+      integer  :: idLonV        ! longitude of V-points
       integer  :: idLhea        ! net latent heat flux
       integer  :: idLrad        ! net longwave radiation flux
       integer  :: idMadH        ! ADM interpolation weights
       integer  :: idMOMi        ! Initial model-observation misfit
       integer  :: idMOMf        ! final model-observation misfit
+      integer  :: idmskP        ! land/mask on PSI-points
+      integer  :: idmskR        ! land/mask on RHO-points
+      integer  :: idmskU        ! land/mask on U-points
+      integer  :: idmskV        ! land/mask on V-points
       integer  :: idMtke        ! turbulent kinetic energy
       integer  :: idMtls        ! turbulent length scale
       integer  :: idM2nc        ! 2D momentum nudging coefficients
@@ -249,6 +263,8 @@
       integer  :: idPair        ! surface air pressure
       integer  :: idPbar        ! streamfunction
       integer  :: idPwet        ! wet/dry mask on PSI-points
+      integer  :: idpmdx        ! inverse grid x-spacing
+      integer  :: idpndy        ! inverse grid y-spacing
       integer  :: idpthR        ! depths of RHO-points
       integer  :: idpthU        ! depths of U-points
       integer  :: idpthV        ! depths of V-points
@@ -282,10 +298,14 @@
       integer  :: idSWCW        ! SIN(omega(k)*t)*COS(omega(l)*t)
       integer  :: idResi        ! 4D-Var residual vector
       integer  :: idsfwf        ! surface freswater flux
+      integer  :: idscoR        ! ADM sensitivity scope RHO-mask
+      integer  :: idscoU        ! ADM sensitivity scope U-mask
+      integer  :: idscoV        ! ADM sensitivity scope V-mask
       integer  :: idTLmo        ! TLM at observation locations
       integer  :: idTair        ! surface air temperature
       integer  :: idTdif        ! vertical T-diffusion coefficient
       integer  :: idtime        ! ocean time
+      integer  :: idtopo        ! time-independent bathymetry
       integer  :: idTref        ! tidal reference date for zero phase
       integer  :: idTper        ! tidal period
       integer  :: idTvan        ! tidal current angle
@@ -401,6 +421,14 @@
       integer  :: idWvel        ! true vertical velocity
       integer  :: idWvqp        ! wave spectrum peakedness
       integer  :: idWztw        ! wec quasi-static sea level adjustment
+      integer  :: idXgrP        ! x-locations of PSI-points
+      integer  :: idXgrR        ! x-locations of RHO-points
+      integer  :: idXgrU        ! x-locations of U-points
+      integer  :: idXgrV        ! x-locations of V-points
+      integer  :: idYgrP        ! y-locations of PSI-points
+      integer  :: idYgrR        ! y-locations of RHO-points
+      integer  :: idYgrU        ! y-locations of U-points
+      integer  :: idYgrV        ! y-locations of V-points
       integer  :: idZoBL        ! bottom roughness length
       integer  :: idZads        ! Free-surface adjoint sensitivity
       integer  :: idZtlf        ! Free-surface impulse forcing
@@ -1426,10 +1454,64 @@
         load=.TRUE.
         varid=varid+1
         SELECT CASE (TRIM(ADJUSTL(Vinfo(8))))
-          CASE ('idtime')
-            idtime=varid
+          CASE ('idangR')
+            idangR=varid
           CASE ('idbath')
             idbath=varid
+          CASE ('idfcor')
+            idfcor=varid
+          CASE ('idtopo')
+            idtopo=varid
+          CASE ('idpmdx')
+            idpmdx=varid
+          CASE ('idpndy')
+            idpndy=varid
+          CASE ('idLonP')
+            idLonP=varid
+          CASE ('idLatP')
+            idLatP=varid
+          CASE ('idLonR')
+            idLonR=varid
+          CASE ('idLatR')
+            idLatR=varid
+          CASE ('idLonU')
+            idLonU=varid
+          CASE ('idLatU')
+            idLatU=varid
+          CASE ('idLonV')
+            idLonV=varid
+          CASE ('idLatV')
+            idLatV=varid
+          CASE ('idmskP')
+            idmskP=varid
+          CASE ('idmskR')
+            idmskR=varid
+          CASE ('idmskU')
+            idmskU=varid
+          CASE ('idmskV')
+            idmskV=varid
+          CASE ('idscoR')
+            idscoR=varid
+          CASE ('idscoU')
+            idscoU=varid
+          CASE ('idscoV')
+            idscoV=varid
+          CASE ('idXgrP')
+            idXgrP=varid
+          CASE ('idYgrP')
+            idYgrP=varid
+          CASE ('idXgrR')
+            idXgrR=varid
+          CASE ('idYgrR')
+            idYgrR=varid
+          CASE ('idXgrU')
+            idXgrU=varid
+          CASE ('idYgrU')
+            idYgrU=varid
+          CASE ('idXgrV')
+            idXgrV=varid
+          CASE ('idYgrV')
+            idYgrV=varid
           CASE ('idpthR')
             idpthR=varid
           CASE ('idpthU')
@@ -1438,6 +1520,8 @@
             idpthV=varid
           CASE ('idpthW')
             idpthW=varid
+          CASE ('idtime')
+            idtime=varid
           CASE ('idFsur')
             idFsur=varid
           CASE ('idRzet')

--- a/ROMS/Modules/mod_param.F
+++ b/ROMS/Modules/mod_param.F
@@ -2,7 +2,7 @@
       MODULE mod_param
 !
 !git $Id$
-!svn $Id: mod_param.F 1189 2023-08-15 21:26:58Z arango $
+!svn $Id: mod_param.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -1471,6 +1471,9 @@
         Jm(ng)=Mm(ng)+J_padd
         NT(ng)=NAT+NBT+NST+NPT
 #ifdef FLOATS
+!
+!  Number of floats variables.
+!
 # ifdef FLOAT_OYSTER
 #  ifdef FLOAT_VWALK
         NFV(ng)=NT(ng)+18
@@ -1485,17 +1488,30 @@
 #  endif
 # endif
 #endif
-        NSV(ng)=NT(ng)+5
+!
+!  Number of state variables.
+!
+        NSV(ng)=NT(ng)+6         ! zeta, ubar, vbar, u, v, W, Tvar(1:MT)
+#if defined GLS_MIXING || defined MY25_MIXING
+        NSV(ng)=NSV(ng)+1        ! TKE
+#endif
+#ifdef WEC
+        NSV(ng)=NSV(ng)+2        ! ubar_stokes, vbar_stokes
+# if defined SOLVE3D
+        NSV(ng)=NSV(ng)+2        ! u_stokes, v_stokes
+# endif
+#endif
 #ifdef ADJUST_WSTRESS
-        NSV(ng)=NSV(ng)+2
+        NSV(ng)=NSV(ng)+2        ! Ustr, Vstr
 #endif
 #ifdef ADJUST_STFLUX
-        NSV(ng)=NSV(ng)+NT(ng)
+        NSV(ng)=NSV(ng)+NT(ng)   ! Tsur(1:MT)
 #endif
       END DO
 !
-!  Set the maximum number of tracer between all nested grids. It cannot
-!  be zero.
+!  Set the maximum number of tracers between all nested grids. It cannot
+!  be zero. Usually, NAT=2 (temperature and salinity), but some Test
+!  Cases do not include salinity.
 !
       MT=MAX(1,MAX(NAT,MAXVAL(NT)))
 !

--- a/ROMS/Modules/mod_param.F
+++ b/ROMS/Modules/mod_param.F
@@ -2,7 +2,7 @@
       MODULE mod_param
 !
 !git $Id$
-!svn $Id: mod_param.F 1178 2023-07-11 17:50:57Z arango $
+!svn $Id: mod_param.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -410,7 +410,9 @@
 !-----------------------------------------------------------------------
 !
       TYPE T_STATS
-        real(r8) :: count         ! processed values count
+        integer(i8b) :: checksum  ! bit sum hash
+        integer      :: count     ! processed values count
+
         real(r8) :: min           ! minimum value
         real(r8) :: max           ! maximum value
         real(r8) :: avg           ! arithmetic mean

--- a/ROMS/Modules/mod_scalars.F
+++ b/ROMS/Modules/mod_scalars.F
@@ -2,7 +2,7 @@
       MODULE mod_scalars
 !
 !git $Id$
-!svn $Id: mod_scalars.F 1184 2023-07-27 20:28:19Z arango $
+!svn $Id: mod_scalars.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -1951,7 +1951,16 @@
 !-----------------------------------------------------------------------
 !
 #if defined FOUR_DVAR || defined VERIFICATION
-      MstateVar=5+MT
+      MstateVar=6+MT
+# if defined GLS_MIXING || defined MY25_MIXING
+      MstateVar=MstateVar+1
+# endif
+# ifdef WEC
+      MstateVar=MstateVar+2
+#  if defined SOLVE3D
+      MstateVar=MstateVar+2
+#  endif
+# endif
 # ifdef ADJUST_WSTRESS
       MstateVar=MstateVar+2
 # endif

--- a/ROMS/Nonlinear/BBL/bbl_output.F
+++ b/ROMS/Nonlinear/BBL/bbl_output.F
@@ -1762,7 +1762,8 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idWorb),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWorb,             &
+     &                       S(ng)%Vid(idWorb),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #  ifdef MASKING
@@ -1771,7 +1772,8 @@
      &                       FORCES(ng) % Uwave_rms)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idWorb),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWorb,             &
+     &                       S(ng)%Vid(idWorb),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
@@ -1799,7 +1801,8 @@
         scale=-rho0
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idUbrs),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUbrs,             &
+     &                       S(ng)%Vid(idUbrs),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #  ifdef MASKING
@@ -1808,7 +1811,8 @@
      &                       BBL(ng) % bustrc)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idUbrs),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUbrs,             &
+     &                       S(ng)%Vid(idUbrs),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
@@ -1833,7 +1837,8 @@
         scale=-rho0
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idVbrs),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idVbrs,             &
+     &                       S(ng)%Vid(idVbrs),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #  ifdef MASKING
@@ -1842,7 +1847,8 @@
      &                       BBL(ng) % bvstrc)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idVbrs),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idVbrs,             &
+     &                       S(ng)%Vid(idVbrs),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
@@ -1867,7 +1873,8 @@
         scale=rho0
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idUbws),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUbws,             &
+     &                       S(ng)%Vid(idUbws),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #  ifdef MASKING
@@ -1876,7 +1883,8 @@
      &                       BBL(ng) % bustrw)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idUbws),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUbws,             &
+     &                       S(ng)%Vid(idUbws),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
@@ -1901,7 +1909,8 @@
         scale=rho0
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idVbws),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idVbws,             &
+     &                       S(ng)%Vid(idVbws),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #  ifdef MASKING
@@ -1910,7 +1919,8 @@
      &                       BBL(ng) % bvstrw)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idVbws),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idVbws,             &
+     &                       S(ng)%Vid(idVbws),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
@@ -1935,7 +1945,8 @@
         scale=rho0
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idUbcs),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUbcs,             &
+     &                       S(ng)%Vid(idUbcs),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #  ifdef MASKING
@@ -1944,7 +1955,8 @@
      &                       BBL(ng) % bustrcwmax)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idUbcs),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUbcs,             &
+     &                       S(ng)%Vid(idUbcs),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
@@ -1969,7 +1981,8 @@
         scale=rho0
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idVbcs),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idVbcs,             &
+     &                       S(ng)%Vid(idVbcs),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #  ifdef MASKING
@@ -1978,7 +1991,8 @@
      &                       BBL(ng) % bvstrcwmax)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idVbcs),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idVbcs,             &
+     &                       S(ng)%Vid(idVbcs),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
@@ -2010,7 +2024,8 @@
           wrk2d=SQRT(BBL(ng)%bustrcwmax*BBL(ng)%bustrcwmax+             &
      &               BBL(ng)%bvstrcwmax*BBL(ng)%bvstrcwmax+1.0E-10_r8)
 !
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idUVwc),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUVwc,             &
+     &                       S(ng)%Vid(idUVwc),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #  ifdef MASKING
@@ -2020,7 +2035,8 @@
           deallocate (wrk2d)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idUVwc),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUVwc,             &
+     &                       S(ng)%Vid(idUVwc),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
@@ -2045,7 +2061,8 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idUbot),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUbot,             &
+     &                       S(ng)%Vid(idUbot),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #  ifdef MASKING
@@ -2054,7 +2071,8 @@
      &                       BBL(ng) % Ubot)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idUbot),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUbot,             &
+     &                       S(ng)%Vid(idUbot),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
@@ -2079,7 +2097,8 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idVbot),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idVbot,             &
+     &                       S(ng)%Vid(idVbot),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #  ifdef MASKING
@@ -2088,7 +2107,8 @@
      &                       BBL(ng) % Vbot)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idVbot),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idVbot,             &
+     &                       S(ng)%Vid(idVbot),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
@@ -2113,7 +2133,8 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idUbur),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUbur,             &
+     &                       S(ng)%Vid(idUbur),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #  ifdef MASKING
@@ -2122,7 +2143,8 @@
      &                       BBL(ng) % Ur)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idUbur),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUbur,             &
+     &                       S(ng)%Vid(idUbur),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
@@ -2147,7 +2169,8 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idVbvr),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idVbvr,             &
+     &                       S(ng)%Vid(idVbvr),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #  ifdef MASKING
@@ -2156,7 +2179,8 @@
      &                       BBL(ng) % Vr)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idVbvr),  &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idVbvr,             &
+     &                       S(ng)%Vid(idVbvr),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
@@ -2184,7 +2208,7 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (.not.Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idUwav,             &
      &                       S(ng)%Vid(idUwav),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2209,7 +2233,7 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (.not.Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idVwav,             &
      &                       S(ng)%Vid(idVwav),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2237,7 +2261,7 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWamp,             &
      &                       S(ng)%Vid(idWamp),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2247,7 +2271,7 @@
      &                       FORCES(ng) % Hwave)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWamp,             &
      &                       S(ng)%Vid(idWamp),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2275,7 +2299,7 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (.not.Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWam2,             &
      &                       S(ng)%Vid(idWam2),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2304,7 +2328,7 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWlen,             &
      &                       S(ng)%Vid(idWlen),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2314,7 +2338,7 @@
      &                       FORCES(ng) % Lwave)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWlen,             &
      &                       S(ng)%Vid(idWlen),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2343,7 +2367,7 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWlep,             &
      &                       S(ng)%Vid(idWlep),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2353,7 +2377,7 @@
      &                       FORCES(ng) % Lwavep)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWlep,             &
      &                       S(ng)%Vid(idWlep),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2382,7 +2406,7 @@
         scale=rad2deg
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWdir,             &
      &                       S(ng)%Vid(idWdir),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2392,7 +2416,7 @@
      &                       FORCES(ng) % Dwave)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWdir,             &
      &                       S(ng)%Vid(idWdir),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2421,7 +2445,7 @@
         scale=rad2deg
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWdip,             &
      &                       S(ng)%Vid(idWdip),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2431,7 +2455,7 @@
      &                       FORCES(ng) % Dwavep)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWdip,             &
      &                       S(ng)%Vid(idWdip),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2460,7 +2484,7 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWptp,             &
      &                       S(ng)%Vid(idWptp),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2470,7 +2494,7 @@
      &                       FORCES(ng) % Pwave_top)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWptp,             &
      &                       S(ng)%Vid(idWptp),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2499,7 +2523,7 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWpbt,             &
      &                       S(ng)%Vid(idWpbt),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2509,7 +2533,7 @@
      &                       FORCES(ng) % Pwave_bot)
 #  ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWpbt,             &
      &                       S(ng)%Vid(idWpbt),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2538,7 +2562,7 @@
         IF (Linstataneous) THEN
           scale=1.0_dp
           gtype=gfactor*r2dvar
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWvds,             &
      &                       S(ng)%Vid(idWvds),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -2563,7 +2587,7 @@
         IF (Linstataneous) THEN
           scale=1.0_dp
           gtype=gfactor*r2dvar
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idWvqp,             &
      &                       S(ng)%Vid(idWvqp),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -4189,7 +4213,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWorb,          &
      &                       S(ng)%pioVar(idWorb),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4200,7 +4224,7 @@
      &                       FORCES(ng) % Uwave_rms)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWorb,          &
      &                       S(ng)%pioVar(idWorb),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4234,7 +4258,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUbrs,          &
      &                       S(ng)%pioVar(idUbrs),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4245,7 +4269,7 @@
      &                       BBL(ng) % bustrc)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUbrs,          &
      &                       S(ng)%pioVar(idUbrs),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4276,7 +4300,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVbrs,          &
      &                       S(ng)%pioVar(idVbrs),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4287,7 +4311,7 @@
      &                       BBL(ng) % bvstrc)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVbrs,          &
      &                       S(ng)%pioVar(idVbrs),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4318,7 +4342,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUbws,          &
      &                       S(ng)%pioVar(idUbws),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4329,7 +4353,7 @@
      &                       BBL(ng) % bustrw)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUbws,          &
      &                       S(ng)%pioVar(idUbws),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4360,7 +4384,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVbws,          &
      &                       S(ng)%pioVar(idVbws),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4371,7 +4395,7 @@
      &                       BBL(ng) % bvstrw)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVbws,          &
      &                       S(ng)%pioVar(idVbws),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4402,7 +4426,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUbcs,          &
      &                       S(ng)%pioVar(idUbcs),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4413,7 +4437,7 @@
      &                       BBL(ng) % bustrcwmax)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUbcs,          &
      &                       S(ng)%pioVar(idUbcs),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4444,7 +4468,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVbcs,          &
      &                       S(ng)%pioVar(idVbcs),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4455,7 +4479,7 @@
      &                       BBL(ng) % bvstrcwmax)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVbcs,          &
      &                       S(ng)%pioVar(idVbcs),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4493,7 +4517,7 @@
           wrk2d=SQRT(BBL(ng)%bustrcwmax*BBL(ng)%bustrcwmax+             &
      &               BBL(ng)%bvstrcwmax*BBL(ng)%bvstrcwmax+1.0E-10_r8)
 !
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUVwc,          &
      &                       S(ng)%pioVar(idUVwc),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4505,7 +4529,7 @@
           deallocate (wrk2d)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUVwc,          &
      &                       S(ng)%pioVar(idUVwc),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4536,7 +4560,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUbot,          &
      &                       S(ng)%pioVar(idUbot),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4547,7 +4571,7 @@
      &                       BBL(ng) % Ubot)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUbot,          &
      &                       S(ng)%pioVar(idUbot),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4578,7 +4602,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVbot,          &
      &                       S(ng)%pioVar(idVbot),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4589,7 +4613,7 @@
      &                       BBL(ng) % Vbot)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVbot,          &
      &                       S(ng)%pioVar(idVbot),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4620,7 +4644,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUbur,          &
      &                       S(ng)%pioVar(idUbur),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4631,7 +4655,7 @@
      &                       BBL(ng) % Ur)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUbur,          &
      &                       S(ng)%pioVar(idUbur),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4662,7 +4686,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVbvr,          &
      &                       S(ng)%pioVar(idVbvr),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4673,7 +4697,7 @@
      &                       BBL(ng) % Vr)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVbvr,          &
      &                       S(ng)%pioVar(idVbvr),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4707,7 +4731,7 @@
           ELSE
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUwav,          &
      &                       S(ng)%pioVar(idUwav),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4737,7 +4761,7 @@
           ELSE
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVwav,          &
      &                       S(ng)%pioVar(idVwav),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4770,7 +4794,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWamp,          &
      &                       S(ng)%pioVar(idWamp),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4781,7 +4805,7 @@
      &                       FORCES(ng) % Hwave)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWamp,          &
      &                       S(ng)%pioVar(idWamp),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4814,7 +4838,7 @@
           ELSE
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWam2,          &
      &                       S(ng)%pioVar(idWam2),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4848,7 +4872,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWlen,          &
      &                       S(ng)%pioVar(idWlen),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4859,7 +4883,7 @@
      &                       FORCES(ng) % Lwave)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWlen,          &
      &                       S(ng)%pioVar(idWlen),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4893,7 +4917,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWlep,          &
      &                       S(ng)%pioVar(idWlep),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4904,7 +4928,7 @@
      &                       FORCES(ng) % Lwavep)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWlep,          &
      &                       S(ng)%pioVar(idWlep),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4938,7 +4962,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWdir,          &
      &                       S(ng)%pioVar(idWdir),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4949,7 +4973,7 @@
      &                       FORCES(ng) % Dwave)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWdir,          &
      &                       S(ng)%pioVar(idWdir),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4983,7 +5007,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWdip,          &
      &                       S(ng)%pioVar(idWdip),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -4993,7 +5017,7 @@
 #   endif
      &                       FORCES(ng) % Dwavep)
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWdip,          &
      &                       S(ng)%pioVar(idWdip),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -5026,7 +5050,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWptp,          &
      &                       S(ng)%pioVar(idWptp),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -5037,7 +5061,7 @@
      &                       FORCES(ng) % Pwave_top)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWptp,          &
      &                       S(ng)%pioVar(idWptp),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -5071,7 +5095,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWpbt,          &
      &                       S(ng)%pioVar(idWpbt),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -5082,7 +5106,7 @@
      &                       FORCES(ng) % Pwave_bot)
 #   ifdef AVERAGES
         ELSE
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWpbt,          &
      &                       S(ng)%pioVar(idWpbt),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -5116,7 +5140,7 @@
           ELSE
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWvds,          &
      &                       S(ng)%pioVar(idWvds),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -5146,13 +5170,13 @@
           ELSE
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idWvqp,          &
      &                       S(ng)%pioVar(idWvqp),                      &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
      &                       LBi, UBi, LBj, UBj, scale,                 &
 #   ifdef MASKING
-<     &                       GRID(ng) % rmask,                          &
+     &                       GRID(ng) % rmask,                          &
 #   endif
      &                       FORCES(ng) % Wave_qp)
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN

--- a/ROMS/Nonlinear/Sediment/sediment_output.F
+++ b/ROMS/Nonlinear/Sediment/sediment_output.F
@@ -4,7 +4,7 @@
 #if (defined SEDIMENT || defined BBL_MODEL) && defined SOLVE3D
 !
 !git $Id$
-!svn $Id: sediment_output.F 1185 2023-08-01 21:42:38Z arango $
+!svn $Id: sediment_output.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -1055,7 +1055,7 @@
         scale=1.0_dp
         gtype=gfactor*r2dvar
         IF (Linstataneous) THEN
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idbath,             &
      &                       S(ng)%Vid(idbath),                         &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1085,7 +1085,7 @@
           scale=1.0_dp
           gtype=gfactor*u2dvar
           IF (Linstataneous) THEN
-            status=nf_fwrite2d(ng, model, S(ng)%ncid,                   &
+            status=nf_fwrite2d(ng, model, S(ng)%ncid, idUbld(i),        &
      &                         S(ng)%Vid(idUbld(i)),                    &
      &                         S(ng)%Rindex, gtype,                     &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -1095,7 +1095,7 @@
      &                         SEDBED(ng) % bedldu(:,:,i))
 #  ifdef AVERAGES
           ELSE
-            status=nf_fwrite2d(ng, model, S(ng)%ncid,                   &
+            status=nf_fwrite2d(ng, model, S(ng)%ncid, idUbld(i),        &
      &                         S(ng)%Vid(idUbld(i)),                    &
      &                         S(ng)%Rindex, gtype,                     &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -1121,7 +1121,7 @@
           scale=1.0_dp
           gtype=gfactor*v2dvar
           IF (Linstataneous) THEN
-            status=nf_fwrite2d(ng, model, S(ng)%ncid,                   &
+            status=nf_fwrite2d(ng, model, S(ng)%ncid, idVbld(i),        &
      &                         S(ng)%Vid(idVbld(i)),                    &
      &                         S(ng)%Rindex, gtype,                     &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -1131,7 +1131,7 @@
      &                         SEDBED(ng) % bedldv(:,:,i))
 #  ifdef AVERAGES
           ELSE
-            status=nf_fwrite2d(ng, model, S(ng)%ncid,                   &
+            status=nf_fwrite2d(ng, model, S(ng)%ncid, idVbld(i),        &
      &                         S(ng)%Vid(idVbld(i)),                    &
      &                         S(ng)%Rindex, gtype,                     &
      &                         LBi, UBi, LBj, UBj, scale,               &
@@ -1161,7 +1161,7 @@
         IF (VarOut(idfrac(i),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*b3dvar
-          status=nf_fwrite3d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite3d(ng, model, S(ng)%ncid, idfrac(i),          &
      &                       S(ng)%Vid(idfrac(i)),                      &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, 1, Nbed, scale,        &
@@ -1186,7 +1186,7 @@
         IF (VarOut(idBmas(i),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*b3dvar
-          status=nf_fwrite3d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite3d(ng, model, S(ng)%ncid, idBmas(i),          &
      &                       S(ng)%Vid(idBmas(i)),                      &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, 1, Nbed, scale,        &
@@ -1211,7 +1211,7 @@
         IF (VarOut(idSbed(i),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*b3dvar
-          status=nf_fwrite3d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite3d(ng, model, S(ng)%ncid, idSbed(i),          &
      &                       S(ng)%Vid(idSbed(i)),                      &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, 1, Nbed, scale,        &
@@ -1243,7 +1243,7 @@
             scale=1.0_dp
           END IF
           gtype=gfactor*r2dvar
-          status=nf_fwrite2d(ng, model, S(ng)%ncid,                     &
+          status=nf_fwrite2d(ng, model, S(ng)%ncid, idBott(i),          &
      &                       S(ng)%Vid(idBott(i)),                      &
      &                       S(ng)%Rindex, gtype,                       &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1270,7 +1270,8 @@
       IF (VarOut(idsurs,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idsurs),    &
+        status=nf_fwrite2d(ng, model, S(ng)%ncid, idsurs,               &
+     &                     S(ng)%Vid(idsurs),                           &
      &                     S(ng)%Rindex, gtype,                         &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -1292,7 +1293,8 @@
       IF (VarOut(idsrrw,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idsrrw),    &
+        status=nf_fwrite2d(ng, model, S(ng)%ncid, idsrrw,               &
+     &                     S(ng)%Vid(idsrrw),                           &
      &                     S(ng)%Rindex, gtype,                         &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -1314,7 +1316,8 @@
       IF (VarOut(idsbtw,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idsbtw),    &
+        status=nf_fwrite2d(ng, model, S(ng)%ncid, idsbtw,               &
+     &                     S(ng)%Vid(idsbtw),                           &
      &                     S(ng)%Rindex, gtype,                         &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -1336,7 +1339,8 @@
       IF (VarOut(idsucr,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idsucr),    &
+        status=nf_fwrite2d(ng, model, S(ng)%ncid, idsucr,               &
+     &                     S(ng)%Vid(idsucr),                           &
      &                     S(ng)%Rindex, gtype,                         &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -1358,7 +1362,8 @@
       IF (VarOut(idsutr,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idsutr),    &
+        status=nf_fwrite2d(ng, model, S(ng)%ncid, idsutr,               &
+     &                     S(ng)%Vid(idsutr),                           &
      &                     S(ng)%Rindex, gtype,                         &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -1380,7 +1385,8 @@
       IF (VarOut(idstcr,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idstcr),    &
+        status=nf_fwrite2d(ng, model, S(ng)%ncid, idstcr,               &
+     &                     S(ng)%Vid(idstcr),                           &
      &                     S(ng)%Rindex, gtype,                         &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -1402,7 +1408,8 @@
       IF (VarOut(idsttr,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, S(ng)%ncid, S(ng)%Vid(idsttr),    &
+        status=nf_fwrite2d(ng, model, S(ng)%ncid, idsttr,               &
+     &                     S(ng)%Vid(idsttr),                           &
      &                     S(ng)%Rindex, gtype,                         &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -2390,7 +2397,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, S(ng)%pioFile,                    &
+        status=nf_fwrite2d(ng, model, S(ng)%pioFile, idbath,            &
      &                     S(ng)%pioVar(idbath),                        &
      &                     S(ng)%Rindex,                                &
      &                     ioDesc,                                      &
@@ -2424,7 +2431,7 @@
             ioDesc => ioDesc_sp_u2dvar(ng)
           END IF
           IF (Linstataneous) THEN
-            status=nf_fwrite2d(ng, model, S(ng)%pioFile,                &
+            status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUbld(i),     &
      &                         S(ng)%pioVar(idUbld(i)),                 &
      &                         S(ng)%Rindex,                            &
      &                         ioDesc,                                  &
@@ -2435,7 +2442,7 @@
      &                         SEDBED(ng) % bedldu(:,:,i))
 #   ifdef AVERAGES
           ELSE
-            status=nf_fwrite2d(ng, model, S(ng)%pioFile,                &
+            status=nf_fwrite2d(ng, model, S(ng)%pioFile, idUbld(i),     &
      &                         S(ng)%pioVar(idUbld(i)),                 &
      &                         S(ng)%Rindex,                            &
      &                         ioDesc,                                  &
@@ -2466,7 +2473,7 @@
             ioDesc => ioDesc_sp_v2dvar(ng)
           END IF
           IF (Linstataneous) THEN
-            status=nf_fwrite2d(ng, model, S(ng)%pioFile,                &
+            status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVbld(i),     &
      &                         S(ng)%pioVar(idVbld(i)),                 &
      &                         S(ng)%Rindex,                            &
      &                         ioDesc,                                  &
@@ -2477,7 +2484,7 @@
      &                         SEDBED(ng) % bedldv(:,:,i))
 #   ifdef AVERAGES
           ELSE
-            status=nf_fwrite2d(ng, model, S(ng)%pioFile,                &
+            status=nf_fwrite2d(ng, model, S(ng)%pioFile, idVbld(i),     &
      &                         S(ng)%pioVar(idVbld(i)),                 &
      &                         S(ng)%Rindex,                            &
      &                         ioDesc,                                  &
@@ -2512,7 +2519,7 @@
           ELSE
             ioDesc => ioDesc_sp_b3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite3d(ng, model, S(ng)%pioFile, idfrac(i),       &
      &                       S(ng)%pioVar(idfrac(i)),                   &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -2542,7 +2549,7 @@
           ELSE
             ioDesc => ioDesc_sp_b3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite3d(ng, model, S(ng)%pioFile, idBmas(i),       &
      &                       S(ng)%pioVar(idBmas(i)),                   &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -2572,7 +2579,7 @@
           ELSE
             ioDesc => ioDesc_sp_b3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite3d(ng, model, S(ng)%pioFile, idSbed(i),       &
      &                       S(ng)%pioVar(idSbed(i)),                   &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -2609,7 +2616,7 @@
           ELSE
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, model, S(ng)%pioFile,                  &
+          status=nf_fwrite2d(ng, model, S(ng)%pioFile, idBott(i),       &
      &                       S(ng)%pioVar(idBott(i)),                   &
      &                       S(ng)%Rindex,                              &
      &                       ioDesc,                                    &
@@ -2641,7 +2648,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, S(ng)%pioFile,                    &
+        status=nf_fwrite2d(ng, model, S(ng)%pioFile, idsurs,            &
      &                     S(ng)%pioVar(idsurs),                        &
      &                     S(ng)%Rindex,                                &
      &                     ioDesc,                                      &
@@ -2664,13 +2671,13 @@
 !
       IF (VarOut(idsrrw,ng)) THEN
         scale=1.0_dp
-        IF (S(ng)%pioVar(idxrrw)%dkind.eq.PIO_double) THEN
+        IF (S(ng)%pioVar(idsrrw)%dkind.eq.PIO_double) THEN
           ioDesc => ioDesc_dp_r2dvar(ng)
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, S(ng)%pioFile,                    &
-     &                     S(ng)%pioVar(idxrrw),                        &
+        status=nf_fwrite2d(ng, model, S(ng)%pioFile, idsrrw,            &
+     &                     S(ng)%pioVar(idsrrw),                        &
      &                     S(ng)%Rindex,                                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -2680,7 +2687,7 @@
      &                     SEDBED(ng) % RR_asymwave)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idxrrw)), S(ng)%Rindex
+            WRITE (stdout,10) TRIM(Vname(1,idsrrw)), S(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2697,7 +2704,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, S(ng)%pioFile,                    &
+        status=nf_fwrite2d(ng, model, S(ng)%pioFile, idsbtw,            &
      &                     S(ng)%pioVar(idsbtw),                        &
      &                     S(ng)%Rindex,                                &
      &                     ioDesc,                                      &
@@ -2725,7 +2732,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, S(ng)%pioFile,                    &
+        status=nf_fwrite2d(ng, model, S(ng)%pioFile, idsucr,            &
      &                     S(ng)%pioVar(idsucr),                        &
      &                     S(ng)%Rindex,                                &
      &                     ioDesc,                                      &
@@ -2753,7 +2760,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, S(ng)%pioFile,                    &
+        status=nf_fwrite2d(ng, model, S(ng)%pioFile, idsutr,            &
      &                     S(ng)%pioVar(idsutr),                        &
      &                     S(ng)%Rindex,                                &
      &                     ioDesc,                                      &
@@ -2781,7 +2788,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, S(ng)%pioFile,                    &
+        status=nf_fwrite2d(ng, model, S(ng)%pioFile, idstcr,            &
      &                     S(ng)%pioVar(idstcr),                        &
      &                     S(ng)%Rindex,                                &
      &                     ioDesc,                                      &
@@ -2809,7 +2816,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, S(ng)%pioFile,                    &
+        status=nf_fwrite2d(ng, model, S(ng)%pioFile, idsttr,            &
      &                     S(ng)%pioVar(idsttr),                        &
      &                     S(ng)%Rindex,                                &
      &                     ioDesc,                                      &

--- a/ROMS/Representer/rp_wrt_ini.F
+++ b/ROMS/Representer/rp_wrt_ini.F
@@ -3,7 +3,7 @@
 #if (defined TANGENT || defined TL_IOMS) && defined FOUR_DVAR
 !
 !git $Id$
-!svn $Id: rp_wrt_ini.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: rp_wrt_ini.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -164,6 +164,19 @@
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
+!  Report.
+!
+      IF (Master) THEN
+        IF (OutRec.eq.2) THEN
+          string='initial  fields'
+        END IF
+# ifdef SOLVE3D
+        WRITE (stdout,10) string, outer, inner, Tindex, Tindex, OutRec
+# else
+        WRITE (stdout,10) string, outer, inner, Tindex, OutRec
+# endif
+      END IF
+!
 !  Set grid type factor to write full (gfactor=1) fields or water
 !  points (gfactor=-1) fields only.
 !
@@ -189,7 +202,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, iRPM, IRP(ng)%ncid, IRP(ng)%Vid(idFsur),   &
+      status=nf_fwrite2d(ng, iRPM, IRP(ng)%ncid, idFsur,                &
+     &                   IRP(ng)%Vid(idFsur),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -203,7 +217,7 @@
 # endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idFsur)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idFsur)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -225,7 +239,7 @@
      &                                                    Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -238,7 +252,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u2dvar
-      status=nf_fwrite2d(ng, iRPM, IRP(ng)%ncid, IRP(ng)%Vid(idUbar),   &
+      status=nf_fwrite2d(ng, iRPM, IRP(ng)%ncid, idUbar,                &
+     &                   IRP(ng)%Vid(idUbar),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -247,7 +262,7 @@
      &                   OCEAN(ng) % tl_ubar(:,:,Tindex))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUbar)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idUbar)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -269,7 +284,7 @@
      &                                                    Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -282,7 +297,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v2dvar
-      status=nf_fwrite2d(ng, iRPM, IRP(ng)%ncid, IRP(ng)%Vid(idVbar),   &
+      status=nf_fwrite2d(ng, iRPM, IRP(ng)%ncid, idVbar,                &
+     &                   IRP(ng)%Vid(idVbar),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -291,7 +307,7 @@
      &                   OCEAN(ng) % tl_vbar(:,:,Tindex))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVbar)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idVbar)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -313,7 +329,7 @@
      &                                                    Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -331,7 +347,8 @@
 !!    scale=rho0
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iRPM, IRP(ng)%ncid, IRP(ng)%Vid(idUsms),   &
+      status=nf_fwrite3d(ng, iRPM, IRP(ng)%ncid, idUsms,                &
+     &                   IRP(ng)%Vid(idUsms),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -340,7 +357,7 @@
      &                   FORCES(ng) % tl_ustr(:,:,:,Tindex))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -352,7 +369,8 @@
 !!    scale=rho0
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iRPM, IRP(ng)%ncid, IRP(ng)%Vid(idVsms),   &
+      status=nf_fwrite3d(ng, iRPM, IRP(ng)%ncid, idVsms,                &
+     &                   IRP(ng)%Vid(idVsms),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -361,7 +379,7 @@
      &                   FORCES(ng) % tl_vstr(:,:,:,Tindex))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -375,7 +393,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iRPM, IRP(ng)%ncid, IRP(ng)%Vid(idUvel),   &
+      status=nf_fwrite3d(ng, iRPM, IRP(ng)%ncid, idUvel,                &
+     &                   IRP(ng)%Vid(idUvel),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -384,7 +403,7 @@
      &                   OCEAN(ng) % tl_u(:,:,:,Tindex))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUvel)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idUvel)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -406,7 +425,7 @@
      &                                                 Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -419,7 +438,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iRPM, IRP(ng)%ncid, IRP(ng)%Vid(idVvel),   &
+      status=nf_fwrite3d(ng, iRPM, IRP(ng)%ncid, idVvel,                &
+     &                   IRP(ng)%Vid(idVvel),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -428,7 +448,7 @@
      &                   OCEAN(ng) % tl_v(:,:,:,Tindex))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVvel)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idVvel)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -450,7 +470,7 @@
      &                                                 Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -464,7 +484,8 @@
       DO itrc=1,NT(ng)
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, iRPM, IRP(ng)%ncid, IRP(ng)%Tid(itrc),   &
+        status=nf_fwrite3d(ng, iRPM, IRP(ng)%ncid, idTvar(itrc),        &
+     &                     IRP(ng)%Tid(itrc),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -473,7 +494,7 @@
      &                     OCEAN(ng) % tl_t(:,:,:,Tindex,itrc))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -498,7 +519,7 @@
      &                                                   Tindex,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
+              WRITE (stdout,20) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
      &                          OutRec
             END IF
             exit_flag=3
@@ -519,7 +540,7 @@
         IF (Lstflux(itrc,ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, iRPM, IRP(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iRPM, IRP(ng)%ncid, idTsur(itrc),      &
      &                       IRP(ng)%Vid(idTsur(itrc)),                 &
      &                       OutRec, gtype,                             &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -529,7 +550,7 @@
      &                       FORCES(ng) % tl_tflux(:,:,:,Tindex,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          OutRec
             END IF
             exit_flag=3
@@ -549,27 +570,16 @@
       CALL netcdf_sync (ng, iRPM, IRP(ng)%name, IRP(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-      IF (Master) THEN
-        IF (OutRec.eq.2) THEN
-          string='initial  fields'
-        END IF
-# ifdef SOLVE3D
-        WRITE (stdout,20) string, outer, inner, Tindex, Tindex, OutRec
-# else
-        WRITE (stdout,20) string, outer, inner, Tindex, OutRec
-# endif
-      END IF
-!
-  10  FORMAT (/,' RP_WRT_INI_NF90 - error while writing variable: ',a,  &
-     &        /,19x,'into representers initial file for time record:',  &
-     &        1x,i4)
-  20  FORMAT (2x,'RP_WRT_INI_NF90  - wrote ',a,                         &
+  10  FORMAT (2x,'RP_WRT_INI_NF90  - writing ',a,                       &
      &        ' (Outer=',i2.2,', Inner=',i3.3,', Index=',i0,            &
 # ifdef SOLVE3D
      &        ',',i0,', Rec=',i0,')')
 # else
      &        ', Rec=',i0,')')
 # endif
+  20  FORMAT (/,' RP_WRT_INI_NF90 - error while writing variable: ',a,  &
+     &        /,19x,'into representers initial file for time record:',  &
+     &        1x,i4)
 !
       RETURN
       END SUBROUTINE rp_wrt_ini_nf90
@@ -615,6 +625,19 @@
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
+!  Report.
+!
+      IF (Master) THEN
+        IF (OutRec.eq.2) THEN
+          string='initial  fields'
+        END IF
+#  ifdef SOLVE3D
+        WRITE (stdout,10) string, outer, inner, Tindex, Tindex, OutRec
+#  else
+        WRITE (stdout,10) string, outer, inner, Tindex, OutRec
+#  endif
+      END IF
+!
 !  Write out model time (s).  Use the "tdays" variable here because of
 !  the management of the "time" variable due to nesting.
 !
@@ -636,7 +659,7 @@
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iRPM, IRP(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iRPM, IRP(ng)%pioFile, idFsur,             &
      &                   IRP(ng)%pioVar(idFsur),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -651,7 +674,7 @@
 #  endif
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idFsur)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idFsur)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -680,7 +703,7 @@
      &                                                    Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -698,7 +721,7 @@
         ioDesc => ioDesc_sp_u2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iRPM, IRP(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iRPM, IRP(ng)%pioFile, idUbar,             &
      &                   IRP(ng)%pioVar(idUbar),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -708,7 +731,7 @@
      &                   OCEAN(ng) % tl_ubar(:,:,Tindex))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUbar)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idUbar)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -737,7 +760,7 @@
      &                                                    Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -755,7 +778,7 @@
         ioDesc => ioDesc_sp_v2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iRPM, IRP(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iRPM, IRP(ng)%pioFile, idVbar,             &
      &                   IRP(ng)%pioVar(idVbar),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -765,7 +788,7 @@
      &                   OCEAN(ng) % tl_vbar(:,:,Tindex))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVbar)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idVbar)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -794,7 +817,7 @@
      &                                                    Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -817,7 +840,7 @@
         ioDesc => ioDesc_sp_u2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iRPM, IRP(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iRPM, IRP(ng)%pioFile, idUsms,             &
      &                   IRP(ng)%pioVar(idUsms),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
@@ -827,7 +850,7 @@
      &                   FORCES(ng) % tl_ustr(:,:,:,Tindex))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -844,7 +867,7 @@
         ioDesc => ioDesc_sp_v2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iRPM, IRP(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iRPM, IRP(ng)%pioFile, idVsms,             &
      &                   IRP(ng)%pioVar(idVsms),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
@@ -854,7 +877,7 @@
      &                   FORCES(ng) % tl_vstr(:,:,:,Tindex))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -873,7 +896,7 @@
         ioDesc => ioDesc_sp_u3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iRPM, IRP(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iRPM, IRP(ng)%pioFile, idUvel,             &
      &                   IRP(ng)%pioVar(idUvel),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -883,7 +906,7 @@
      &                   OCEAN(ng) % tl_u(:,:,:,Tindex))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUvel)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idUvel)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -912,7 +935,7 @@
      &                                                 Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -930,7 +953,7 @@
         ioDesc => ioDesc_sp_v3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iRPM, IRP(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iRPM, IRP(ng)%pioFile, idVvel,             &
      &                   IRP(ng)%pioVar(idVvel),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -940,7 +963,7 @@
      &                   OCEAN(ng) % tl_v(:,:,:,Tindex))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVvel)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idVvel)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -969,7 +992,7 @@
      &                                                 Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -988,7 +1011,7 @@
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iRPM, IRP(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iRPM, IRP(ng)%pioFile, idTvar(itrc),     &
      &                     IRP(ng)%pioTrc(itrc),                        &
      &                     OutRec, ioDesc,                              &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -998,7 +1021,7 @@
      &                     OCEAN(ng) % tl_t(:,:,:,Tindex,itrc))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1031,7 +1054,7 @@
      &                                                   Tindex,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
+              WRITE (stdout,20) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
      &                          OutRec
             END IF
             exit_flag=3
@@ -1057,7 +1080,7 @@
             ioDesc => ioDesc_sp_r2dfrc(ng)
           END IF
 !
-          status=nf_fwrite3d(ng, iRPM, IRP(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iRPM, IRP(ng)%pioFile, idTsur(itrc),   &
      &                       IRP(ng)%pioVar(idTsur(itrc)),              &
      &                       OutRec, ioDesc,                            &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -1067,7 +1090,7 @@
      &                       FORCES(ng) % tl_tflux(:,:,:,Tindex,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          OutRec
             END IF
             exit_flag=3
@@ -1087,27 +1110,16 @@
       CALL pio_netcdf_sync (ng, iRPM, IRP(ng)%name, IRP(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-      IF (Master) THEN
-        IF (OutRec.eq.2) THEN
-          string='initial  fields'
-        END IF
-#  ifdef SOLVE3D
-        WRITE (stdout,20) string, outer, inner, Tindex, Tindex, OutRec
-#  else
-        WRITE (stdout,20) string, outer, inner, Tindex, OutRec
-#  endif
-      END IF
-!
-  10  FORMAT (/,' RP_WRT_INI_PIO - error while writing variable: ',a,   &
-     &        /,18x,'into representers initial file for time record:',  &
-     &        1x,i4)
-  20  FORMAT (2x,'RP_WRT_INI_PIO   - wrote ',a,                         &
+  10  FORMAT (2x,'RP_WRT_INI_PIO   - writing ',a,                       &
      &        ' (Outer=',i2.2,', Inner=',i3.3,', Index=',i0,            &
 #  ifdef SOLVE3D
      &        ',',i0,', Rec=',i0,')')
 #  else
      &        ', Rec=',i0,')')
 #  endif
+  20  FORMAT (/,' RP_WRT_INI_PIO - error while writing variable: ',a,   &
+     &        /,18x,'into representers initial file for time record:',  &
+     &        1x,i4)
 !
       RETURN
       END SUBROUTINE rp_wrt_ini_pio

--- a/ROMS/Tangent/tl_wrt_his.F
+++ b/ROMS/Tangent/tl_wrt_his.F
@@ -3,7 +3,7 @@
 #if defined TANGENT || defined TL_IOMS
 !
 !git $Id$
-!svn $Id: tl_wrt_his.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: tl_wrt_his.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -177,6 +177,22 @@
       Fcount=TLM(ng)%load
       TLM(ng)%Nrec(Fcount)=TLM(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+# ifdef SOLVE3D
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, TLM(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, TLM(ng)%Rindex
+#  endif
+# else
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, TLM(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) KOUT, TLM(ng)%Rindex
+#  endif
+# endif
+!
 !  If requested, set time index to recycle time records in the tangent
 !  linear file.
 !
@@ -206,7 +222,8 @@
 !
       scale=1.0_dp                          ! m2/s2
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idUsms),   &
+      status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idUsms,                &
+     &                   TLM(ng)%Vid(idUsms),                           &
      &                   TLM(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -215,7 +232,7 @@
      &                   FORCES(ng) % tl_ustr(:,:,:,Lfout(ng)))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), Lfout(ng)
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), Lfout(ng)
         END IF
         exit_flag=3
         ioerror=status
@@ -226,7 +243,8 @@
 !
       scale=1.0_dp                          ! m2/s2
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idVsms),   &
+      status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idVsms,                &
+     &                   TLM(ng)%Vid(idVsms),                           &
      &                   TLM(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -235,7 +253,7 @@
      &                   FORCES(ng) % tl_vstr(:,:,:,Lfout(ng)))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), Lfout(ng)
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), Lfout(ng)
         END IF
         exit_flag=3
         ioerror=status
@@ -252,7 +270,7 @@
         IF (Lstflux(itrc,ng)) THEN
           scale=1.0_dp                      ! kinematic flux units
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idTsur(itrc),      &
      &                       TLM(ng)%Vid(idTsur(itrc)),                 &
      &                       TLM(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -262,7 +280,7 @@
      &                       FORCES(ng)% tl_tflux(:,:,:,Lfout(ng),itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))), Lfout(ng)
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))), Lfout(ng)
             END IF
             exit_flag=3
             ioerror=status
@@ -279,7 +297,8 @@
       IF (Hout(idUsms,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idUsms), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idUsms,              &
+     &                     TLM(ng)%Vid(idUsms),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -288,7 +307,7 @@
      &                     FORCES(ng) % tl_sustr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUsms)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUsms)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -301,7 +320,8 @@
       IF (Hout(idVsms,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idVsms), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idVsms,              &
+     &                     TLM(ng)%Vid(idVsms),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -310,7 +330,7 @@
      &                     FORCES(ng) % tl_svstr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVsms)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVsms)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -326,7 +346,7 @@
         IF (Hout(idTsur(itrc),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r2dvar
-          status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid,                    &
+          status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idTsur(itrc),      &
      &                       TLM(ng)%Vid(idTsur(itrc)),                 &
      &                       TLM(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -336,7 +356,7 @@
      &                       FORCES(ng) % tl_stflx(:,:,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          TLM(ng)%Rindex
             END IF
             exit_flag=3
@@ -353,7 +373,8 @@
       IF (Hout(idFsur,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idFsur), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idFsur,              &
+     &                     TLM(ng)%Vid(idFsur),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 # ifdef MASKING
@@ -371,7 +392,7 @@
 # endif
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idFsur)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idFsur)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -380,7 +401,8 @@
 
 # if defined FORWARD_WRITE && defined FORWARD_RHS
 !
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idRzet), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idRzet,              &
+     &                     TLM(ng)%Vid(idRzet),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -389,7 +411,7 @@
      &                     OCEAN(ng) % tl_rzeta(:,:,KOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRzet)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRzet)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -413,7 +435,7 @@
      &                                                    Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))),            &
      &                        TLM(ng)%Rindex
           END IF
           exit_flag=3
@@ -428,7 +450,8 @@
       IF (Hout(idUbar,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idUbar), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idUbar,              &
+     &                     TLM(ng)%Vid(idUbar),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 # ifdef MASKING
@@ -441,7 +464,7 @@
 # endif
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbar)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbar)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -451,7 +474,8 @@
 # ifdef FORWARD_WRITE
 #  ifdef FORWARD_RHS
 !
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idRu2d), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idRu2d,              &
+     &                     TLM(ng)%Vid(idRu2d),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #   ifdef MASKING
@@ -460,7 +484,7 @@
      &                     OCEAN(ng) % tl_rubar(:,:,KOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRu2d)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRu2d)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -470,7 +494,8 @@
 #  ifdef SOLVE3D
 #   ifdef FORWARD_RHS
 !
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idRuct), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idRuct,              &
+     &                     TLM(ng)%Vid(idRuct),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #    ifdef MASKING
@@ -479,7 +504,7 @@
      &                     COUPLING(ng) % tl_rufrc)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRuct)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRuct)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -487,7 +512,8 @@
         END IF
 #   endif
 !
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idUfx1), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idUfx1,              &
+     &                     TLM(ng)%Vid(idUfx1),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #   ifdef MASKING
@@ -496,14 +522,15 @@
      &                     COUPLING(ng) % tl_DU_avg1)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUfx1)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUfx1)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
 !
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idUfx2), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idUfx2,              &
+     &                     TLM(ng)%Vid(idUfx2),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #   ifdef MASKING
@@ -512,7 +539,7 @@
      &                     COUPLING(ng) % tl_DU_avg2)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUfx2)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUfx2)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -537,7 +564,7 @@
      &                                                    Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))),            &
      &                        TLM(ng)%Rindex
           END IF
           exit_flag=3
@@ -552,7 +579,8 @@
       IF (Hout(idVbar,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idVbar), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idVbar,              &
+     &                     TLM(ng)%Vid(idVbar),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 # ifdef MASKING
@@ -565,7 +593,7 @@
 # endif
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbar)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbar)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -575,7 +603,8 @@
 # ifdef FORWARD_WRITE
 #  ifdef FORWARD_RHS
 !
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idRv2d), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idRv2d,              &
+     &                     TLM(ng)%Vid(idRv2d),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #   ifdef MASKING
@@ -584,7 +613,7 @@
      &                     OCEAN(ng) % tl_rvbar(:,:,KOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRv2d)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRv2d)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -594,7 +623,8 @@
 #  ifdef SOLVE3D
 #   ifdef FORWARD_RHS
 !
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idRvct), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idRvct,              &
+     &                     TLM(ng)%Vid(idRvct),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #    ifdef MASKING
@@ -603,7 +633,7 @@
      &                     COUPLING(ng) % tl_rvfrc)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRvct)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRvct)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -611,7 +641,8 @@
         END IF
 #   endif
 !
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idVfx1), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idVfx1,              &
+     &                     TLM(ng)%Vid(idVfx1),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #   ifdef MASKING
@@ -620,14 +651,15 @@
      &                     COUPLING(ng) % tl_DV_avg1)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVfx1)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVfx1)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
 !
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idVfx2), &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%ncid, idVfx2,              &
+     &                     TLM(ng)%Vid(idVfx2),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #   ifdef MASKING
@@ -636,7 +668,7 @@
      &                     COUPLING(ng) % tl_DV_avg2)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVfx2)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVfx2)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -661,7 +693,7 @@
      &                                                    Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))),            &
      &                        TLM(ng)%Rindex
           END IF
           exit_flag=3
@@ -677,7 +709,8 @@
       IF (Hout(idUvel,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u3dvar
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idUvel), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idUvel,              &
+     &                     TLM(ng)%Vid(idUvel),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -690,7 +723,7 @@
 #  endif
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUvel)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUvel)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -699,7 +732,8 @@
 
 #  if defined FORWARD_WRITE && defined FORWARD_RHS
 !
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idRu3d), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idRu3d,              &
+     &                     TLM(ng)%Vid(idRu3d),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #   ifdef MASKING
@@ -708,7 +742,7 @@
      &                     OCEAN(ng) % tl_ru(:,:,:,NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRu3d)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRu3d)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -732,7 +766,7 @@
      &                                                 Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))),            &
      &                        TLM(ng)%Rindex
           END IF
           exit_flag=3
@@ -747,7 +781,8 @@
       IF (Hout(idVvel,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v3dvar
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idVvel), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idVvel,              &
+     &                     TLM(ng)%Vid(idVvel),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -760,7 +795,7 @@
 #  endif
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvel)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvel)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -769,7 +804,8 @@
 
 #  if defined FORWARD_WRITE && defined FORWARD_RHS
 !
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idRv3d), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idRv3d,              &
+     &                     TLM(ng)%Vid(idRv3d),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #   ifdef MASKING
@@ -778,7 +814,7 @@
      &                     OCEAN(ng) % tl_rv(:,:,:,NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRv3d)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRv3d)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -802,7 +838,7 @@
      &                                                 Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))),            &
      &                        TLM(ng)%Rindex
           END IF
           exit_flag=3
@@ -818,7 +854,8 @@
         IF (Hout(idTvar(itrc),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Tid(itrc), &
+          status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idTvar(itrc),      &
+     &                       TLM(ng)%Tid(itrc),                         &
      &                       TLM(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
 #  ifdef MASKING
@@ -831,7 +868,7 @@
 #  endif
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),            &
      &                          TLM(ng)%Rindex
             END IF
             exit_flag=3
@@ -858,7 +895,7 @@
      &                                                 Lbout(ng),itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
+              WRITE (stdout,20) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
      &                          TLM(ng)%Rindex
             END IF
             exit_flag=3
@@ -874,7 +911,8 @@
       IF (Hout(idDano,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idDano), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idDano,              &
+     &                     TLM(ng)%Vid(idDano),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -883,7 +921,7 @@
      &                     OCEAN(ng) % tl_rho)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idDano)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idDano)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -900,7 +938,8 @@
       IF (Hout(idVvis,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idVvis), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idVvis,              &
+     &                     TLM(ng)%Vid(idVvis),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
 #   ifdef MASKING
@@ -914,7 +953,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvis)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvis)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -927,7 +966,8 @@
       IF (Hout(idTdif,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idTdif), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idTdif,              &
+     &                     TLM(ng)%Vid(idTdif),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
 #   ifdef MASKING
@@ -941,7 +981,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTdif)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTdif)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -956,7 +996,8 @@
       IF (Hout(idSdif,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idSdif), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idSdif,              &
+     &                     TLM(ng)%Vid(idSdif),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
 #    ifdef MASKING
@@ -970,7 +1011,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSdif)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSdif)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -985,7 +1026,8 @@
       IF (Hout(idMtke,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idMtke), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idMtke,              &
+     &                     TLM(ng)%Vid(idMtke),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
 #    ifdef MASKING
@@ -995,7 +1037,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idMtke)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idMtke)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1004,7 +1046,8 @@
 !
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idVmKK), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idVmKK,              &
+     &                     TLM(ng)%Vid(idVmKK),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
 #    ifdef MASKING
@@ -1013,7 +1056,7 @@
      &                     MIXING(ng) % tl_Akk)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVmKK)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVmKK)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1026,7 +1069,8 @@
       IF (Hout(idMtls,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idMtls), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idMtls,              &
+     &                     TLM(ng)%Vid(idMtls),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
 #    ifdef MASKING
@@ -1036,7 +1080,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idMtls)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idMtls)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1045,7 +1089,8 @@
 !
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idVmLS), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idVmLS,              &
+     &                     TLM(ng)%Vid(idVmLS),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
 #    ifdef MASKING
@@ -1054,7 +1099,7 @@
      &                     MIXING(ng) % tl_Lscale)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVmLS)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVmLS)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1064,7 +1109,8 @@
 #    ifdef GSL_MIXING
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, TLM(ng)%Vid(idVmKP), &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%ncid, idVmKP,              &
+     &                     TLM(ng)%Vid(idVmKP),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
 #     ifdef MASKING
@@ -1073,7 +1119,7 @@
      &                     MIXING(ng) % tl_Akp)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVmKP)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVmKP)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1093,23 +1139,7 @@
       CALL netcdf_sync (ng, iTLM, TLM(ng)%name, TLM(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-# ifdef SOLVE3D
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, TLM(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, TLM(ng)%Rindex
-#  endif
-# else
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, TLM(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) KOUT, TLM(ng)%Rindex
-#  endif
-# endif
-!
-  10  FORMAT (/,' TL_WRT_HIS_NF90 - error while writing variable: ',a,  &
-     &        /,19x,'into tangent NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'TL_WRT_HIS_NF90  - wrote history', t40,               &
+  10  FORMAT (2x,'TL_WRT_HIS_NF90  - writing history', t42,             &
 # ifdef SOLVE3D
 #  ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
@@ -1123,6 +1153,8 @@
      &        'fields (Index=',i1,')   in record = ',i0)
 #  endif
 # endif
+  20  FORMAT (/,' TL_WRT_HIS_NF90 - error while writing variable: ',a,  &
+     &        /,19x,'into tangent NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE tl_wrt_his_nf90
@@ -1176,6 +1208,22 @@
       Fcount=TLM(ng)%load
       TLM(ng)%Nrec(Fcount)=TLM(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+# ifdef SOLVE3D
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, TLM(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, TLM(ng)%Rindex
+#  endif
+# else
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, TLM(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) KOUT, TLM(ng)%Rindex
+#  endif
+# endif
+!
 !  If requested, set time index to recycle time records in the tangent
 !  linear file.
 !
@@ -1210,7 +1258,7 @@
         ioDesc => ioDesc_sp_u2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idUsms,             &
      &                   TLM(ng)%pioVar(idUsms),                        &
      &                   TLM(ng)%Rindex, ioDesc,                        &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
@@ -1220,7 +1268,7 @@
      &                   FORCES(ng) % tl_ustr(:,:,:,Lfout(ng)))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), Lfout(ng)
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), Lfout(ng)
         END IF
         exit_flag=3
         ioerror=status
@@ -1236,7 +1284,7 @@
         ioDesc => ioDesc_sp_v2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idVsms,             &
      &                   TLM(ng)%pioVar(idVsms),                        &
      &                   TLM(ng)%Rindex, ioDesc,                        &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
@@ -1246,7 +1294,7 @@
      &                   FORCES(ng) % tl_vstr(:,:,:,Lfout(ng)))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), Lfout(ng)
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), Lfout(ng)
         END IF
         exit_flag=3
         ioerror=status
@@ -1268,7 +1316,7 @@
             ioDesc => ioDesc_sp_r2dfrc(ng)
           END IF
 !
-          status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idTsur(itrc),   &
      &                       TLM(ng)%pioVar(idTsur(itrc)),              &
      &                       TLM(ng)%Rindex, ioDesc,                    &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -1278,7 +1326,7 @@
      &                       FORCES(ng)% tl_tflux(:,:,:,Lfout(ng),itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))), Lfout(ng)
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))), Lfout(ng)
             END IF
             exit_flag=3
             ioerror=status
@@ -1300,7 +1348,7 @@
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
 !
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idUsms,           &
      &                     TLM(ng)%pioVar(idUsms),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1310,7 +1358,7 @@
      &                     FORCES(ng) % tl_sustr)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUsms)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUsms)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1328,7 +1376,7 @@
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
 !
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idVsms,           &
      &                     TLM(ng)%pioVar(idVsms),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1338,7 +1386,7 @@
      &                     FORCES(ng) % tl_svstr)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVsms)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVsms)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1359,7 +1407,7 @@
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
 !
-          status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                 &
+          status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idTsur(itrc),   &
      &                       TLM(ng)%pioVar(idTsur(itrc)),              &
      &                       TLM(ng)%Rindex, ioDesc,                    &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1369,7 +1417,7 @@
      &                       FORCES(ng) % tl_stflx(:,:,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          TLM(ng)%Rindex
             END IF
             exit_flag=3
@@ -1391,7 +1439,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
 
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idFsur,           &
      &                     TLM(ng)%pioVar(idFsur),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1410,7 +1458,7 @@
 # endif
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idFsur)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idFsur)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1425,7 +1473,7 @@
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
 
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idRzet,           &
      &                     TLM(ng)%pioVar(idRzet),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1435,7 +1483,7 @@
      &                     OCEAN(ng) % tl_rzeta(:,:,KOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRzet)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRzet)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1467,7 +1515,7 @@
      &                                                    Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,ifield)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,ifield)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1486,7 +1534,7 @@
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
 
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idUbar,           &
      &                     TLM(ng)%pioVar(idUbar),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1500,7 +1548,7 @@
 # endif
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbar)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbar)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1516,7 +1564,7 @@
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
 
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idRu2d,           &
      &                     TLM(ng)%pioVar(idRu2d),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1526,7 +1574,7 @@
      &                     OCEAN(ng) % tl_rubar(:,:,KOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRu2d)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRu2d)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1542,7 +1590,7 @@
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
 
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idRuct,           &
      &                     TLM(ng)%pioVar(idRuct),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1552,7 +1600,7 @@
      &                     COUPLING(ng) % tl_rufrc)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRuct)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRuct)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1566,7 +1614,7 @@
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
 
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idUfx1,           &
      &                     TLM(ng)%pioVar(idUfx1),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1576,7 +1624,7 @@
      &                     COUPLING(ng) % tl_DU_avg1)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUfx1)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUfx1)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1589,7 +1637,7 @@
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
 
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idUfx2,           &
      &                     TLM(ng)%pioVar(idUfx2),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1599,7 +1647,7 @@
      &                     COUPLING(ng) % tl_DU_avg2)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUfx2)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUfx2)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1632,7 +1680,7 @@
      &                                                    Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,ifield)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,ifield)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1651,7 +1699,7 @@
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
 
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idVbar,           &
      &                     TLM(ng)%pioVar(idVbar),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1665,7 +1713,7 @@
 # endif
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbar)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbar)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1681,7 +1729,7 @@
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
 
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idRv2d,           &
      &                     TLM(ng)%pioVar(idRv2d),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1691,7 +1739,7 @@
      &                     OCEAN(ng) % tl_rvbar(:,:,KOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRv2d)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRv2d)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1707,7 +1755,7 @@
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
 
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idRvct,           &
      &                     TLM(ng)%pioVar(idRvct),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1717,7 +1765,7 @@
      &                     COUPLING(ng) % tl_rvfrc)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRvct)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRvct)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1731,7 +1779,7 @@
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
 
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idVfx1,           &
      &                     TLM(ng)%pioVar(idVfx1),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1741,7 +1789,7 @@
      &                     COUPLING(ng) % tl_DV_avg1)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVfx1)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVfx1)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1754,7 +1802,7 @@
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
 
-        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite2d(ng, iTLM, TLM(ng)%pioFile, idVfx2,           &
      &                     TLM(ng)%pioVar(idVfx2),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1764,7 +1812,7 @@
      &                     COUPLING(ng) % tl_DV_avg2)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVfx2)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVfx2)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1797,7 +1845,7 @@
      &                                                    Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,ifield)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,ifield)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1817,7 +1865,7 @@
           ioDesc => ioDesc_sp_u3dvar(ng)
         END IF
 
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idUvel,           &
      &                     TLM(ng)%pioVar(idUvel),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1831,7 +1879,7 @@
 #  endif
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUvel)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUvel)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1846,7 +1894,7 @@
           ioDesc => ioDesc_sp_u3dvar(ng)
         END IF
 
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idRu3d,           &
      &                     TLM(ng)%pioVar(idRu3d),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1856,7 +1904,7 @@
      &                     OCEAN(ng) % tl_ru(:,:,:,NOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRu3d)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRu3d)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1888,7 +1936,7 @@
      &                                                 Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,ifield)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,ifield)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1907,7 +1955,7 @@
           ioDesc => ioDesc_sp_v3dvar(ng)
         END IF
 
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idVvel,           &
      &                     TLM(ng)%pioVar(idVvel),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1921,7 +1969,7 @@
 #  endif
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvel)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvel)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1936,7 +1984,7 @@
           ioDesc => ioDesc_sp_v3dvar(ng)
         END IF
 
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idRv3d,           &
      &                     TLM(ng)%pioVar(idRv3d),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1946,7 +1994,7 @@
      &                     OCEAN(ng) % tl_rv(:,:,:,NOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRv3d)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRv3d)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1978,7 +2026,7 @@
      &                                                 Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,ifield)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,ifield)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1998,7 +2046,7 @@
             ioDesc => ioDesc_sp_r3dvar(ng)
           END IF
 
-          status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idTvar(itrc),   &
      &                       TLM(ng)%pioTrc(itrc),                      &
      &                       TLM(ng)%Rindex, ioDesc,                    &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -2012,7 +2060,7 @@
 #  endif
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),            &
      &                          TLM(ng)%Rindex
             END IF
             exit_flag=3
@@ -2047,7 +2095,7 @@
      &                                                 Lbout(ng),itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), TLM(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), TLM(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -2067,7 +2115,7 @@
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idDano,           &
      &                     TLM(ng)%pioVar(idDano),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -2077,7 +2125,7 @@
      &                     OCEAN(ng) % tl_rho)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idDano)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idDano)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2099,7 +2147,7 @@
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idVvis,           &
      &                     TLM(ng)%pioVar(idVvis),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -2114,7 +2162,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvis)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvis)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2132,7 +2180,7 @@
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idTdif,           &
      &                     TLM(ng)%pioVar(idTdif),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -2147,7 +2195,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTdif)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTdif)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2167,7 +2215,7 @@
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
 
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idSdif,           &
      &                     TLM(ng)%pioVar(idSdif),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -2182,7 +2230,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSdif)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSdif)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2202,7 +2250,7 @@
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
 
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idMtke,           &
      &                     TLM(ng)%pioVar(idMtke),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -2213,7 +2261,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idMtke)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idMtke)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2227,7 +2275,7 @@
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
 
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idVmKK,           &
      &                     TLM(ng)%pioVar(idVmKK),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -2237,7 +2285,7 @@
      &                     MIXING(ng) % tl_Akk)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVmKK)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVmKK)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2255,7 +2303,7 @@
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
 
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idMtls,           &
      &                     TLM(ng)%pioVar(idMtls),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -2266,7 +2314,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idMtls)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idMtls)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2280,7 +2328,7 @@
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
 
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idVmLS,           &
      &                     TLM(ng)%pioVar(idVmLS),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -2290,7 +2338,7 @@
      &                     MIXING(ng) % tl_Lscale)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVmLS)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVmLS)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2306,7 +2354,7 @@
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
 
-        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, TLM(ng)%pioFile, idVmKP,           &
      &                     TLM(ng)%pioVar(idVmKP),                      &
      &                     TLM(ng)%Rindex, ioDesc,                      &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -2316,7 +2364,7 @@
      &                     MIXING(ng) % tl_Akp)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVmKP)), TLM(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVmKP)), TLM(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2336,23 +2384,7 @@
       CALL pio_netcdf_sync (ng, iTLM, TLM(ng)%name, TLM(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-# ifdef SOLVE3D
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, TLM(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, TLM(ng)%Rindex
-#  endif
-# else
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, TLM(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) KOUT, TLM(ng)%Rindex
-#  endif
-# endif
-!
-  10  FORMAT (/,' TL_WRT_HIS_PIO - error while writing variable: ',a,   &
-     &        /,19x,'into tangent NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'TL_WRT_HIS_PIO   - wrote history', t40,               &
+  10  FORMAT (2x,'TL_WRT_HIS_PIO   - writing history', t42,             &
 # ifdef SOLVE3D
 #  ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
@@ -2366,6 +2398,8 @@
      &        'fields (Index=',i1,')   in record = ',i0)
 #  endif
 # endif
+  20  FORMAT (/,' TL_WRT_HIS_PIO - error while writing variable: ',a,   &
+     &        /,19x,'into tangent NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE tl_wrt_his_pio

--- a/ROMS/Tangent/tl_wrt_ini.F
+++ b/ROMS/Tangent/tl_wrt_ini.F
@@ -3,7 +3,7 @@
 #if (defined TANGENT || defined TL_IOMS) && defined FOUR_DVAR
 !
 !git $Id$
-!svn $Id: tl_wrt_ini.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: tl_wrt_ini.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -171,6 +171,49 @@
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
+!  Report.
+!
+      IF (Master) THEN
+# if defined RPCG
+        IF (OutRec.eq.1) THEN
+          string='inner-loop initial fields          '
+        ELSE IF (OutRec.eq.2) THEN
+          string='final outer-loop increments        '
+        ELSE IF (OutRec.eq.3) THEN
+          string='sum of final outer-loop increments '
+        ELSE IF (OutRec.eq.4) THEN
+          string='sum of adjoint solutions           '
+        ELSE IF (OutRec.eq.5) THEN
+          string='augmented correction term          '
+        END IF
+# elif defined SP4DVAR
+        IF (OutRec.eq.1) THEN
+          string='TLM initial fields             '
+        ELSE IF ((2.le.OutRec).and.(OutRec.le.Nsaddle+1)) THEN
+          string='TLM saddle-point starting field'
+        ELSE IF ((Nsaddle+2.le.OutRec).and.(OutRec.le.2*Nsaddle+2)) THEN
+          string='ADM saddle-point starting field'
+        END IF
+# else
+        IF (OutRec.eq.1) THEN
+          string='initial  fields'
+        ELSE IF (OutRec.eq.2) THEN
+          string='v-increments   '
+        ELSE IF (OutRec.eq.3) THEN
+          string='v-increments   '
+        ELSE IF (OutRec.eq.4) THEN
+          string='v-summations   '
+        ELSE IF (OutRec.eq.5) THEN
+          string='x-increments   '
+        END IF
+# endif
+# ifdef SOLVE3D
+        WRITE (stdout,10) string, outer, inner, Tindex, Tindex, OutRec
+# else
+        WRITE (stdout,10) string, outer, inner, Tindex, OutRec
+# endif
+      END IF
+!
 !  Set grid type factor to write full (gfactor=1) fields or water
 !  points (gfactor=-1) fields only.
 !
@@ -196,7 +239,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(idFsur),   &
+      status=nf_fwrite2d(ng, iTLM, ITL(ng)%ncid, idFsur,                &
+     &                   ITL(ng)%Vid(idFsur),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -245,7 +289,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u2dvar
-      status=nf_fwrite2d(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(idUbar),   &
+      status=nf_fwrite2d(ng, iTLM, ITL(ng)%ncid, idUbar,                &
+     &                   ITL(ng)%Vid(idUbar),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -289,7 +334,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v2dvar
-      status=nf_fwrite2d(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(idVbar),   &
+      status=nf_fwrite2d(ng, iTLM, ITL(ng)%ncid, idVbar,                &
+     &                   ITL(ng)%Vid(idVbar),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -336,7 +382,8 @@
 !
       scale=1.0_dp                          ! m2/s2
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(idUsms),   &
+      status=nf_fwrite3d(ng, iTLM, ITL(ng)%ncid, idUsms,                &
+     &                   ITL(ng)%Vid(idUsms),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -356,7 +403,8 @@
 !
       scale=1.0_dp                          ! m2/s2
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(idVsms),   &
+      status=nf_fwrite3d(ng, iTLM, ITL(ng)%ncid, idVsms,                &
+     &                   ITL(ng)%Vid(idVsms),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -378,7 +426,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(idUvel),   &
+      status=nf_fwrite3d(ng, iTLM, ITL(ng)%ncid, idUvel,                &
+     &                   ITL(ng)%Vid(idUvel),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -422,7 +471,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(idVvel),   &
+      status=nf_fwrite3d(ng, iTLM, ITL(ng)%ncid, idVvel,                &
+     &                   ITL(ng)%Vid(idVvel),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -467,7 +517,8 @@
       DO itrc=1,NT(ng)
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Tid(itrc),   &
+        status=nf_fwrite3d(ng, iTLM, ITL(ng)%ncid, idTvar(itrc),        &
+     &                     ITL(ng)%Tid(itrc),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -521,7 +572,7 @@
         IF (Lstflux(itrc,ng)) THEN
           scale=1.0_dp                      ! kinematic flux units
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, iTLM, ITL(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iTLM, ITL(ng)%ncid, idTsur(itrc),      &
      &                       ITL(ng)%Vid(idTsur(itrc)),                 &
      &                       OutRec, gtype,                             &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -608,60 +659,16 @@
       CALL netcdf_sync (ng, iTLM, DAV(ng)%name, DAV(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
-!
-      IF (Master) THEN
-# if defined RPCG
-        IF (OutRec.eq.1) THEN
-          string='inner-loop initial fields          '
-        ELSE IF (OutRec.eq.2) THEN
-          string='final outer-loop increments        '
-        ELSE IF (OutRec.eq.3) THEN
-          string='sum of final outer-loop increments '
-        ELSE IF (OutRec.eq.4) THEN
-          string='sum of adjoint solutions           '
-        ELSE IF (OutRec.eq.5) THEN
-          string='augmented correction term          '
-        END IF
-# elif defined SP4DVAR
-        IF (OutRec.eq.1) THEN
-          string='TLM initial fields             '
-        ELSE IF ((2.le.OutRec).and.(OutRec.le.Nsaddle+1)) THEN
-          string='TLM saddle-point starting field'
-        ELSE IF ((Nsaddle+2.le.OutRec).and.(OutRec.le.2*Nsaddle+2)) THEN
-          string='ADM saddle-point starting field'
-        END IF
-# else
-        IF (OutRec.eq.1) THEN
-          string='initial  fields'
-        ELSE IF (OutRec.eq.2) THEN
-          string='v-increments   '
-        ELSE IF (OutRec.eq.3) THEN
-          string='v-increments   '
-        ELSE IF (OutRec.eq.4) THEN
-          string='v-summations   '
-        ELSE IF (OutRec.eq.5) THEN
-          string='x-increments   '
-        END IF
-# endif
-!
-# ifdef SOLVE3D
-        WRITE (stdout,30) string, outer, inner, Tindex, Tindex, OutRec
-# else
-        WRITE (stdout,30) string, outer, inner, Tindex, OutRec
-# endif
-      END IF
-!
-  10  FORMAT (/,' TL_WRT_INI_NF90 - unable to open initial NetCDF',     &
-     &        ' file: ',a)
-  20  FORMAT (/,' TL_WRT_INI_NF90 - error while writing variable: ',a,  &
-     &        /,14x,'into tangent initial file for time record: ',i0)
-  30  FORMAT (2x,'TL_WRT_INI_NF90  - wrote ',a,                         &
+      !
+10    FORMAT (2x,'TL_WRT_INI_NF90  - writing ',a,                       &
      &        ' (Outer=',i2.2,', Inner=',i3.3,', Index=',i0,            &
 # ifdef SOLVE3D
      &        ',',i0,', Rec=',i0,')')
 # else
      &        ', Rec=',i0,')')
 # endif
+  20  FORMAT (/,' TL_WRT_INI_NF90 - error while writing variable: ',a,  &
+     &        /,14x,'into tangent initial file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE tl_wrt_ini_nf90
@@ -712,6 +719,49 @@
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
+!  Report.
+!
+      IF (Master) THEN
+#  if defined RPCG
+        IF (OutRec.eq.1) THEN
+          string='inner-loop initial fields          '
+        ELSE IF (OutRec.eq.2) THEN
+          string='final outer-loop increments        '
+        ELSE IF (OutRec.eq.3) THEN
+          string='sum of final outer-loop increments '
+        ELSE IF (OutRec.eq.4) THEN
+          string='sum of adjoint solutions           '
+        ELSE IF (OutRec.eq.5) THEN
+          string='augmented correction term          '
+        END IF
+#  elif defined SP4DVAR
+        IF (OutRec.eq.1) THEN
+          string='TLM initial fields             '
+        ELSE IF ((2.le.OutRec).and.(OutRec.le.Nsaddle+1)) THEN
+          string='TLM saddle-point starting field'
+        ELSE IF ((Nsaddle+2.le.OutRec).and.(OutRec.le.2*Nsaddle+2)) THEN
+          string='ADM saddle-point starting field'
+        END IF
+#  else
+        IF (OutRec.eq.1) THEN
+          string='initial  fields'
+        ELSE IF (OutRec.eq.2) THEN
+          string='v-increments   '
+        ELSE IF (OutRec.eq.3) THEN
+          string='v-increments   '
+        ELSE IF (OutRec.eq.4) THEN
+          string='v-summations   '
+        ELSE IF (OutRec.eq.5) THEN
+          string='x-increments   '
+        END IF
+#  endif
+#  ifdef SOLVE3D
+        WRITE (stdout,30) string, outer, inner, Tindex, Tindex, OutRec
+#  else
+        WRITE (stdout,30) string, outer, inner, Tindex, OutRec
+#  endif
+      END IF
+!
 !  Write out model time (s). Use the "tdays" variable here because of
 !  the management of the "time" variable due to nesting.
 !
@@ -733,7 +783,7 @@
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iTLM, ITL(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iTLM, ITL(ng)%pioFile, idFsur,             &
      &                   ITL(ng)%pioVar(idFsur),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -795,7 +845,7 @@
         ioDesc => ioDesc_sp_u2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iTLM, ITL(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iTLM, ITL(ng)%pioFile, idUbar,             &
      &                   ITL(ng)%pioVar(idUbar),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -852,7 +902,7 @@
         ioDesc => ioDesc_sp_v2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iTLM, ITL(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iTLM, ITL(ng)%pioFile, idVbar,             &
      &                   ITL(ng)%pioVar(idVbar),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -912,7 +962,7 @@
         ioDesc => ioDesc_sp_u2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iTLM, ITL(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iTLM, ITL(ng)%pioFile, idUsms,             &
      &                   ITL(ng)%pioVar(idUsms),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
@@ -938,7 +988,7 @@
         ioDesc => ioDesc_sp_v2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iTLM, ITL(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iTLM, ITL(ng)%pioFile, idVsms,             &
      &                   ITL(ng)%pioVar(idVsms),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
@@ -966,7 +1016,7 @@
         ioDesc => ioDesc_sp_u3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iTLM, ITL(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iTLM, ITL(ng)%pioFile, idUvel,             &
      &                   ITL(ng)%pioVar(idUvel),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -1023,7 +1073,7 @@
         ioDesc => ioDesc_sp_v3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iTLM, ITL(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iTLM, ITL(ng)%pioFile, idVvel,             &
      &                   ITL(ng)%pioVar(idVvel),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -1081,7 +1131,7 @@
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iTLM, ITL(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, ITL(ng)%pioFile, idTvar(itrc),     &
      &                     ITL(ng)%pioTrc(itrc),                        &
      &                     OutRec, ioDesc,                              &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1148,7 +1198,7 @@
             ioDesc => ioDesc_sp_r2dfrc(ng)
           END IF
 !
-          status=nf_fwrite3d(ng, iTLM, ITL(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iTLM, ITL(ng)%pioFile, idTsur(itrc),   &
      &                       ITL(ng)%pioVar(idTsur(itrc)),              &
      &                       OutRec, ioDesc,                            &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -1236,59 +1286,15 @@
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #  endif
 !
-      IF (Master) THEN
-#  if defined RPCG
-        IF (OutRec.eq.1) THEN
-          string='inner-loop initial fields          '
-        ELSE IF (OutRec.eq.2) THEN
-          string='final outer-loop increments        '
-        ELSE IF (OutRec.eq.3) THEN
-          string='sum of final outer-loop increments '
-        ELSE IF (OutRec.eq.4) THEN
-          string='sum of adjoint solutions           '
-        ELSE IF (OutRec.eq.5) THEN
-          string='augmented correction term          '
-        END IF
-#  elif defined SP4DVAR
-        IF (OutRec.eq.1) THEN
-          string='TLM initial fields             '
-        ELSE IF ((2.le.OutRec).and.(OutRec.le.Nsaddle+1)) THEN
-          string='TLM saddle-point starting field'
-        ELSE IF ((Nsaddle+2.le.OutRec).and.(OutRec.le.2*Nsaddle+2)) THEN
-          string='ADM saddle-point starting field'
-        END IF
-#  else
-        IF (OutRec.eq.1) THEN
-          string='initial  fields'
-        ELSE IF (OutRec.eq.2) THEN
-          string='v-increments   '
-        ELSE IF (OutRec.eq.3) THEN
-          string='v-increments   '
-        ELSE IF (OutRec.eq.4) THEN
-          string='v-summations   '
-        ELSE IF (OutRec.eq.5) THEN
-          string='x-increments   '
-        END IF
-#  endif
-!
-#  ifdef SOLVE3D
-        WRITE (stdout,30) string, outer, inner, Tindex, Tindex, OutRec
-#  else
-        WRITE (stdout,30) string, outer, inner, Tindex, OutRec
-#  endif
-      END IF
-!
-  10  FORMAT (/,' TL_WRT_INI_PIO - unable to open initial NetCDF',      &
-     &        ' file: ',a)
-  20  FORMAT (/,' TL_WRT_INI_PIO - error while writing variable: ',a,   &
-     &        /,14x,'into tangent initial file for time record: ',i0)
-  30  FORMAT (2x,'TL_WRT_INI_PIO   - wrote ',a,                         &
+  10  FORMAT (2x,'TL_WRT_INI_PIO   - writing ',a,                       &
      &        ' (Outer=',i2.2,', Inner=',i3.3,', Index=',i0,            &
 #  ifdef SOLVE3D
      &        ',',i0,', Rec=',i0,')')
 #  else
      &        ', Rec=',i0,')')
 #  endif
+  20  FORMAT (/,' TL_WRT_INI_PIO - error while writing variable: ',a,   &
+     &        /,14x,'into tangent initial file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE tl_wrt_ini_pio

--- a/ROMS/Tangent/tl_wrt_ini.F
+++ b/ROMS/Tangent/tl_wrt_ini.F
@@ -3,7 +3,7 @@
 #if (defined TANGENT || defined TL_IOMS) && defined FOUR_DVAR
 !
 !git $Id$
-!svn $Id: tl_wrt_ini.F 1189 2023-08-15 21:26:58Z arango $
+!svn $Id: tl_wrt_ini.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -756,9 +756,9 @@
         END IF
 #  endif
 #  ifdef SOLVE3D
-        WRITE (stdout,30) string, outer, inner, Tindex, Tindex, OutRec
+        WRITE (stdout,10) string, outer, inner, Tindex, Tindex, OutRec
 #  else
-        WRITE (stdout,30) string, outer, inner, Tindex, OutRec
+        WRITE (stdout,10) string, outer, inner, Tindex, OutRec
 #  endif
       END IF
 !

--- a/ROMS/Utility/checkdefs.F
+++ b/ROMS/Utility/checkdefs.F
@@ -2,7 +2,7 @@
       SUBROUTINE checkdefs
 !
 !git $Id$
-!svn $Id: checkdefs.F 1178 2023-07-11 17:50:57Z arango $
+!svn $Id: checkdefs.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -1903,6 +1903,13 @@
      &   'Double precision output fields in NetCDF files'
       is=LEN_TRIM(Coptions)+1
       Coptions(is:is+12)=' OUT_DOUBLE,'
+#endif
+#ifdef OUTPUT_STATS
+!
+      IF (Master) WRITE (stdout,20) 'OUTPUT_STATS',                     &
+     &   'Reporting NetCDF output fields statistics'
+      is=LEN_TRIM(Coptions)+1
+      Coptions(is:is+14)=' OUTPUT_STATS,'
 #endif
 #ifdef _OPENMP
 !

--- a/ROMS/Utility/def_info.F
+++ b/ROMS/Utility/def_info.F
@@ -2,7 +2,7 @@
       MODULE def_info_mod
 !
 !git $Id$
-!svn $Id: def_info.F 1184 2023-07-27 20:28:19Z arango $
+!svn $Id: def_info.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -3075,13 +3075,13 @@
 !
 !  Bathymetry.
 !
-        Vinfo( 1)='h'
-        Vinfo( 2)='bathymetry at RHO-points'
-        Vinfo( 3)='meter'
-        Vinfo(14)='bathymetry'
-        Vinfo(21)='sea_floor_depth'
+        Vinfo( 1)=Vname(1,idtopo)
+        Vinfo( 2)=Vname(2,idtopo)
+        Vinfo( 3)=Vname(3,idtopo)
+        Vinfo(14)=Vname(4,idtopo)
+        Vinfo(21)=Vname(6,idtopo)
         Vinfo(22)='coordinates'
-        Aval(5)=REAL(r2dvar,r8)
+        Aval(5)=REAL(Iinfo(1,idtopo,ng),r8)
         IF (ncid.eq.STA(ng)%ncid) THEN
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   1, (/stadim/), Aval, Vinfo, ncname)
@@ -3096,13 +3096,13 @@
 !  Coriolis Parameter.
 !
         IF (ncid.ne.STA(ng)%ncid) THEN
-          Vinfo( 1)='f'
-          Vinfo( 2)='Coriolis parameter at RHO-points'
-          Vinfo( 3)='second-1'
-          Vinfo(14)='Coriolis parameter'
-          Vinfo(21)='coriolis_parameter'
+          Vinfo( 1)=Vname(1,idfcor)
+          Vinfo( 2)=Vname(2,idfcor)
+          Vinfo( 3)=Vname(3,idfcor)
+          Vinfo(14)=Vname(4,idfcor)
+          Vinfo(21)=Vname(6,idfcor)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idfcor,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -3111,24 +3111,24 @@
 !  Curvilinear coordinate metrics.
 !
         IF (ncid.ne.STA(ng)%ncid) THEN
-          Vinfo( 1)='pm'
-          Vinfo( 2)='curvilinear coordinate metric in XI'
-          Vinfo( 3)='meter-1'
-          Vinfo(14)='pm'
-          Vinfo(21)='inverse_grid_x_spacing'
+          Vinfo( 1)=Vname(1,idpmdx)
+          Vinfo( 2)=Vname(2,idpmdx)
+          Vinfo( 3)=Vname(3,idpmdx)
+          Vinfo(14)=Vname(4,idpmdx)
+          Vinfo(21)=Vname(6,idpmdx)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idpmdx,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-          Vinfo( 1)='pn'
-          Vinfo( 2)='curvilinear coordinate metric in ETA'
-          Vinfo( 3)='meter-1'
-          Vinfo(14)='pn'
-          Vinfo(21)='inverse_grid_y_spacing'
+!
+          Vinfo( 1)=Vname(1,idpndy)
+          Vinfo( 2)=Vname(2,idpndy)
+          Vinfo( 3)=Vname(3,idpndy)
+          Vinfo(14)=Vname(4,idpndy)
+          Vinfo(21)=Vname(6,idpndy)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idpndy,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -3137,11 +3137,11 @@
 !  Grid coordinates of RHO-points.
 !
         IF (spherical) THEN
-          Vinfo( 1)='lon_rho'
-          Vinfo( 2)='longitude of RHO-points'
-          Vinfo( 3)='degree_east'
-          Vinfo(14)='longitude'
-          Vinfo(21)='grid_longitude_at_cell_center'
+          Vinfo( 1)=Vname(1,idLonR)
+          Vinfo( 2)=Vname(2,idLonR)
+          Vinfo( 3)=Vname(3,idLonR)
+          Vinfo(14)=Vname(4,idLonR)
+          Vinfo(21)=Vname(6,idLonR)
           IF (ncid.eq.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     1, (/stadim/), Aval, Vinfo, ncname)
@@ -3151,12 +3151,12 @@
      &                     2, t2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='lat_rho'
-          Vinfo( 2)='latitude of RHO-points'
-          Vinfo( 3)='degree_north'
-          Vinfo(14)='latitude'
-          Vinfo(21)='grid_latitude_at_cell_center'
+!
+          Vinfo( 1)=Vname(1,idLatR)
+          Vinfo( 2)=Vname(2,idLatR)
+          Vinfo( 3)=Vname(3,idLatR)
+          Vinfo(14)=Vname(4,idLatR)
+          Vinfo(21)=Vname(6,idLatR)
           IF (ncid.eq.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     1, (/stadim/), Aval, Vinfo,  ncname)
@@ -3167,11 +3167,11 @@
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
         ELSE
-          Vinfo( 1)='x_rho'
-          Vinfo( 2)='x-locations of RHO-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Xr'
-          Vinfo(21)='grid_x_location_at_cell_center'
+          Vinfo( 1)=Vname(1,idXgrR)
+          Vinfo( 2)=Vname(2,idXgrR)
+          Vinfo( 3)=Vname(3,idXgrR)
+          Vinfo(14)=Vname(4,idXgrR)
+          Vinfo(21)=Vname(6,idXgrR)
           IF (ncid.eq.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     1, (/stadim/), Aval, Vinfo, ncname)
@@ -3181,12 +3181,12 @@
      &                     2, t2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='y_rho'
-          Vinfo( 2)='y-locations of RHO-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Yr'
-          Vinfo(21)='grid_y_location_at_cell_center'
+!
+          Vinfo( 1)=Vname(1,idYgrR)
+          Vinfo( 2)=Vname(2,idYgrR)
+          Vinfo( 3)=Vname(3,idYgrR)
+          Vinfo(14)=Vname(4,idYgrR)
+          Vinfo(21)=Vname(6,idYgrR)
           IF (ncid.eq.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     1, (/stadim/), Aval, Vinfo, ncname)
@@ -3201,44 +3201,44 @@
 !  Grid coordinates of U-points.
 !
         IF (spherical) THEN
-          Vinfo( 1)='lon_u'
-          Vinfo( 2)='longitude of U-points'
-          Vinfo( 3)='degree_east'
-          Vinfo(14)='longitude'
-          Vinfo(21)='grid_longitude_at_cell_y_edges'
+          Vinfo( 1)=Vname(1,idLonU)
+          Vinfo( 2)=Vname(2,idLonU)
+          Vinfo( 3)=Vname(3,idLonU)
+          Vinfo(14)=Vname(4,idLonU)
+          Vinfo(21)=Vname(6,idLonU)
           IF (ncid.ne.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     2, u2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='lat_u'
-          Vinfo( 2)='latitude of U-points'
-          Vinfo( 3)='degree_north'
-          Vinfo(14)='latitude'
-          Vinfo(21)='grid_latitude_at_cell_y_edges'
+!
+          Vinfo( 1)=Vname(1,idLatU)
+          Vinfo( 2)=Vname(2,idLatU)
+          Vinfo( 3)=Vname(3,idLatU)
+          Vinfo(14)=Vname(4,idLatU)
+          Vinfo(21)=Vname(6,idLatU)
           IF (ncid.ne.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     2, u2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
         ELSE
-          Vinfo( 1)='x_u'
-          Vinfo( 2)='x-locations of U-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Xu'
-          Vinfo(21)='grid_x_location_at_cell_y_edges'
+          Vinfo( 1)=Vname(1,idXgrU)
+          Vinfo( 2)=Vname(2,idXgrU)
+          Vinfo( 3)=Vname(3,idXgrU)
+          Vinfo(14)=Vname(4,idXgrU)
+          Vinfo(21)=Vname(6,idXgrU)
           IF (ncid.ne.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     2, u2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='y_u'
-          Vinfo( 2)='y-locations of U-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Yu'
-          Vinfo(21)='grid_y_location_at_cell_y_edges'
+!
+          Vinfo( 1)=Vname(1,idYgrU)
+          Vinfo( 2)=Vname(2,idYgrU)
+          Vinfo( 3)=Vname(3,idYgrU)
+          Vinfo(14)=Vname(4,idYgrU)
+          Vinfo(21)=Vname(6,idYgrU)
           IF (ncid.ne.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     2, u2dgrd, Aval, Vinfo, ncname)
@@ -3249,44 +3249,44 @@
 !  Grid coordinates of V-points.
 !
         IF (spherical) THEN
-          Vinfo( 1)='lon_v'
-          Vinfo( 2)='longitude of V-points'
-          Vinfo( 3)='degree_east'
-          Vinfo(14)='longitude'
-          Vinfo(21)='grid_longitude_at_cell_x_edges'
+          Vinfo( 1)=Vname(1,idLonV)
+          Vinfo( 2)=Vname(2,idLonV)
+          Vinfo( 3)=Vname(3,idLonV)
+          Vinfo(14)=Vname(4,idLonV)
+          Vinfo(21)=Vname(6,idLonV)
           IF (ncid.ne.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     2, v2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='lat_v'
-          Vinfo( 2)='latitude of V-points'
-          Vinfo( 3)='degree_north'
-          Vinfo(14)='latitude'
-          Vinfo(21)='grid_latitude_at_cell_x_edges'
+!
+          Vinfo( 1)=Vname(1,idLatV)
+          Vinfo( 2)=Vname(2,idLatV)
+          Vinfo( 3)=Vname(3,idLatV)
+          Vinfo(14)=Vname(4,idLatV)
+          Vinfo(21)=Vname(6,idLatV)
           IF (ncid.ne.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     2, v2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
         ELSE
-          Vinfo( 1)='x_v'
-          Vinfo( 2)='x-locations of V-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Xv'
-          Vinfo(21)='grid_x_location_at_cell_x_edges'
+          Vinfo( 1)=Vname(1,idXgrV)
+          Vinfo( 2)=Vname(2,idXgrV)
+          Vinfo( 3)=Vname(3,idXgrV)
+          Vinfo(14)=Vname(4,idXgrV)
+          Vinfo(21)=Vname(6,idXgrV)
           IF (ncid.ne.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     2, v2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='y_v'
-          Vinfo( 2)='y-locations of V-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Yv'
-          Vinfo(21)='grid_y_location_at_cell_x_edges'
+!
+          Vinfo( 1)=Vname(1,idYgrV)
+          Vinfo( 2)=Vname(2,idYgrV)
+          Vinfo( 3)=Vname(3,idYgrV)
+          Vinfo(14)=Vname(4,idYgrV)
+          Vinfo(21)=Vname(6,idYgrV)
           IF (ncid.ne.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     2, v2dgrd, Aval, Vinfo, ncname)
@@ -3297,44 +3297,44 @@
 !  Grid coordinates of PSI-points.
 !
         IF (spherical) THEN
-          Vinfo( 1)='lon_psi'
-          Vinfo( 2)='longitude of PSI-points'
-          Vinfo( 3)='degree_east'
-          Vinfo(14)='longitude'
-          Vinfo(21)='grid_longitude_at_cell_corners'
+          Vinfo( 1)=Vname(1,idLonP)
+          Vinfo( 2)=Vname(2,idLonP)
+          Vinfo( 3)=Vname(3,idLonP)
+          Vinfo(14)=Vname(4,idLonP)
+          Vinfo(21)=Vname(6,idLonP)
           IF (ncid.ne.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     2, p2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='lat_psi'
-          Vinfo( 2)='latitude of PSI-points'
-          Vinfo( 3)='degree_north'
-          Vinfo(14)='latitude'
-          Vinfo(21)='grid_latitude_at_cell_corners'
+!
+          Vinfo( 1)=Vname(1,idLatP)
+          Vinfo( 2)=Vname(2,idLatP)
+          Vinfo( 3)=Vname(3,idLatP)
+          Vinfo(14)=Vname(4,idLatP)
+          Vinfo(21)=Vname(6,idLatP)
           IF (ncid.ne.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     2, p2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
         ELSE
-          Vinfo( 1)='x_psi'
-          Vinfo( 2)='x-locations of PSI-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Xp'
-          Vinfo(21)='grid_x_location_at_cell_corners'
+          Vinfo( 1)=Vname(1,idXgrP)
+          Vinfo( 2)=Vname(2,idXgrP)
+          Vinfo( 3)=Vname(3,idXgrP)
+          Vinfo(14)=Vname(4,idXgrP)
+          Vinfo(21)=Vname(6,idXgrP)
           IF (ncid.ne.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     2, p2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='y_psi'
-          Vinfo( 2)='y-locations of PSI-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Yp'
-          Vinfo(21)='grid_y_location_at_cell_corners'
+!
+          Vinfo( 1)=Vname(1,idYgrP)
+          Vinfo( 2)=Vname(2,idYgrP)
+          Vinfo( 3)=Vname(3,idYgrP)
+          Vinfo(14)=Vname(4,idYgrP)
+          Vinfo(21)=Vname(6,idYgrP)
           IF (ncid.ne.STA(ng)%ncid) THEN
             status=def_var(ng, model, ncid, varid, NF_TYPE,             &
      &                     2, p2dgrd, Aval, Vinfo, ncname)
@@ -3346,13 +3346,13 @@
 !
 !  Angle between XI-axis and EAST at RHO-points.
 !
-        Vinfo( 1)='angle'
-        Vinfo( 2)='angle between XI-axis and EAST'
-        Vinfo( 3)='radians'
-        Vinfo(14)='curvilinear angle'
-        Vinfo(21)='grid_angle_of_rotation_from_east_to_y'
+        Vinfo( 1)=Vname(1,idangR)
+        Vinfo( 2)=Vname(2,idangR)
+        Vinfo( 3)=Vname(3,idangR)
+        Vinfo(14)=Vname(4,idangR)
+        Vinfo(21)=Vname(6,idangR)
         Vinfo(22)='coordinates'
-        Aval(5)=REAL(r2dvar,r8)
+        Aval(5)=REAL(Iinfo(1,idangR,ng),r8)
         IF (ncid.eq.STA(ng)%ncid) THEN
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   1, (/stadim/), Aval, Vinfo,  ncname)
@@ -3368,46 +3368,46 @@
 !  Masking fields at RHO-, U-, V-points, and PSI-points.
 !
         IF (ncid.ne.STA(ng)%ncid) THEN
-          Vinfo( 1)='mask_rho'
-          Vinfo( 2)='mask on RHO-points'
+          Vinfo( 1)=Vname(1,idmskR)
+          Vinfo( 2)=Vname(2,idmskR)
           Vinfo( 9)='land'
           Vinfo(10)='water'
-          Vinfo(21)='land_sea_mask_at_cell_center'
+          Vinfo(21)=Vname(6,idmskR)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idmskR,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-          Vinfo( 1)='mask_u'
-          Vinfo( 2)='mask on U-points'
+!
+          Vinfo( 1)=Vname(1,idmskU)
+          Vinfo( 2)=Vname(2,idmskU)
           Vinfo( 9)='land'
           Vinfo(10)='water'
-          Vinfo(21)='land_sea_mask_at_cell_y_edges'
+          Vinfo(21)=Vname(6,idmskU)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(u2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idmskU,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, u2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-          Vinfo( 1)='mask_v'
-          Vinfo( 2)='mask on V-points'
+!
+          Vinfo( 1)=Vname(1,idmskV)
+          Vinfo( 2)=Vname(2,idmskV)
           Vinfo( 9)='land'
           Vinfo(10)='water'
-          Vinfo(21)='land_sea_mask_at_cell_x_edges'
+          Vinfo(21)=Vname(6,idmskV)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(v2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idmskV,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, v2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-          Vinfo( 1)='mask_psi'
-          Vinfo( 2)='mask on psi-points'
+!
+          Vinfo( 1)=Vname(1,idmskP)
+          Vinfo( 2)=Vname(2,idmskP)
           Vinfo( 9)='land'
           Vinfo(10)='water'
-          Vinfo(21)='land_sea_mask_at_cell_corners'
+          Vinfo(21)=Vname(6,idmskP)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(p2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idmskP,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, p2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -3420,35 +3420,35 @@
 !  Adjoint sensitivity spatial scope mask at RHO-, U-, and V-points.
 !
         IF (ncid.ne.STA(ng)%ncid) THEN
-          Vinfo( 1)='scope_rho'
-          Vinfo( 2)='adjoint sensitivity spatial scope on RHO-points'
+          Vinfo( 1)=Vname(1,idscoR)
+          Vinfo( 2)=Vname(2,idscoR)
           Vinfo( 9)='inactive'
           Vinfo(10)='active'
-          Vinfo(21)='adjoint_sensitivity_scope_mask_at_cell_center'
+          Vinfo(21)=Vname(6,idscoR)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idscoR,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-          Vinfo( 1)='scope_u'
-          Vinfo( 2)='adjoint sensitivity spatial scope on U-points'
+!
+          Vinfo( 1)=Vname(1,idscoU)
+          Vinfo( 2)=Vname(2,idscoU)
           Vinfo( 9)='inactive'
           Vinfo(10)='active'
-          Vinfo(21)='adjoint_sensitivity_scope_mask_at_cell_y_edges'
+          Vinfo(21)=Vname(6,idscoU)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(u2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idscoU,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, u2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-          Vinfo( 1)='scope_v'
-          Vinfo( 2)='adjoint sensitivity spatial scope on V-points'
+!
+          Vinfo( 1)=Vname(1,idscoV)
+          Vinfo( 2)=Vname(2,idscoV)
           Vinfo( 9)='inactive'
           Vinfo(10)='active'
-          Vinfo(21)='adjoint_sensitivity_scope_mask_at_cell_x_edges'
+          Vinfo(21)=Vname(6,idscoV)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(v2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idscoV,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, v2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -3466,7 +3466,7 @@
           Vinfo(14)=Vname(4,idZoBL)
           Vinfo(21)=Vname(6,idZoBL)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idZoBL,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -3478,7 +3478,7 @@
           Vinfo(14)=Vname(4,idragL)
           Vinfo(21)=Vname(6,idragL)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idragL,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -3490,7 +3490,7 @@
           Vinfo(14)=Vname(4,idragQ)
           Vinfo(21)=Vname(6,idragQ)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idragQ,ng),r8)
           status=def_var(ng, model, ncid, varid, NF_TYPE,               &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -6498,13 +6498,13 @@
 !
 !  Bathymetry.
 !
-        Vinfo( 1)='h'
-        Vinfo( 2)='bathymetry at RHO-points'
-        Vinfo( 3)='meter'
-        Vinfo(14)='bathymetry'
-        Vinfo(21)='sea_floor_depth'
+        Vinfo( 1)=Vname(1,idtopo)
+        Vinfo( 2)=Vname(2,idtopo)
+        Vinfo( 3)=Vname(3,idtopo)
+        Vinfo(14)=Vname(4,idtopo)
+        Vinfo(21)=Vname(6,idtopo)
         Vinfo(22)='coordinates'
-        Aval(5)=REAL(r2dvar,r8)
+        Aval(5)=REAL(Iinfo(1,idtopo,ng),r8)
         IF (FileH.eq.ABS(STA(ng)%pioFile%fh)) THEN
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   1, (/stadim/), Aval, Vinfo, ncname)
@@ -6519,13 +6519,13 @@
 !  Coriolis Parameter.
 !
         IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
-          Vinfo( 1)='f'
-          Vinfo( 2)='Coriolis parameter at RHO-points'
-          Vinfo( 3)='second-1'
-          Vinfo(14)='Coriolis parameter'
-          Vinfo(21)='coriolis_parameter'
+          Vinfo( 1)=Vname(1,idfcor)
+          Vinfo( 2)=Vname(2,idfcor)
+          Vinfo( 3)=Vname(3,idfcor)
+          Vinfo(14)=Vname(4,idfcor)
+          Vinfo(21)=Vname(6,idfcor)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idfcor,ng),r8)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -6534,24 +6534,24 @@
 !  Curvilinear coordinate metrics.
 !
         IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
-          Vinfo( 1)='pm'
-          Vinfo( 2)='curvilinear coordinate metric in XI'
-          Vinfo( 3)='meter-1'
-          Vinfo(14)='pm'
-          Vinfo(21)='inverse_grid_x_spacing'
+          Vinfo( 1)=Vname(1,idpmdx)
+          Vinfo( 2)=Vname(2,idpmdx)
+          Vinfo( 3)=Vname(3,idpmdx)
+          Vinfo(14)=Vname(4,idpmdx)
+          Vinfo(21)=Vname(6,idpmdx)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idpmdx,ng),r8)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-          Vinfo( 1)='pn'
-          Vinfo( 2)='curvilinear coordinate metric in ETA'
-          Vinfo( 3)='meter-1'
-          Vinfo(14)='pn'
-          Vinfo(21)='inverse_grid_y_spacing'
+!
+          Vinfo( 1)=Vname(1,idpndy)
+          Vinfo( 2)=Vname(2,idpndy)
+          Vinfo( 3)=Vname(3,idpndy)
+          Vinfo(14)=Vname(4,idpndy)
+          Vinfo(21)=Vname(6,idpndy)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idpndy,ng),r8)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -6560,11 +6560,11 @@
 !  Grid coordinates of RHO-points.
 !
         IF (spherical) THEN
-          Vinfo( 1)='lon_rho'
-          Vinfo( 2)='longitude of RHO-points'
-          Vinfo( 3)='degree_east'
-          Vinfo(14)='longitude'
-          Vinfo(21)='grid_longitude_at_cell_center'
+          Vinfo( 1)=Vname(1,idLonR)
+          Vinfo( 2)=Vname(2,idLonR)
+          Vinfo( 3)=Vname(3,idLonR)
+          Vinfo(14)=Vname(4,idLonR)
+          Vinfo(21)=Vname(6,idLonR)
           IF (FileH.eq.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     1, (/stadim/), Aval, Vinfo, ncname)
@@ -6574,12 +6574,12 @@
      &                     2, t2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='lat_rho'
-          Vinfo( 2)='latitude of RHO-points'
-          Vinfo( 3)='degree_north'
-          Vinfo(14)='latitude'
-          Vinfo(21)='grid_latitude_at_cell_center'
+!
+          Vinfo( 1)=Vname(1,idLatR)
+          Vinfo( 2)=Vname(2,idLatR)
+          Vinfo( 3)=Vname(3,idLatR)
+          Vinfo(14)=Vname(4,idLatR)
+          Vinfo(21)=Vname(6,idLatR)
           IF (FileH.eq.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     1, (/stadim/), Aval, Vinfo,  ncname)
@@ -6590,11 +6590,11 @@
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
         ELSE
-          Vinfo( 1)='x_rho'
-          Vinfo( 2)='x-locations of RHO-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Xr'
-          Vinfo(21)='grid_x_location_at_cell_center'
+          Vinfo( 1)=Vname(1,idXgrR)
+          Vinfo( 2)=Vname(2,idXgrR)
+          Vinfo( 3)=Vname(3,idXgrR)
+          Vinfo(14)=Vname(4,idXgrR)
+          Vinfo(21)=Vname(6,idXgrR)
           IF (FileH.eq.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     1, (/stadim/), Aval, Vinfo, ncname)
@@ -6604,12 +6604,12 @@
      &                     2, t2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='y_rho'
-          Vinfo( 2)='y-locations of RHO-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Yr'
-          Vinfo(21)='grid_y_location_at_cell_center'
+!
+          Vinfo( 1)=Vname(1,idYgrR)
+          Vinfo( 2)=Vname(2,idYgrR)
+          Vinfo( 3)=Vname(3,idYgrR)
+          Vinfo(14)=Vname(4,idYgrR)
+          Vinfo(21)=Vname(6,idYgrR)
           IF (FileH.eq.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     1, (/stadim/), Aval, Vinfo, ncname)
@@ -6624,44 +6624,44 @@
 !  Grid coordinates of U-points.
 !
         IF (spherical) THEN
-          Vinfo( 1)='lon_u'
-          Vinfo( 2)='longitude of U-points'
-          Vinfo( 3)='degree_east'
-          Vinfo(14)='longitude'
-          Vinfo(21)='grid_longitude_at_cell_y_edges'
+          Vinfo( 1)=Vname(1,idLonU)
+          Vinfo( 2)=Vname(2,idLonU)
+          Vinfo( 3)=Vname(3,idLonU)
+          Vinfo(14)=Vname(4,idLonU)
+          Vinfo(21)=Vname(6,idLonU)
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     2, u2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='lat_u'
-          Vinfo( 2)='latitude of U-points'
-          Vinfo( 3)='degree_north'
-          Vinfo(14)='latitude'
-          Vinfo(21)='grid_latitude_at_cell_y_edges'
+!
+          Vinfo( 1)=Vname(1,idLatU)
+          Vinfo( 2)=Vname(2,idLatU)
+          Vinfo( 3)=Vname(3,idLatU)
+          Vinfo(14)=Vname(4,idLatU)
+          Vinfo(21)=Vname(6,idLatU)
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     2, u2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
         ELSE
-          Vinfo( 1)='x_u'
-          Vinfo( 2)='x-locations of U-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Xu'
-          Vinfo(21)='grid_x_location_at_cell_y_edges'
+          Vinfo( 1)=Vname(1,idXgrU)
+          Vinfo( 2)=Vname(2,idXgrU)
+          Vinfo( 3)=Vname(3,idXgrU)
+          Vinfo(14)=Vname(4,idXgrU)
+          Vinfo(21)=Vname(6,idXgrU)
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     2, u2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='y_u'
-          Vinfo( 2)='y-locations of U-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Yu'
-          Vinfo(21)='grid_y_location_at_cell_y_edges'
+!
+          Vinfo( 1)=Vname(1,idYgrU)
+          Vinfo( 2)=Vname(2,idYgrU)
+          Vinfo( 3)=Vname(3,idYgrU)
+          Vinfo(14)=Vname(4,idYgrU)
+          Vinfo(21)=Vname(6,idYgrU)
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     2, u2dgrd, Aval, Vinfo, ncname)
@@ -6672,44 +6672,44 @@
 !  Grid coordinates of V-points.
 !
         IF (spherical) THEN
-          Vinfo( 1)='lon_v'
-          Vinfo( 2)='longitude of V-points'
-          Vinfo( 3)='degree_east'
-          Vinfo(14)='longitude'
-          Vinfo(21)='grid_longitude_at_cell_x_edges'
+          Vinfo( 1)=Vname(1,idLonV)
+          Vinfo( 2)=Vname(2,idLonV)
+          Vinfo( 3)=Vname(3,idLonV)
+          Vinfo(14)=Vname(4,idLonV)
+          Vinfo(21)=Vname(6,idLonV)
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     2, v2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='lat_v'
-          Vinfo( 2)='latitude of V-points'
-          Vinfo( 3)='degree_north'
-          Vinfo(14)='latitude'
-          Vinfo(21)='grid_latitude_at_cell_x_edges'
+!
+          Vinfo( 1)=Vname(1,idLatV)
+          Vinfo( 2)=Vname(2,idLatV)
+          Vinfo( 3)=Vname(3,idLatV)
+          Vinfo(14)=Vname(4,idLatV)
+          Vinfo(21)=Vname(6,idLatV)
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     2, v2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
         ELSE
-          Vinfo( 1)='x_v'
-          Vinfo( 2)='x-locations of V-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Xv'
-          Vinfo(21)='grid_x_location_at_cell_x_edges'
+          Vinfo( 1)=Vname(1,idXgrV)
+          Vinfo( 2)=Vname(2,idXgrV)
+          Vinfo( 3)=Vname(3,idXgrV)
+          Vinfo(14)=Vname(4,idXgrV)
+          Vinfo(21)=Vname(6,idXgrV)
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     2, v2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='y_v'
-          Vinfo( 2)='y-locations of V-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Yv'
-          Vinfo(21)='grid_y_location_at_cell_x_edges'
+!
+          Vinfo( 1)=Vname(1,idYgrV)
+          Vinfo( 2)=Vname(2,idYgrV)
+          Vinfo( 3)=Vname(3,idYgrV)
+          Vinfo(14)=Vname(4,idYgrV)
+          Vinfo(21)=Vname(6,idYgrV)
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     2, v2dgrd, Aval, Vinfo, ncname)
@@ -6720,44 +6720,44 @@
 !  Grid coordinates of PSI-points.
 !
         IF (spherical) THEN
-          Vinfo( 1)='lon_psi'
-          Vinfo( 2)='longitude of PSI-points'
-          Vinfo( 3)='degree_east'
-          Vinfo(14)='longitude'
-          Vinfo(21)='grid_longitude_at_cell_corners'
+          Vinfo( 1)=Vname(1,idLonP)
+          Vinfo( 2)=Vname(2,idLonP)
+          Vinfo( 3)=Vname(3,idLonP)
+          Vinfo(14)=Vname(4,idLonP)
+          Vinfo(21)=Vname(6,idLonP)
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     2, p2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='lat_psi'
-          Vinfo( 2)='latitude of PSI-points'
-          Vinfo( 3)='degree_north'
-          Vinfo(14)='latitude'
-          Vinfo(21)='grid_latitude_at_cell_corners'
+!
+          Vinfo( 1)=Vname(1,idLatP)
+          Vinfo( 2)=Vname(2,idLatP)
+          Vinfo( 3)=Vname(3,idLatP)
+          Vinfo(14)=Vname(4,idLatP)
+          Vinfo(21)=Vname(6,idLatP)
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     2, p2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
         ELSE
-          Vinfo( 1)='x_psi'
-          Vinfo( 2)='x-locations of PSI-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Xp'
-          Vinfo(21)='grid_x_location_at_cell_corners'
+          Vinfo( 1)=Vname(1,idXgrP)
+          Vinfo( 2)=Vname(2,idXgrP)
+          Vinfo( 3)=Vname(3,idXgrP)
+          Vinfo(14)=Vname(4,idXgrP)
+          Vinfo(21)=Vname(6,idXgrP)
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     2, p2dgrd, Aval, Vinfo, ncname)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
-
-          Vinfo( 1)='y_psi'
-          Vinfo( 2)='y-locations of PSI-points'
-          Vinfo( 3)='meter'
-          Vinfo(14)='Yp'
-          Vinfo(21)='grid_y_location_at_cell_corners'
+!
+          Vinfo( 1)=Vname(1,idYgrP)
+          Vinfo( 2)=Vname(2,idYgrP)
+          Vinfo( 3)=Vname(3,idYgrP)
+          Vinfo(14)=Vname(4,idYgrP)
+          Vinfo(21)=Vname(6,idYgrP)
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,        &
      &                     2, p2dgrd, Aval, Vinfo, ncname)
@@ -6769,13 +6769,13 @@
 !
 !  Angle between XI-axis and EAST at RHO-points.
 !
-        Vinfo( 1)='angle'
-        Vinfo( 2)='angle between XI-axis and EAST'
-        Vinfo( 3)='radians'
-        Vinfo(14)='curvilinear angle'
-        Vinfo(21)='grid_angle_of_rotation_from_east_to_y'
+        Vinfo( 1)=Vname(1,idangR)
+        Vinfo( 2)=Vname(2,idangR)
+        Vinfo( 3)=Vname(3,idangR)
+        Vinfo(14)=Vname(4,idangR)
+        Vinfo(21)=Vname(6,idangR)
         Vinfo(22)='coordinates'
-        Aval(5)=REAL(r2dvar,r8)
+        Aval(5)=REAL(Iinfo(1,idangR,ng),r8)
         IF (FileH.eq.ABS(STA(ng)%pioFile%fh)) THEN
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   1, (/stadim/), Aval, Vinfo,  ncname)
@@ -6791,46 +6791,44 @@
 !  Masking fields at RHO-, U-, V-points, and PSI-points.
 !
         IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
-          Vinfo( 1)='mask_rho'
-          Vinfo( 2)='mask on RHO-points'
+          Vinfo( 1)=Vname(1,idmskR)
+          Vinfo( 2)=Vname(2,idmskR)
           Vinfo( 9)='land'
           Vinfo(10)='water'
-          Vinfo(21)='land_sea_mask_at_cell_center'
+          Vinfo(21)=Vname(6,idmskR)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idmskR,ng),r8)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-          Vinfo( 1)='mask_u'
-          Vinfo( 2)='mask on U-points'
+!
+          Vinfo( 1)=Vname(1,idmskU)
+          Vinfo( 2)=Vname(2,idmskU)
           Vinfo( 9)='land'
           Vinfo(10)='water'
-          Vinfo(21)='land_sea_mask_at_cell_y_edges'
+          Vinfo(21)=Vname(6,idmskU)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(u2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idmskU,ng),r8)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, u2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-          Vinfo( 1)='mask_v'
-          Vinfo( 2)='mask on V-points'
+!
+          Vinfo( 1)=Vname(1,idmskV)
+          Vinfo( 2)=Vname(2,idmskV)
           Vinfo( 9)='land'
           Vinfo(10)='water'
-          Vinfo(21)='land_sea_mask_at_cell_x_edges'
-          Vinfo(22)='coordinates'
-          Aval(5)=REAL(v2dvar,r8)
+          Vinfo(21)=Vname(6,idmskV)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, v2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-          Vinfo( 1)='mask_psi'
-          Vinfo( 2)='mask on psi-points'
+!
+          Vinfo( 1)=Vname(1,idmskP)
+          Vinfo( 2)=Vname(2,idmskP)
           Vinfo( 9)='land'
           Vinfo(10)='water'
-          Vinfo(21)='land_sea_mask_at_cell_corners'
+          Vinfo(21)=Vname(6,idmskP)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(p2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idmskP,ng),r8)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, p2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -6843,35 +6841,35 @@
 !  Adjoint sensitivity spatial scope mask at RHO-, U-, and V-points.
 !
         IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
-          Vinfo( 1)='scope_rho'
-          Vinfo( 2)='adjoint sensitivity spatial scope on RHO-points'
+          Vinfo( 1)=Vname(1,idscoR)
+          Vinfo( 2)=Vname(2,idscoR)
           Vinfo( 9)='inactive'
           Vinfo(10)='active'
-          Vinfo(21)='adjoint_sensitivity_scope_mask_at_cell_center'
+          Vinfo(21)=Vname(6,idscoR)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idscoR,ng),r8)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-          Vinfo( 1)='scope_u'
-          Vinfo( 2)='adjoint sensitivity spatial scope on U-points'
+!
+          Vinfo( 1)=Vname(1,idscoU)
+          Vinfo( 2)=Vname(2,idscoU)
           Vinfo( 9)='inactive'
           Vinfo(10)='active'
-          Vinfo(21)='adjoint_sensitivity_scope_mask_at_cell_y_edges'
+          Vinfo(21)=Vname(6,idscoU)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(u2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idscoU,ng),r8)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, u2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-          Vinfo( 1)='scope_v'
-          Vinfo( 2)='adjoint sensitivity spatial scope on V-points'
+!
+          Vinfo( 1)=Vname(1,idscoV)
+          Vinfo( 2)=Vname(2,idscoV)
           Vinfo( 9)='inactive'
           Vinfo(10)='active'
-          Vinfo(21)='adjoint_sensitivity_scope_mask_at_cell_x_edges'
+          Vinfo(21)=Vname(6,idscoV)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(v2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idscoV,ng),r8)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, v2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -6889,7 +6887,7 @@
           Vinfo(14)=Vname(4,idZoBL)
           Vinfo(21)=Vname(6,idZoBL)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idZoBL,ng),r8)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -6901,7 +6899,7 @@
           Vinfo(14)=Vname(4,idragL)
           Vinfo(21)=Vname(6,idragL)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idragL,ng),r8)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -6913,7 +6911,7 @@
           Vinfo(14)=Vname(4,idragQ)
           Vinfo(21)=Vname(6,idragQ)
           Vinfo(22)='coordinates'
-          Aval(5)=REAL(r2dvar,r8)
+          Aval(5)=REAL(Iinfo(1,idragQ,ng),r8)
           status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,          &
      &                   2, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN

--- a/ROMS/Utility/def_station.F
+++ b/ROMS/Utility/def_station.F
@@ -3,7 +3,7 @@
 #ifdef STATIONS
 !
 !git $Id$
-!svn $Id: def_station.F 1185 2023-08-01 21:42:38Z arango $
+!svn $Id: def_station.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !

--- a/ROMS/Utility/nf_fread2d_bry.F
+++ b/ROMS/Utility/nf_fread2d_bry.F
@@ -2,7 +2,7 @@
       MODULE nf_fread2d_bry_mod
 !
 !git $Id$
-!svn $Id: nf_fread2d_bry.F 1159 2023-03-24 23:49:03Z arango $
+!svn $Id: nf_fread2d_bry.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -572,10 +572,10 @@
 !
         IF (Lchecksum) THEN
           Npts=(UBij-LBij+1)*Nrec*4
-          IF (.not.allocatable(Cwrk)) allocate ( Cwrk(Npts) )
+          IF (.not.allocated(Cwrk)) allocate ( Cwrk(Npts) )
           Cwrk=PACK(wrk(LBij:UBij, 1:4, 1:Nrec), .TRUE.)
           CALL get_hash (Cwrk, Npts, checksum)
-          IF (allocatable(Cwrk)) deallocate (Cwrk)
+          IF (allocated(Cwrk)) deallocate (Cwrk)
         END IF
       END IF
 !

--- a/ROMS/Utility/nf_fwrite2d.F
+++ b/ROMS/Utility/nf_fwrite2d.F
@@ -2,7 +2,7 @@
       MODULE nf_fwrite2d_mod
 !
 !git $Id$
-!svn $Id: nf_fwrite2d.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: nf_fwrite2d.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -16,8 +16,9 @@
 !  On Input:                                                           !
 !                                                                      !
 !     ng           Nested grid number                                  !
-!     model        Calling model identifier.                           !
-!     ncid         NetCDF file ID.                                     !
+!     model        Calling model identifier                            !
+!     ncid         NetCDF file ID                                      !
+!     ifield       Field metadata index (integer)                      !
 #if defined PIO_LIB && defined DISTRIBUTE
 !or   pioFile      PIO file descriptor structure, TYPE(file_desc_t)    !
 !                    pioFile%fh         file handler                   !
@@ -80,7 +81,8 @@
 #if defined PARALLEL_IO && defined DISTRIBUTE
 !
 !***********************************************************************
-      FUNCTION nf90_fwrite2d (ng, model, ncid, ncvarid, tindex, gtype,  &
+      FUNCTION nf90_fwrite2d (ng, model, ncid, ifield,                  &
+     &                        ncvarid, tindex, gtype,                   &
      &                        LBi, UBi, LBj, UBj, Ascl,                 &
 # ifdef MASKING
      &                        Amask,                                    &
@@ -101,6 +103,7 @@
       logical, intent(in), optional :: SetFillVal
 !
       integer, intent(in) :: ng, model, ncid, ncvarid, tindex, gtype
+      integer, intent(in) :: ifield
       integer, intent(in) :: LBi, UBi, LBj, UBj
 !
       real(dp), intent(in) :: Ascl
@@ -373,7 +376,8 @@
 
 !
 !***********************************************************************
-      FUNCTION nf90_fwrite2d (ng, model, ncid, ncvarid, tindex, gtype,  &
+      FUNCTION nf90_fwrite2d (ng, model, ncid, ifield,                  &
+     &                        ncvarid, tindex, gtype,                   &
      &                        LBi, UBi, LBj, UBj, Ascl,                 &
 # ifdef MASKING
      &                        Amask,                                    &
@@ -388,12 +392,16 @@
 !
       USE distribute_mod, ONLY : mp_bcasti, mp_gather2d
 # endif
+# ifdef OUTPUT_STATS
+      USE stats_mod,      ONLY : stats_2dfld
+# endif
 !
 !  Imported variable declarations.
 !
       logical, intent(in), optional :: SetFillVal
 !
       integer, intent(in) :: ng, model, ncid, ncvarid, tindex, gtype
+      integer, intent(in) :: ifield
       integer, intent(in) :: LBi, UBi, LBj, UBj
 !
       real(dp), intent(in) :: Ascl
@@ -418,7 +426,7 @@
       logical :: LandFill
 !
 # endif
-      integer :: i, j, ic, Npts
+      integer :: i, j, ic, Npts, tile
       integer :: Imin, Imax, Jmin, Jmax
       integer :: Ilen, Jlen, IJlen, MyType
       integer :: status
@@ -426,6 +434,11 @@
       integer, dimension(3) :: start, total
 !
       real(r8), dimension((Lm(ng)+2)*(Mm(ng)+2)) :: Awrk
+
+# ifdef OUTPUT_STATS
+!
+      TYPE (T_STATS) :: Stats
+# endif
 !
 !-----------------------------------------------------------------------
 !  Set starting and ending indices to process.
@@ -486,6 +499,17 @@
 !
       Awrk=0.0_r8
 
+# ifdef OUTPUT_STATS
+!
+!  Initialize output variable statistics structure.
+!
+      Stats % checksum=0_i8b
+      Stats % count=0
+      Stats % min=spval
+      Stats % max=-spval
+      Stats % avg=0.0_r8
+      Stats % rms=0.0_r8
+# endif
 # ifdef DISTRIBUTE
 !
 !-----------------------------------------------------------------------
@@ -589,6 +613,32 @@
         END IF
         status=nf90_put_var(ncid, ncvarid, Awrk, start, total)
       END IF
+
+# ifdef OUTPUT_STATS
+!
+!-----------------------------------------------------------------------
+!  Compute and report output field statistics.
+!-----------------------------------------------------------------------
+!
+#  ifdef DISTRIBUTE
+      tile=MyRank
+#  else
+      tile=-1
+#  endif
+      CALL stats_2dfld (ng, tile, model, gtype, Stats,                  &
+     &                  LBi, UBi, LBj, UBj,                             &
+     &                  Adat,                                           &
+#  ifdef MASKING
+     &                  Fmask = Amask,                                  &
+#  endif
+     &                  debug = .FALSE.)
+      IF (OutThread) THEN
+        WRITE (stdout,10) TRIM(Vname(1,ifield)), Stats%min, Stats%max,  &
+     &                    Stats%checksum
+  10    FORMAT (4x,'- ',a,':',t35,'Min = ',1p,e15.8,',  Max = ',        &
+     &          1p,e15.8,',  CheckSum = ',i0)
+      END IF
+# endif
 # ifdef DISTRIBUTE
 !
 !-----------------------------------------------------------------------
@@ -605,8 +655,8 @@
 #if defined PIO_LIB && defined DISTRIBUTE
 !
 !***********************************************************************
-      FUNCTION pio_fwrite2d (ng, model, pioFile, pioVar, tindex,        &
-     &                       pioDesc,                                   &
+      FUNCTION pio_fwrite2d (ng, model, pioFile, ifield,                &
+     &                       pioVar, tindex, pioDesc,                   &
      &                       LBi, UBi, LBj, UBj, Ascl,                  &
 # ifdef MASKING
      &                       Amask,                                     &
@@ -624,6 +674,7 @@
       logical, intent(in), optional :: SetFillVal
 !
       integer, intent(in) :: ng, model, tindex
+      integer, intent(in) :: ifield
       integer, intent(in) :: LBi, UBi, LBj, UBj
 !
       real(dp), intent(in) :: Ascl

--- a/ROMS/Utility/nf_fwrite2d.F
+++ b/ROMS/Utility/nf_fwrite2d.F
@@ -2,7 +2,7 @@
       MODULE nf_fwrite2d_mod
 !
 !git $Id$
-!svn $Id: nf_fwrite2d.F 1189 2023-08-15 21:26:58Z arango $
+!svn $Id: nf_fwrite2d.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -668,6 +668,9 @@
       USE mod_pio_netcdf
 !
       USE distribute_mod, ONLY : mp_reduce
+# ifdef OUTPUT_STATS
+      USE stats_mod,      ONLY : stats_2dfld
+# endif
 !
 !  Imported variable declarations.
 !
@@ -703,7 +706,7 @@
 
       logical,  pointer :: Lwater(:,:)
 !
-      integer :: i, j
+      integer :: i, j, tile
       integer :: Imin, Imax, Jmin, Jmax
       integer :: Cgrid, dkind, ghost, gtype
       integer :: status
@@ -714,6 +717,11 @@
 
       real(r4), pointer :: Awrk4(:,:)
       real(r8), pointer :: Awrk8(:,:)
+
+# ifdef OUTPUT_STATS
+!
+      TYPE (T_STATS) :: Stats
+# endif
 !
       character (len= 3), dimension(2) :: op_handle
 !
@@ -769,6 +777,17 @@
       ELSE
         LandFill=tindex.gt.0
       END IF
+# endif
+# ifdef OUTPUT_STATS
+!
+!  Initialize output variable statistics structure.
+!
+      Stats % checksum=0_i8b
+      Stats % count=0
+      Stats % min=spval
+      Stats % max=-spval
+      Stats % avg=0.0_r8
+      Stats % rms=0.0_r8
 # endif
 !
 !-----------------------------------------------------------------------
@@ -846,6 +865,32 @@
      &                         Awrk4(Imin:Imax,Jmin:Jmax),              &
      &                         status)
       END IF
+
+# ifdef OUTPUT_STATS
+!
+!-----------------------------------------------------------------------
+!  Compute and report output field statistics.
+!-----------------------------------------------------------------------
+!
+#  ifdef DISTRIBUTE
+      tile=MyRank
+#  else
+      tile=-1
+#  endif
+      CALL stats_2dfld (ng, tile, model, gtype, Stats,                  &
+     &                  LBi, UBi, LBj, UBj,                             &
+     &                  Adat,                                           &
+#  ifdef MASKING
+     &                  Fmask = Amask,                                  &
+#  endif
+     &                  debug = .FALSE.)
+      IF (OutThread) THEN
+        WRITE (stdout,10) TRIM(Vname(1,ifield)), Stats%min, Stats%max,  &
+     &                    Stats%checksum
+  10    FORMAT (4x,'- ',a,':',t35,'Min = ',1p,e15.8,',  Max = ',        &
+     &          1p,e15.8,',  CheckSum = ',i0)
+      END IF
+# endif
 !
 !-----------------------------------------------------------------------
 !  If applicable, compute global minimum and maximum values.

--- a/ROMS/Utility/nf_fwrite3d.F
+++ b/ROMS/Utility/nf_fwrite3d.F
@@ -2,7 +2,7 @@
       MODULE nf_fwrite3d_mod
 !
 !git $Id$
-!svn $Id: nf_fwrite3d.F 1189 2023-08-15 21:26:58Z arango $
+!svn $Id: nf_fwrite3d.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -794,6 +794,9 @@
       USE mod_pio_netcdf
 !
       USE distribute_mod, ONLY : mp_reduce
+# ifdef OUTPUT_STATS
+      USE stats_mod,      ONLY : stats_3dfld
+# endif
 !
 !  Imported variable declarations.
 !
@@ -829,7 +832,7 @@
 
       logical, pointer :: Lwater(:,:,:)
 !
-      integer :: i, j, k
+      integer :: i, j, k, tile
       integer :: Imin, Imax, Jmin, Jmax
       integer :: Cgrid, dkind, ghost, gtype
       integer :: status
@@ -840,6 +843,11 @@
 
       real(r4), pointer :: Awrk4(:,:,:)
       real(r8), pointer :: Awrk8(:,:,:)
+
+# ifdef OUTPUT_STATS
+!
+      TYPE (T_STATS) :: Stats
+# endif
 !
       character (len= 3), dimension(2) :: op_handle
 !
@@ -895,6 +903,17 @@
       ELSE
         LandFill=tindex.gt.0
       END IF
+# endif
+# ifdef OUTPUT_STATS
+!
+!  Initialize output variable statistics structure.
+!
+      Stats % checksum=0_i8b
+      Stats % count=0
+      Stats % min=spval
+      Stats % max=-spval
+      Stats % avg=0.0_r8
+      Stats % rms=0.0_r8
 # endif
 !
 !-----------------------------------------------------------------------
@@ -974,6 +993,32 @@
      &                         Awrk4(Imin:Imax,Jmin:Jmax,LBk:UBk),      &
      &                         status)
       END IF
+
+# ifdef OUTPUT_STATS
+!
+!-----------------------------------------------------------------------
+!  Compute and report output field statistics.
+!-----------------------------------------------------------------------
+!
+#  ifdef DISTRIBUTE
+      tile=MyRank
+#  else
+      tile=-1
+#  endif
+      CALL stats_3dfld (ng, tile, model, gtype, Stats,                  &
+     &                  LBi, UBi, LBj, UBj, LBk, UBk,                   &
+     &                  Adat,                                           &
+#  ifdef MASKING
+     &                  Fmask = Amask,                                  &
+#  endif
+     &                  debug = .FALSE.)
+      IF (OutThread) THEN
+        WRITE (stdout,10) TRIM(Vname(1,ifield)), Stats%min, Stats%max,  &
+     &                    Stats%checksum
+  10    FORMAT (4x,'- ',a,':',t35,'Min = ',1p,e15.8,',  Max = ',        &
+     &          1p,e15.8,',  CheckSum = ',i0)
+      END IF
+# endif
 !
 !-----------------------------------------------------------------------
 !  If applicable, compute global minimum and maximum values.

--- a/ROMS/Utility/nf_fwrite3d.F
+++ b/ROMS/Utility/nf_fwrite3d.F
@@ -2,7 +2,7 @@
       MODULE nf_fwrite3d_mod
 !
 !git $Id$
-!svn $Id: nf_fwrite3d.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: nf_fwrite3d.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -17,6 +17,7 @@
 !     ng           Nested grid number                                  !
 !     model        Calling model identifier                            !
 !     ncid         NetCDF file ID                                      !
+!     ifield       Field metadata index (integer)                      !
 #if defined PIO_LIB && defined DISTRIBUTE
 !or   pioFile      PIO file descriptor structure, TYPE(file_desc_t)    !
 !                    pioFile%fh         file handler                   !
@@ -81,7 +82,8 @@
 #if defined PARALLEL_IO && defined DISTRIBUTE
 !
 !***********************************************************************
-      FUNCTION nf90_fwrite3d (ng, model, ncid, ncvarid, tindex, gtype,  &
+      FUNCTION nf90_fwrite3d (ng, model, ncid, ifield,                  &
+     &                        ncvarid, tindex, gtype,                   &
      &                        LBi, UBi, LBj, UBj, LBk, UBk, Ascl,       &
 # ifdef MASKING
      &                        Amask,                                    &
@@ -102,6 +104,7 @@
       logical, intent(in), optional :: SetFillVal
 !
       integer, intent(in) :: ng, model, ncid, ncvarid, tindex, gtype
+      integer, intent(in) :: ifield
       integer, intent(in) :: LBi, UBi, LBj, UBj, LBk, UBk
 !
       real(dp), intent(in) :: Ascl
@@ -397,7 +400,8 @@
 
 !
 !***********************************************************************
-      FUNCTION nf90_fwrite3d (ng, model, ncid, ncvarid, tindex, gtype,  &
+      FUNCTION nf90_fwrite3d (ng, model, ncid, ifield,                  &
+     &                        ncvarid, tindex, gtype,                   &
      &                        LBi, UBi, LBj, UBj, LBk, UBk, Ascl,       &
 # ifdef MASKING
      &                        Amask,                                    &
@@ -417,12 +421,16 @@
       USE distribute_mod, ONLY : mp_gather3d
 #  endif
 # endif
+# ifdef OUTPUT_STATS
+      USE stats_mod,      ONLY : stats_3dfld
+# endif
 !
 !  Imported variable declarations.
 !
       logical, intent(in), optional :: SetFillVal
 !
       integer, intent(in) :: ng, model, ncid, ncvarid, tindex, gtype
+      integer, intent(in) :: ifield
       integer, intent(in) :: LBi, UBi, LBj, UBj, LBk, UBk
 !
       real(dp), intent(in) :: Ascl
@@ -446,7 +454,7 @@
 # ifdef MASKING
       logical :: LandFill
 # endif
-      integer :: i, j, k, ic, Npts
+      integer :: i, j, k, ic, Npts, tile
       integer :: Imin, Imax, Jmin, Jmax, Koff
       integer :: Ilen, Jlen, Klen, IJlen, MyType
       integer :: status
@@ -457,6 +465,11 @@
       real(r8), dimension((Lm(ng)+2)*(Mm(ng)+2)) :: Awrk
 # else
       real(r8), dimension((Lm(ng)+2)*(Mm(ng)+2)*(UBk-LBk+1)) :: Awrk
+# endif
+
+# ifdef OUTPUT_STATS
+!
+      TYPE (T_STATS) :: Stats
 # endif
 !
 !-----------------------------------------------------------------------
@@ -532,6 +545,17 @@
 !
       Awrk=0.0_r8
 
+# ifdef OUTPUT_STATS
+!
+!  Initialize output variable statistics structure.
+!
+      Stats % checksum=0_i8b
+      Stats % count=0
+      Stats % min=spval
+      Stats % max=-spval
+      Stats % avg=0.0_r8
+      Stats % rms=0.0_r8
+# endif
 # ifdef DISTRIBUTE
 !
 !-----------------------------------------------------------------------
@@ -716,6 +740,31 @@
         status=nf90_put_var(ncid, ncvarid, Awrk, start, total)
       END IF
 # endif
+# ifdef OUTPUT_STATS
+!
+!-----------------------------------------------------------------------
+!  Compute and report output field statistics.
+!-----------------------------------------------------------------------
+!
+#  ifdef DISTRIBUTE
+      tile=MyRank
+#  else
+      tile=-1
+#  endif
+      CALL stats_3dfld (ng, tile, model, gtype, Stats,                  &
+     &                  LBi, UBi, LBj, UBj, LBk, UBk,                   &
+     &                  Adat,                                           &
+#  ifdef MASKING
+     &                  Fmask = Amask,                                  &
+#  endif
+     &                  debug = .FALSE.)
+      IF (OutThread) THEN
+        WRITE (stdout,10) TRIM(Vname(1,ifield)), Stats%min, Stats%max,  &
+     &                    Stats%checksum
+  10    FORMAT (4x,'- ',a,':',t35,'Min = ',1p,e15.8,',  Max = ',        &
+     &          1p,e15.8,',  CheckSum = ',i0)
+      END IF
+# endif
 # ifdef DISTRIBUTE
 !
 !-----------------------------------------------------------------------
@@ -732,8 +781,8 @@
 #if defined PIO_LIB && defined DISTRIBUTE
 !
 !***********************************************************************
-      FUNCTION pio_fwrite3d (ng, model, pioFile, pioVar, tindex,        &
-     &                       pioDesc,                                   &
+      FUNCTION pio_fwrite3d (ng, model, pioFile, ifield,                &
+     &                       pioVar, tindex, pioDesc,                   &
      &                       LBi, UBi, LBj, UBj, LBk, UBk, Ascl,        &
 # ifdef MASKING
      &                       Amask,                                     &
@@ -751,6 +800,7 @@
       logical, intent(in), optional :: SetFillVal
 !
       integer, intent(in) :: ng, model, tindex
+      integer, intent(in) :: ifield
       integer, intent(in) :: LBi, UBi, LBj, UBj, LBk, UBk
 !
       real(dp), intent(in) :: Ascl

--- a/ROMS/Utility/nf_fwrite4d.F
+++ b/ROMS/Utility/nf_fwrite4d.F
@@ -2,7 +2,7 @@
       MODULE nf_fwrite4d_mod
 !
 !git $Id$
-!svn $Id: nf_fwrite4d.F 1189 2023-08-15 21:26:58Z arango $
+!svn $Id: nf_fwrite4d.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -839,6 +839,9 @@
       USE mod_pio_netcdf
 !
       USE distribute_mod, ONLY : mp_reduce
+# ifdef OUTPUT_STATS
+      USE stats_mod,      ONLY : stats_4dfld
+# endif
 !
 !  Imported variable declarations.
 !
@@ -874,7 +877,7 @@
 
       logical, pointer :: Lwater(:,:,:,:)
 !
-      integer :: i, j, k, l
+      integer :: i, j, k, l, tile
       integer :: Imin, Imax, Jmin, Jmax
       integer :: Cgrid, dkind, ghost, gtype
       integer :: status
@@ -885,6 +888,11 @@
 
       real(r4), pointer :: Awrk4(:,:,:,:)
       real(r8), pointer :: Awrk8(:,:,:,:)
+
+# ifdef OUTPUT_STATS
+!
+      TYPE (T_STATS) :: Stats
+# endif
 !
       character (len= 3), dimension(2) :: op_handle
 !
@@ -940,6 +948,17 @@
       ELSE
         LandFill=tindex.gt.0
       END IF
+# endif
+# ifdef OUTPUT_STATS
+!
+!  Initialize output variable statistics structure.
+!
+      Stats % checksum=0_i8b
+      Stats % count=0
+      Stats % min=spval
+      Stats % max=-spval
+      Stats % avg=0.0_r8
+      Stats % rms=0.0_r8
 # endif
 !
 !-----------------------------------------------------------------------
@@ -1025,6 +1044,32 @@
      &                               LBk:UBk,LBt:UBt),                  &
      &                         status)
       END IF
+
+# ifdef OUTPUT_STATS
+!
+!-----------------------------------------------------------------------
+!  Compute and report output field statistics.
+!-----------------------------------------------------------------------
+!
+#  ifdef DISTRIBUTE
+      tile=MyRank
+#  else
+      tile=-1
+#  endif
+      CALL stats_4dfld (ng, tile, model, gtype, Stats,                  &
+     &                  LBi, UBi, LBj, UBj, LBk, UBk, LBt, UBt,         &
+     &                  Adat,                                           &
+#  ifdef MASKING
+     &                  Fmask = Amask,                                  &
+#  endif
+     &                  debug = .FALSE.)
+      IF (OutThread) THEN
+        WRITE (stdout,10) TRIM(Vname(1,ifield)), Stats%min, Stats%max,  &
+     &                    Stats%checksum
+  10    FORMAT (4x,'- ',a,':',t35,'Min = ',1p,e15.8,',  Max = ',        &
+     &          1p,e15.8,',  CheckSum = ',i0)
+      END IF
+# endif
 !
 !-----------------------------------------------------------------------
 !  If applicable, compute global minimum and maximum values.

--- a/ROMS/Utility/nf_fwrite4d.F
+++ b/ROMS/Utility/nf_fwrite4d.F
@@ -2,7 +2,7 @@
       MODULE nf_fwrite4d_mod
 !
 !git $Id$
-!svn $Id: nf_fwrite4d.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: nf_fwrite4d.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -17,6 +17,7 @@
 !     ng           Nested grid number                                  !
 !     model        Calling model identifier                            !
 !     ncid         NetCDF file ID                                      !
+!     ifield       Field metadata index (integer)                      !
 #if defined PIO_LIB && defined DISTRIBUTE
 !or   pioFile      PIO file descriptor structure, TYPE(file_desc_t)    !
 !                    pioFile%fh         file handler                   !
@@ -41,7 +42,7 @@
 !     LBk          K-dimension Lower bound                             !
 !     UBk          K-dimension Upper bound                             !
 !     LBt          Time-dimension Lower bound                          !
-!     UBt          Time-dimension Upoer bound                          !
+!     UBt          Time-dimension Upper bound                          !
 !     Amask        land/Sea mask, if any (real)                        !
 !     Ascl         Factor to scale field before writing (real)         !
 !     Adat         Field to write out (real)                           !
@@ -83,7 +84,8 @@
 #if defined PARALLEL_IO && defined DISTRIBUTE
 !
 !***********************************************************************
-      FUNCTION nf90_fwrite4d (ng, model, ncid, ncvarid, tindex, gtype,  &
+      FUNCTION nf90_fwrite4d (ng, model, ncid, ifield,                  &
+     &                        ncvarid, tindex, gtype,                   &
      &                        LBi, UBi, LBj, UBj, LBk, UBk, LBt, UBt,   &
      &                        Ascl,                                     &
 # ifdef MASKING
@@ -105,6 +107,7 @@
       logical, intent(in), optional :: SetFillVal
 !
       integer, intent(in) :: ng, model, ncid, ncvarid, tindex, gtype
+      integer, intent(in) :: ifield
       integer, intent(in) :: LBi, UBi, LBj, UBj, LBk, UBk, LBt, UBt
 !
       real(dp), intent(in) :: Ascl
@@ -422,7 +425,8 @@
 
 !
 !***********************************************************************
-      FUNCTION nf90_fwrite4d (ng, model, ncid, ncvarid, tindex, gtype,  &
+      FUNCTION nf90_fwrite4d (ng, model, ncid, ifield,                  &
+     &                        ncvarid, tindex, gtype,                   &
      &                        LBi, UBi, LBj, UBj, LBk, UBk, LBt, UBt,   &
      &                        Ascl,                                     &
 # ifdef MASKING
@@ -443,12 +447,16 @@
       USE distribute_mod, ONLY : mp_gather3d
 #  endif
 # endif
+# ifdef OUTPUT_STATS
+      USE stats_mod,      ONLY : stats_4dfld
+# endif
 !
 !  Imported variable declarations.
 !
       logical, intent(in), optional :: SetFillVal
 !
       integer, intent(in) :: ng, model, ncid, ncvarid, tindex, gtype
+      integer, intent(in) :: ifield
       integer, intent(in) :: LBi, UBi, LBj, UBj, LBk, UBk, LBt, UBt
 !
       real(dp), intent(in) :: Ascl
@@ -473,7 +481,7 @@
       logical :: LandFill
 !
 # endif
-      integer :: i, j, k, ic, fourth, Npts
+      integer :: i, j, k, ic, fourth, Npts, tile
       integer :: Imin, Imax, Jmin, Jmax, Kmin, Kmax, Koff, Loff
       integer :: Ilen, Jlen, Klen, IJlen, MyType
       integer :: status
@@ -484,6 +492,10 @@
       real(r8), dimension((Lm(ng)+2)*(Mm(ng)+2)) :: Awrk
 # else
       real(r8), dimension((Lm(ng)+2)*(Mm(ng)+2)*(UBk-LBk+1)) :: Awrk
+# endif
+# ifdef OUTPUT_STATS
+!
+      TYPE (T_STATS) :: Stats
 # endif
 !
 !-----------------------------------------------------------------------
@@ -565,6 +577,17 @@
 !
       Awrk=0.0_r8
 
+# ifdef OUTPUT_STATS
+!
+!  Initialize output variable statistics structure.
+!
+      Stats % checksum=0_i8b
+      Stats % count=0
+      Stats % min=spval
+      Stats % max=-spval
+      Stats % avg=0.0_r8
+      Stats % rms=0.0_r8
+# endif
 # ifdef DISTRIBUTE
 !
 !-----------------------------------------------------------------------
@@ -761,6 +784,31 @@
         END IF
       END DO
 # endif
+# ifdef OUTPUT_STATS
+!
+!-----------------------------------------------------------------------
+!  Compute and report output field statistics.
+!-----------------------------------------------------------------------
+!
+#  ifdef DISTRIBUTE
+      tile=MyRank
+#  else
+      tile=-1
+#  endif
+      CALL stats_4dfld (ng, tile, model, gtype, Stats,                  &
+     &                  LBi, UBi, LBj, UBj, LBk, UBk, LBt, UBt,         &
+     &                  Adat,                                           &
+#  ifdef MASKING
+     &                  Fmask = Amask,                                  &
+#  endif
+     &                  debug = .FALSE.)
+      IF (OutThread) THEN
+        WRITE (stdout,10) TRIM(Vname(1,ifield)), Stats%min, Stats%max,  &
+     &                    Stats%checksum
+  10    FORMAT (4x,'- ',a,':',t35,'Min = ',1p,e15.8,',  Max = ',        &
+     &          1p,e15.8,',  CheckSum = ',i0)
+      END IF
+# endif
 # ifdef DISTRIBUTE
 !
 !-----------------------------------------------------------------------
@@ -777,8 +825,8 @@
 #if defined PIO_LIB && defined DISTRIBUTE
 !
 !***********************************************************************
-      FUNCTION pio_fwrite4d (ng, model, pioFile, pioVar, tindex,        &
-     &                       pioDesc,                                   &
+      FUNCTION pio_fwrite4d (ng, model, pioFile, ifield,                &
+     &                       pioVar, tindex, pioDesc,                   &
      &                       LBi, UBi, LBj, UBj, LBk, UBk, LBt, UBt,    &
      &                       Ascl,                                      &
 # ifdef MASKING
@@ -797,6 +845,7 @@
       logical, intent(in), optional :: SetFillVal
 !
       integer, intent(in) :: ng, model, tindex
+      integer, intent(in) :: ifield
       integer, intent(in) :: LBi, UBi, LBj, UBj, LBk, UBk, LBt, UBt
 !
       real(dp), intent(in) :: Ascl

--- a/ROMS/Utility/normalization.F
+++ b/ROMS/Utility/normalization.F
@@ -4,7 +4,7 @@
 #if defined FOUR_DVAR
 !
 !git $Id$
-!svn $Id: normalization.F 1180 2023-07-13 02:42:10Z arango $
+!svn $Id: normalization.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -6016,7 +6016,8 @@
 !
       gtype=gfactor*Iinfo(1,ifield,ng)
       scale=1.0_dp
-      status=nf_fwrite2d(ng, model, ncid, ncvarid, tindex, gtype,       &
+      status=nf_fwrite2d(ng, model, ncid, ifield,                       &
+     &                   ncvarid, tindex, gtype,                        &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
      &                   Amask,                                         &
@@ -6108,7 +6109,8 @@
 !  Write out 2D normalization field.
 !
       scale=1.0_dp
-      status=nf_fwrite2d(ng, model, pioFile, pioVar, tindex, pioDesc,   &
+      status=nf_fwrite2d(ng, model, pioFile, ifield,                    &
+     &                   pioVar, tindex, pioDesc,                       &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 #  ifdef MASKING
      &                   Amask,                                         &
@@ -6205,7 +6207,8 @@
 !
       gtype=gfactor*Iinfo(1,ifield,ng)
       scale=1.0_dp
-      status=nf_fwrite3d(ng, model, ncid, ncvarid, tindex, gtype,       &
+      status=nf_fwrite3d(ng, model, ncid, ifield,                       &
+     &                   ncvarid, tindex, gtype,                        &
      &                   LBi, UBi, LBj, UBj, LBk, UBk, scale,           &
 # ifdef MASKING
      &                   Amask,                                         &
@@ -6297,7 +6300,8 @@
 !  Write out 3D normalization field.
 !
       scale=1.0_dp
-      status=nf_fwrite3d(ng, model, pioFile, pioVar, tindex, pioDesc,   &
+      status=nf_fwrite3d(ng, model, pioFile, ifield,                    &
+     &                   pioVar, tindex, pioDesc,                       &
      &                   LBi, UBi, LBj, UBj, LBk, UBk, scale,           &
 #  ifdef MASKING
      &                   Amask,                                         &

--- a/ROMS/Utility/obs_write.F
+++ b/ROMS/Utility/obs_write.F
@@ -3,7 +3,7 @@
 #if (defined FOUR_DVAR || defined VERIFICATION) && defined OBSERVATIONS
 !
 !git $Id$
-!svn $Id: obs_write.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: obs_write.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -1715,7 +1715,7 @@
       IF (wrtZetaRef(ng).and.balance(isFsur)) THEN
         Tindex=0
         scale=1.0_dp
-        status=nf_fwrite2d(ng, model, DAV(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, DAV(ng)%ncid, idFsur,             &
      &                     DAV(ng)%Vid(idFsur), Tindex, r2dvar,         &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 #  ifdef MASKING
@@ -2168,7 +2168,7 @@
         END IF
         Tindex=0
         scale=1.0_dp
-        status=nf_fwrite2d(ng, model, DAV(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, DAV(ng)%pioFile, idFsur,          &
      &                     DAV(ng)%pioVar(idFsur), Tindex,              &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &

--- a/ROMS/Utility/state_join.F
+++ b/ROMS/Utility/state_join.F
@@ -251,7 +251,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite2d(ng, model, OutId,                        &
+            status=nf_fwrite2d(ng, model, OutId, idFsur,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #ifdef MASKING
@@ -298,7 +298,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite2d(ng, model, OutId,                        &
+            status=nf_fwrite2d(ng, model, OutId, idRzet,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 # ifdef MASKING
@@ -343,7 +343,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite2d(ng, model, OutId,                        &
+            status=nf_fwrite2d(ng, model, OutId, idUbar,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #ifdef MASKING
@@ -389,7 +389,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite2d(ng, model, OutId,                        &
+            status=nf_fwrite2d(ng, model, OutId, idRu2d,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 # ifdef MASKING
@@ -434,7 +434,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite2d(ng, model, OutId,                        &
+            status=nf_fwrite2d(ng, model, OutId, idVbar,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #ifdef MASKING
@@ -480,7 +480,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite2d(ng, model, OutId,                        &
+            status=nf_fwrite2d(ng, model, OutId, idRv2d,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 # ifdef MASKING
@@ -527,7 +527,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite2d(ng, model, OutId,                        &
+            status=nf_fwrite2d(ng, model, OutId, idRuct,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #  ifdef MASKING
@@ -572,7 +572,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite2d(ng, model, OutId,                        &
+            status=nf_fwrite2d(ng, model, OutId, idUfx1,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 # ifdef MASKING
@@ -616,7 +616,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite2d(ng, model, OutId,                        &
+            status=nf_fwrite2d(ng, model, OutId, idUfx2,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 # ifdef MASKING
@@ -662,7 +662,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite2d(ng, model, OutId,                        &
+            status=nf_fwrite2d(ng, model, OutId, idRvct,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #  ifdef MASKING
@@ -707,7 +707,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite2d(ng, model, OutId,                        &
+            status=nf_fwrite2d(ng, model, OutId, idVfx1,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 # ifdef MASKING
@@ -751,7 +751,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite2d(ng, model, OutId,                        &
+            status=nf_fwrite2d(ng, model, OutId, idVfx2,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 # ifdef MASKING
@@ -795,7 +795,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite3d(ng, model, OutId,                        &
+            status=nf_fwrite3d(ng, model, OutId, idUvel,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), Fscl,      &
 # ifdef MASKING
@@ -841,7 +841,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite3d(ng, model, OutId,                        &
+            status=nf_fwrite3d(ng, model, OutId, idRu3d,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), Fscl,      &
 #  ifdef MASKING
@@ -886,7 +886,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite3d(ng, model, OutId,                        &
+            status=nf_fwrite3d(ng, model, OutId, idVvel,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), Fscl,      &
 # ifdef MASKING
@@ -932,7 +932,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite3d(ng, model, OutId,                        &
+            status=nf_fwrite3d(ng, model, OutId, idRv3d,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), Fscl,      &
 #  ifdef MASKING
@@ -978,7 +978,7 @@
               RETURN
             END IF
 !
-            status=nf_fwrite3d(ng, model, OutId,                        &
+            status=nf_fwrite3d(ng, model, OutId, idVvis,                &
      &                         var_id(i), OutRec, gtype,                &
      &                         LBi, UBi, LBj, UBj, 0, N(ng), Fscl,      &
 #  ifdef MASKING
@@ -1028,7 +1028,7 @@
                 RETURN
               END IF
 !
-              status=nf_fwrite3d(ng, model, OutId,                      &
+              status=nf_fwrite3d(ng, model, OutId, idTvar(itrc),        &
      &                           var_id(i), OutRec, gtype,              &
      &                           LBi, UBi, LBj, UBj, 1, N(ng), Fscl,    &
 # ifdef MASKING
@@ -1076,7 +1076,7 @@
                 RETURN
               END IF
 !
-              status=nf_fwrite3d(ng, model, OutId,                      &
+              status=nf_fwrite3d(ng, model, OutId, idDiff(itrc),        &
      &                           var_id(i), OutRec, gtype,              &
      &                           LBi, UBi, LBj, UBj, 0, N(ng), Fscl,    &
 # ifdef MASKING
@@ -1305,7 +1305,7 @@
               ioDesc => ioDesc_sp_r2dvar(ng)
             END IF
 !
-            status=nf_fwrite2d(ng, model, pioFileOut,                   &
+            status=nf_fwrite2d(ng, model, pioFileOut, idFsur,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 # ifdef MASKING
@@ -1370,7 +1370,7 @@
               ioDesc => ioDesc_sp_r2dvar(ng)
             END IF
 !
-            status=nf_fwrite2d(ng, model, pioFileOut,                   &
+            status=nf_fwrite2d(ng, model, pioFileOut, idRzet,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #  ifdef MASKING
@@ -1433,7 +1433,7 @@
               ioDesc => ioDesc_sp_u2dvar(ng)
             END IF
 !
-            status=nf_fwrite2d(ng, model, pioFileOut,                   &
+            status=nf_fwrite2d(ng, model, pioFileOut, idUbar,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 # ifdef MASKING
@@ -1497,7 +1497,7 @@
               ioDesc => ioDesc_sp_u2dvar(ng)
             END IF
 !
-            status=nf_fwrite2d(ng, model, pioFileOut,                   &
+            status=nf_fwrite2d(ng, model, pioFileOut, idRu2d,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #  ifdef MASKING
@@ -1560,7 +1560,7 @@
               ioDesc => ioDesc_sp_v2dvar(ng)
             END IF
 !
-            status=nf_fwrite2d(ng, model, pioFileOut,                   &
+            status=nf_fwrite2d(ng, model, pioFileOut, idVbar,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 # ifdef MASKING
@@ -1624,7 +1624,7 @@
               ioDesc => ioDesc_sp_v2dvar(ng)
             END IF
 !
-            status=nf_fwrite2d(ng, model, pioFileOut,                   &
+            status=nf_fwrite2d(ng, model, pioFileOut, idRv2d            &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #  ifdef MASKING
@@ -1689,7 +1689,7 @@
               ioDesc => ioDesc_sp_u2dvar(ng)
             END IF
 !
-            status=nf_fwrite2d(ng, model, pioFileOut,                   &
+            status=nf_fwrite2d(ng, model, pioFileOut, idRuct,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #   ifdef MASKING
@@ -1752,7 +1752,7 @@
               ioDesc => ioDesc_sp_u2dvar(ng)
             END IF
 !
-            status=nf_fwrite2d(ng, model, pioFileOut,                   &
+            status=nf_fwrite2d(ng, model, pioFileOut, idUfx1,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #  ifdef MASKING
@@ -1814,7 +1814,7 @@
               ioDesc => ioDesc_sp_u2dvar(ng)
             END IF
 !
-            status=nf_fwrite2d(ng, model, pioFileOut,                   &
+            status=nf_fwrite2d(ng, model, pioFileOut, idUfx2,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #  ifdef MASKING
@@ -1878,7 +1878,7 @@
               ioDesc => ioDesc_sp_v2dvar(ng)
             END IF
 !
-            status=nf_fwrite2d(ng, model, pioFileOut,                   &
+            status=nf_fwrite2d(ng, model, pioFileOut, idRvct,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #   ifdef MASKING
@@ -1941,7 +1941,7 @@
               ioDesc => ioDesc_sp_v2dvar(ng)
             END IF
 !
-            status=nf_fwrite2d(ng, model, pioFileOut,                   &
+            status=nf_fwrite2d(ng, model, pioFileOut, idVfx1,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #  ifdef MASKING
@@ -2003,7 +2003,7 @@
               ioDesc => ioDesc_sp_v2dvar(ng)
             END IF
 !
-            status=nf_fwrite2d(ng, model, pioFileOut,                   &
+            status=nf_fwrite2d(ng, model, pioFileOut, idVfx2,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, Fscl,                &
 #  ifdef MASKING
@@ -2065,7 +2065,7 @@
               ioDesc => ioDesc_sp_u3dvar(ng)
             END IF
 !
-            status=nf_fwrite3d(ng, model, pioFileOut,                   &
+            status=nf_fwrite3d(ng, model, pioFileOut, idUvel,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), Fscl,      &
 #  ifdef MASKING
@@ -2129,7 +2129,7 @@
               ioDesc => ioDesc_sp_u3dvar(ng)
             END IF
 !
-            status=nf_fwrite3d(ng, model, pioFileOut,                   &
+            status=nf_fwrite3d(ng, model, pioFileOut, idRu3d,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), Fscl,      &
 #   ifdef MASKING
@@ -2192,7 +2192,7 @@
               ioDesc => ioDesc_sp_v3dvar(ng)
             END IF
 !
-            status=nf_fwrite3d(ng, model, pioFileOut,                   &
+            status=nf_fwrite3d(ng, model, pioFileOut, idVvel,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), Fscl,      &
 #  ifdef MASKING
@@ -2256,7 +2256,7 @@
               ioDesc => ioDesc_sp_v3dvar(ng)
             END IF
 !
-            status=nf_fwrite3d(ng, model, pioFileOut,                   &
+            status=nf_fwrite3d(ng, model, pioFileOut, idRv3d,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), Fscl,      &
 #   ifdef MASKING
@@ -2320,7 +2320,7 @@
               ioDesc => ioDesc_sp_w3dvar(ng)
             END IF
 !
-            status=nf_fwrite3d(ng, model, pioFileOut,                   &
+            status=nf_fwrite3d(ng, model, pioFileOut, idVvis,           &
      &                         pioVar, OutRec, ioDesc,                  &
      &                         LBi, UBi, LBj, UBj, 0, N(ng), Fscl,      &
 #   ifdef MASKING
@@ -2389,7 +2389,7 @@
                 ioDesc => ioDesc_sp_r3dvar(ng)
               END IF
 !
-              status=nf_fwrite3d(ng, model, pioFileOut,                 &
+              status=nf_fwrite3d(ng, model, pioFileOut, idTvar(itrc),   &
      &                           pioVar, OutRec, ioDesc,                &
      &                           LBi, UBi, LBj, UBj, 1, N(ng), Fscl,    &
 #  ifdef MASKING
@@ -2459,7 +2459,7 @@
                 ioDesc => ioDesc_sp_w3dvar(ng)
               END IF
 !
-              status=nf_fwrite3d(ng, model, pioFileOut,                 &
+              status=nf_fwrite3d(ng, model, pioFileOut, idDiff(itrc),   &
      &                           pioVar, OutRec, ioDesc,                &
      &                           LBi, UBi, LBj, UBj, 0, N(ng), Fscl,    &
 #  ifdef MASKING

--- a/ROMS/Utility/stats.F
+++ b/ROMS/Utility/stats.F
@@ -2,7 +2,7 @@
       MODULE stats_mod
 !
 !git $Id$
-!svn $Id: stats.F 1189 2023-08-15 21:26:58Z arango $
+!svn $Id: stats.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -192,7 +192,7 @@
         END DO
       END IF
 !
-!  Compute data checksom value.
+!  Compute data checksum value.
 !
       Npts=(Imax-Imin+1)*(Jmax-Jmin+1)
       IF (.not.allocated(Cwrk)) allocate ( Cwrk(Npts) )
@@ -439,7 +439,7 @@
         END DO
       END IF
 !
-!  Compute data checksom value.
+!  Compute data checksum value.
 !
       Npts=(Imax-Imin+1)*(Jmax-Jmin+1)*(UBk-LBk+1)
       IF (.not.allocated(Cwrk)) allocate ( Cwrk(Npts) )
@@ -695,7 +695,7 @@
         END DO
       END IF
 !
-!  Compute data checksom value.
+!  Compute data checksum value.
 !
       Npts=(Imax-Imin+1)*(Jmax-Jmin+1)*(UBk-LBk+1)*(UBt-LBt+1)
       IF (.not.allocated(Cwrk)) allocate ( Cwrk(Npts) )

--- a/ROMS/Utility/stats.F
+++ b/ROMS/Utility/stats.F
@@ -2,7 +2,7 @@
       MODULE stats_mod
 !
 !git $Id$
-!svn $Id: stats.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: stats.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -12,6 +12,7 @@
 !  This module contains several routines to compute the statistics of  !
 !  provided field array, F.  The following information is computed:    !
 !                                                                      !
+!    S % checksum                bit sum hash                          !
 !    S % count                   processed values count                !
 !    S % min                     minimum value                         !
 !    S % max                     maximum value                         !
@@ -26,6 +27,7 @@
 !                                                                      !
 !    stats_2dfld      Statistic information for 2D state field         !
 !    stats_3dfld      Statistic information for 3D state field         !
+!    stats_4dfld      Statistic information for 4D state field         !
 !                                                                      !
 !=======================================================================
 !
@@ -33,6 +35,7 @@
 !
       PUBLIC :: stats_2dfld
       PUBLIC :: stats_3dfld
+      PUBLIC :: stats_4dfld
 !
       CONTAINS
 !
@@ -73,6 +76,7 @@
 !
       USE distribute_mod, ONLY : mp_reduce
 #endif
+      USE get_hash_mod,   ONLY : get_hash
 !
 !  Imported variable declarations.
 !
@@ -94,14 +98,16 @@
 !
       logical :: Lprint
 
-      integer :: Imin, Imax, Jmin, Jmax, NSUB
-      integer :: i, j
+      integer :: Imin, Imax, Jmin, Jmax, Npts, NSUB
+      integer :: i, j, my_count
 
       integer :: my_threadnum
 
       real(r8) :: fac
-      real(r8) :: my_count, my_max, my_min
+      real(r8) :: my_max, my_min
       real(r8) :: my_avg, my_rms
+
+      real(r8), allocatable :: Cwrk(:)
 
 #ifdef DISTRIBUTE
       real(r8), dimension(5) :: rbuffer
@@ -148,7 +154,7 @@
 !
 !  Initialize local values.
 !
-      my_count=0.0_r8
+      my_count=0
       my_min= 1.0E+37_r8
       my_max=-1.0E+37_r8
       my_avg=0.0_r8
@@ -166,7 +172,7 @@
         DO j=Jmin,Jmax
           DO i=Imin,Imax
             IF (Fmask(i,j).gt.0.0_r8) THEN
-              my_count=my_count+1.0_r8
+              my_count=my_count+1
               my_min=MIN(my_min, F(i,j))
               my_max=MAX(my_max, F(i,j))
               my_avg=my_avg+F(i,j)
@@ -177,7 +183,7 @@
       ELSE
         DO j=Jmin,Jmax
           DO i=Imin,Imax
-            my_count=my_count+1.0_r8
+            my_count=my_count+1
             my_min=MIN(my_min, F(i,j))
             my_max=MAX(my_max, F(i,j))
             my_avg=my_avg+F(i,j)
@@ -185,6 +191,18 @@
           END DO
         END DO
       END IF
+!
+!  Compute data checksom value.
+!
+      Npts=(Imax-Imin+1)*(Jmax-Jmin+1)
+      IF (.not.allocated(Cwrk)) allocate ( Cwrk(Npts) )
+      Cwrk=PACK(F(Imin:Imax, Jmin:Jmax), .TRUE.)
+#ifdef DISTRIBUTE
+      CALL get_hash (Cwrk, Npts, S.checksum, .TRUE.)
+#else
+      CALL get_hash (Cwrk, Npts, S.checksum)
+#endif
+      IF (allocated(Cwrk)) deallocate (Cwrk)
 !
 !  Compute global field mean, range, and processed values count.
 !
@@ -209,7 +227,8 @@
      &            'MINVAL   = ', MINVAL(F(Imin:Imax,Jmin:Jmax)),        &
      &            'MAXVAL   = ', MAXVAL(F(Imin:Imax,Jmin:Jmax)),        &
      &            'SUM      = ', SUM(F(Imin:Imax,Jmin:Jmax)),           &
-     &            'MEAN     = ', SUM(F(Imin:Imax,Jmin:Jmax))/my_count,  &
+     &            'MEAN     = ', SUM(F(Imin:Imax,Jmin:Jmax))/           &
+     &                           REAL(my_count,r8),                     &
      &            'my_min   = ', my_min,                                &
      &            'my_max   = ', my_max,                                &
      &            'S%min    = ', S%min,                                 &
@@ -218,8 +237,7 @@
      &            'S%avg    = ', S%avg,                                 &
      &            'my_rms   = ', my_rms,                                &
      &            'S%rms    = ', S%rms
-  10    FORMAT (10x,3(5x,a,i4),/,                                       &
-     &          15x,a,f15.0,5x,a,f15.0,/,                               &
+  10    FORMAT (10x,5(5x,a,i0),/,                                       &
      &          6(15x,a,1p,e15.8,0p,5x,a,1p,e15.8,0p,/))
         CALL my_flush (stdout)
       END IF
@@ -227,7 +245,7 @@
       IF (tile_count.eq.NSUB) THEN
         tile_count=0
 #ifdef DISTRIBUTE
-        rbuffer(1)=S%count
+        rbuffer(1)=REAL(S%count, r8)
         rbuffer(2)=S%min
         rbuffer(3)=S%max
         rbuffer(4)=S%avg
@@ -238,7 +256,7 @@
         op_handle(4)='SUM'
         op_handle(5)='SUM'
         CALL mp_reduce (ng, model, 5, rbuffer, op_handle)
-        S%count=rbuffer(1)
+        S%count=INT(rbuffer(1))
         S%min=rbuffer(2)
         S%max=rbuffer(3)
         S%avg=rbuffer(4)
@@ -248,7 +266,7 @@
 !  Finalize computation of the mean and root mean square.
 !
         IF (S%count.gt.0) THEN
-          fac=1.0_r8/S%count
+          fac=1.0_r8/REAL(S%count, r8)
           S%avg=S%avg*fac
           S%rms=SQRT(S%rms*fac)
         ELSE
@@ -258,7 +276,7 @@
       END IF
 !$OMP END CRITICAL (F_STATS)
 !$OMP BARRIER
-
+!
       RETURN
       END SUBROUTINE stats_2dfld
 !
@@ -301,6 +319,7 @@
 !
       USE distribute_mod, ONLY : mp_reduce
 #endif
+      USE get_hash_mod,   ONLY : get_hash
 !
 !  Imported variable declarations.
 !
@@ -322,14 +341,16 @@
 !
       logical :: Lprint
 
-      integer :: Imin, Imax, Jmin, Jmax, NSUB
-      integer :: i, j, k
+      integer :: Imin, Imax, Jmin, Jmax, Npts, NSUB
+      integer :: i, j, k, my_count
 
       integer :: my_threadnum
 
       real(r8) :: fac
-      real(r8) :: my_count, my_max, my_min
+      real(r8) :: my_max, my_min
       real(r8) :: my_avg, my_rms
+
+      real(r8), allocatable :: Cwrk(:)
 
 #ifdef DISTRIBUTE
       real(r8), dimension(5) :: rbuffer
@@ -376,7 +397,7 @@
 !
 !  Initialize local values.
 !
-      my_count=0.0_r8
+      my_count=0
       my_min= 1.0E+37_r8
       my_max=-1.0E+37_r8
       my_avg=0.0_r8
@@ -395,7 +416,7 @@
           DO j=Jmin,Jmax
             DO i=Imin,Imax
               IF (Fmask(i,j).gt.0.0_r8) THEN
-                my_count=my_count+1.0_r8
+                my_count=my_count+1
                 my_min=MIN(my_min, F(i,j,k))
                 my_max=MAX(my_max, F(i,j,k))
                 my_avg=my_avg+F(i,j,k)
@@ -408,7 +429,7 @@
         DO k=LBk,UBk
           DO j=Jmin,Jmax
             DO i=Imin,Imax
-              my_count=my_count+1.0_r8
+              my_count=my_count+1
               my_min=MIN(my_min, F(i,j,k))
               my_max=MAX(my_max, F(i,j,k))
               my_avg=my_avg+F(i,j,k)
@@ -417,6 +438,18 @@
           END DO
         END DO
       END IF
+!
+!  Compute data checksom value.
+!
+      Npts=(Imax-Imin+1)*(Jmax-Jmin+1)*(UBk-LBk+1)
+      IF (.not.allocated(Cwrk)) allocate ( Cwrk(Npts) )
+      Cwrk=PACK(F(Imin:Imax, Jmin:Jmax, LBk:UBk), .TRUE.)
+#ifdef DISTRIBUTE
+      CALL get_hash (Cwrk, Npts, S.checksum, .TRUE.)
+#else
+      CALL get_hash (Cwrk, Npts, S.checksum)
+#endif
+      IF (allocated(Cwrk)) deallocate (Cwrk)
 !
 !  Compute global field mean, range, and processed values count.
 !  Notice that the critical region F_STATS is the same as in
@@ -444,7 +477,8 @@
      &            'MINVAL   = ', MINVAL(F(Imin:Imax,Jmin:Jmax,:)),      &
      &            'MAXVAL   = ', MAXVAL(F(Imin:Imax,Jmin:Jmax,:)),      &
      &            'SUM      = ', SUM(F(Imin:Imax,Jmin:Jmax,:)),         &
-     &            'MEAN     = ', SUM(F(Imin:Imax,Jmin:Jmax,:))/my_count,&
+     &            'MEAN     = ', SUM(F(Imin:Imax,Jmin:Jmax,:))/         &
+     &                           REAL(my_count,r8),                     &
      &            'my_min   = ', my_min,                                &
      &            'my_max   = ', my_max,                                &
      &            'S%min    = ', S%min,                                 &
@@ -453,8 +487,7 @@
      &            'S%avg    = ', S%avg,                                 &
      &            'my_rms   = ', my_rms,                                &
      &            'S%rms    = ', S%rms
-  10    FORMAT (10x,3(5x,a,i4),/,                                       &
-     &          15x,a,f15.0,5x,a,f15.0,/,                               &
+  10    FORMAT (10x,5(5x,a,i0),/,                                       &
      &          6(15x,a,1p,e15.8,0p,5x,a,1p,e15.8,0p,/))
         CALL my_flush (stdout)
       END IF
@@ -462,7 +495,7 @@
       IF (thread_count.eq.NSUB) THEN
         thread_count=0
 #ifdef DISTRIBUTE
-        rbuffer(1)=S%count
+        rbuffer(1)=REAL(S%count, r8)
         rbuffer(2)=S%min
         rbuffer(3)=S%max
         rbuffer(4)=S%avg
@@ -473,7 +506,7 @@
         op_handle(4)='SUM'
         op_handle(5)='SUM'
         CALL mp_reduce (ng, model, 5, rbuffer, op_handle)
-        S%count=rbuffer(1)
+        S%count=INT(rbuffer(1))
         S%min=rbuffer(2)
         S%max=rbuffer(3)
         S%avg=rbuffer(4)
@@ -483,7 +516,7 @@
 !  Finalize computation of the mean and root mean square.
 !
         IF (S%count.gt.0) THEN
-          fac=1.0_r8/S%count
+          fac=1.0_r8/REAL(S%count, r8)
           S%avg=S%avg*fac
           S%rms=SQRT(S%rms*fac)
         ELSE
@@ -493,8 +526,264 @@
       END IF
 !$OMP END CRITICAL (F_STATS)
 !$OMP BARRIER
-
+!
       RETURN
       END SUBROUTINE stats_3dfld
+!
+      SUBROUTINE stats_4dfld (ng, tile, model, gtype, S,                &
+     &                        LBi, UBi, LBj, UBj, LBk, UBk, LBt, UBt,   &
+     &                        F, Fmask, debug)
+!
+!=======================================================================
+!                                                                      !
+!  This routine computes requested 4D-field statistics.                !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     ng           Nested grid number (integer)                        !
+!     tile         Domain partition (integer)                          !
+!     model        Calling model identifier (integer)                  !
+!     gtype        Grid type (integer)                                 !
+!     LBi          I-dimension Lower bound (integer)                   !
+!     UBi          I-dimension Upper bound (integer)                   !
+!     LBj          J-dimension Lower bound (integer)                   !
+!     UBj          J-dimension Upper bound (integer)                   !
+!     LBk          K-dimension Lower bound (integer)                   !
+!     UBk          K-dimension Upper bound (integer)                   !
+!     LBt          Time-dimension Lower bound (integer)                !
+!     UBt          Time-dimension Upper bound (integer)                !
+!     F            4D state field (4D tiled array)                     !
+!     Fmask        Land/sea mask (OPTIONAL, 2D tiled array)            !
+!     debug        Switch to debug (OPTIONAL, logical)                 !
+!                                                                      !
+!  On Ouput:                                                           !
+!                                                                      !
+!     S            Field statistics (structure)                        !
+!                                                                      !
+!=======================================================================
+!
+      USE mod_param
+      USE mod_parallel
+      USE mod_iounits
+      USE mod_ncparam
 
+#ifdef DISTRIBUTE
+!
+      USE distribute_mod, ONLY : mp_reduce
+#endif
+      USE get_hash_mod,   ONLY : get_hash
+!
+!  Imported variable declarations.
+!
+      logical, intent(in), optional :: debug
+
+      integer, intent(in) :: ng, tile, model, gtype
+      integer, intent(in) :: LBi, UBi, LBj, UBj, LBk, UBk, LBt, UBt
+
+#ifdef ASSUMED_SHAPE
+      real(r8), intent(in) :: F(LBi:,LBj:,LBk:,LBt:)
+      real(r8), intent(in), optional :: Fmask(LBi:,LBj:)
+#else
+      real(r8), intent(in) :: F(LBi:UBi,LBj:UBj,LBk:UBk)
+      real(r8), intent(in), optional :: Fmask(LBi:UBi,LBj:UBj,LBt:UBt)
+#endif
+      TYPE(T_STATS), intent(inout) :: S
+!
+!  Local variable declarations.
+!
+      logical :: Lprint
+
+      integer :: Imin, Imax, Jmin, Jmax, Npts, NSUB
+      integer :: i, j, k, l, my_count
+
+      integer :: my_threadnum
+
+      real(r8) :: fac
+      real(r8) :: my_max, my_min
+      real(r8) :: my_avg, my_rms
+
+      real(r8), allocatable :: Cwrk(:)
+
+#ifdef DISTRIBUTE
+      real(r8), dimension(5) :: rbuffer
+      character (len=3), dimension(5) :: op_handle
+#endif
+!
+!-----------------------------------------------------------------------
+!  Set tile indices.
+!-----------------------------------------------------------------------
+!
+!  Determine I- and J-indices according to staggered C-grid type.
+!
+      SELECT CASE (ABS(gtype))
+        CASE (p3dvar)
+          Imin=BOUNDS(ng)%IstrP(tile)
+          Imax=BOUNDS(ng)%IendP(tile)
+          Jmin=BOUNDS(ng)%JstrP(tile)
+          Jmax=BOUNDS(ng)%JendP(tile)
+        CASE (r3dvar)
+          Imin=BOUNDS(ng)%IstrT(tile)
+          Imax=BOUNDS(ng)%IendT(tile)
+          Jmin=BOUNDS(ng)%JstrT(tile)
+          Jmax=BOUNDS(ng)%JendT(tile)
+        CASE (u3dvar)
+          Imin=BOUNDS(ng)%IstrP(tile)
+          Imax=BOUNDS(ng)%IendT(tile)
+          Jmin=BOUNDS(ng)%JstrT(tile)
+          Jmax=BOUNDS(ng)%JendT(tile)
+        CASE (v3dvar)
+          Imin=BOUNDS(ng)%IstrT(tile)
+          Imax=BOUNDS(ng)%IendT(tile)
+          Jmin=BOUNDS(ng)%JstrP(tile)
+          Jmax=BOUNDS(ng)%JendT(tile)
+        CASE DEFAULT
+          Imin=BOUNDS(ng)%IstrT(tile)
+          Imax=BOUNDS(ng)%IendT(tile)
+          Jmin=BOUNDS(ng)%JstrT(tile)
+          Jmax=BOUNDS(ng)%JendT(tile)
+      END SELECT
+!
+!-----------------------------------------------------------------------
+!  Compute field statistics.
+!-----------------------------------------------------------------------
+!
+!  Initialize local values.
+!
+      my_count=0
+      my_min= 1.0E+37_r8
+      my_max=-1.0E+37_r8
+      my_avg=0.0_r8
+      my_rms=0.0_r8
+!
+      IF (PRESENT(debug)) THEN
+        Lprint=debug
+      ELSE
+        Lprint=.FALSE.
+      END IF
+!
+!  Compute field mean, range, and processed values count for each tile.
+!
+      IF (PRESENT(Fmask)) THEN
+        DO l=LBt,UBt
+          DO k=LBk,UBk
+            DO j=Jmin,Jmax
+              DO i=Imin,Imax
+                IF (Fmask(i,j).gt.0.0_r8) THEN
+                  my_count=my_count+1
+                  my_min=MIN(my_min, F(i,j,k,l))
+                  my_max=MAX(my_max, F(i,j,k,l))
+                  my_avg=my_avg+F(i,j,k,l)
+                  my_rms=my_rms+F(i,j,k,l)*F(i,j,k,l)
+                END IF
+              END DO
+            END DO
+          END DO
+        END DO
+      ELSE
+        DO l=LBt,UBt
+          DO k=LBk,UBk
+            DO j=Jmin,Jmax
+              DO i=Imin,Imax
+                my_count=my_count+1
+                my_min=MIN(my_min, F(i,j,k,l))
+                my_max=MAX(my_max, F(i,j,k,l))
+                my_avg=my_avg+F(i,j,k,l)
+                my_rms=my_rms+F(i,j,k,l)*F(i,j,k,l)
+              END DO
+            END DO
+          END DO
+        END DO
+      END IF
+!
+!  Compute data checksom value.
+!
+      Npts=(Imax-Imin+1)*(Jmax-Jmin+1)*(UBk-LBk+1)*(UBt-LBt+1)
+      IF (.not.allocated(Cwrk)) allocate ( Cwrk(Npts) )
+      Cwrk=PACK(F(Imin:Imax, Jmin:Jmax, LBk:UBk, LBt:UBt), .TRUE.)
+#ifdef DISTRIBUTE
+      CALL get_hash (Cwrk, Npts, S.checksum, .TRUE.)
+#else
+      CALL get_hash (Cwrk, Npts, S.checksum)
+#endif
+      IF (allocated(Cwrk)) deallocate (Cwrk)
+!
+!  Compute global field mean, range, and processed values count.
+!  Notice that the critical region F_STATS is the same as in
+!  "stats_2dfld" but we are usinf different counter "thread_count"
+!  to avoid interference and race conditions in shared-memory.
+!
+#ifdef DISTRIBUTE
+      NSUB=1                             ! distributed-memory
+#else
+      NSUB=NtileX(ng)*NtileE(ng)         ! tiled application
+#endif
+!$OMP CRITICAL (F_STATS)
+      S%count=S%count+my_count
+      S%min=MIN(S%min,my_min)
+      S%max=MAX(S%max,my_max)
+      S%avg=S%avg+my_avg
+      S%rms=S%rms+my_rms
+      IF (Lprint) THEN
+        WRITE (stdout,10)                                               &
+     &            'thread = ', my_threadnum(),                          &
+     &            'tile = ', tile,                                      &
+     &            'tile_count = ', thread_count,                        &
+     &            'my_count = ', my_count,                              &
+     &            'S%count  = ', S%count,                               &
+     &            'MINVAL   = ', MINVAL(F(Imin:Imax,Jmin:Jmax,:,:)),    &
+     &            'MAXVAL   = ', MAXVAL(F(Imin:Imax,Jmin:Jmax,:,:)),    &
+     &            'SUM      = ', SUM(F(Imin:Imax,Jmin:Jmax,:,:)),       &
+     &            'MEAN     = ', SUM(F(Imin:Imax,Jmin:Jmax,:,:))/       &
+     &                           REAL(my_count,r8),                     &
+     &            'my_min   = ', my_min,                                &
+     &            'my_max   = ', my_max,                                &
+     &            'S%min    = ', S%min,                                 &
+     &            'S%max    = ', S%max,                                 &
+     &            'my_avg   = ', my_avg,                                &
+     &            'S%avg    = ', S%avg,                                 &
+     &            'my_rms   = ', my_rms,                                &
+     &            'S%rms    = ', S%rms
+  10    FORMAT (10x,5(5x,a,i0),/,                                       &
+     &          6(15x,a,1p,e15.8,0p,5x,a,1p,e15.8,0p,/))
+        CALL my_flush (stdout)
+      END IF
+      thread_count=thread_count+1
+      IF (thread_count.eq.NSUB) THEN
+        thread_count=0
+#ifdef DISTRIBUTE
+        rbuffer(1)=REAL(S%count, r8)
+        rbuffer(2)=S%min
+        rbuffer(3)=S%max
+        rbuffer(4)=S%avg
+        rbuffer(5)=S%rms
+        op_handle(1)='SUM'
+        op_handle(2)='MIN'
+        op_handle(3)='MAX'
+        op_handle(4)='SUM'
+        op_handle(5)='SUM'
+        CALL mp_reduce (ng, model, 5, rbuffer, op_handle)
+        S%count=INT(rbuffer(1))
+        S%min=rbuffer(2)
+        S%max=rbuffer(3)
+        S%avg=rbuffer(4)
+        S%rms=rbuffer(5)
+#endif
+!
+!  Finalize computation of the mean and root mean square.
+!
+        IF (S%count.gt.0) THEN
+          fac=1.0_r8/REAL(S%count, r8)
+          S%avg=S%avg*fac
+          S%rms=SQRT(S%rms*fac)
+        ELSE
+          S%avg=1.0E+37_r8
+          S%rms=1.0E+37_r8
+        END IF
+      END IF
+!$OMP END CRITICAL (F_STATS)
+!$OMP BARRIER
+!
+      RETURN
+      END SUBROUTINE stats_4dfld
+!
       END MODULE stats_mod

--- a/ROMS/Utility/time_corr.F
+++ b/ROMS/Utility/time_corr.F
@@ -4,7 +4,7 @@
 #undef ENDPOINT_TRAPEZOIDAL
 !
 !git $Id$
-!svn $Id: time_corr.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: time_corr.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group       Andrew M. Moore   !
 !    Licensed under a MIT/X style license                              !
@@ -448,7 +448,7 @@
 !  Write out convolved solution.
 !
           MyType=gtype
-          status=nf_fwrite2d(ng, model, TLF(ng)%ncid,                   &
+          status=nf_fwrite2d(ng, model, TLF(ng)%ncid, idZtlf,           &
      &                       TLF(ng)%Vid(idZtlf),                       &
      &                       Iout, MyType,                              &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -515,7 +515,7 @@
 !  Write out convolved solution.
 !
           MyType=gtype
-          status=nf_fwrite2d(ng, model, TLF(ng)%ncid,                   &
+          status=nf_fwrite2d(ng, model, TLF(ng)%ncid, idUbtf,           &
      &                       TLF(ng)%Vid(idUbtf),                       &
      &                       Iout, MyType,                              &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -581,7 +581,7 @@
 !
 !  Write out convolved solution.
 !
-          status=nf_fwrite2d(ng, model, TLF(ng)%ncid,                   &
+          status=nf_fwrite2d(ng, model, TLF(ng)%ncid, idVbtf,           &
      &                       TLF(ng)%Vid(idVbtf),                       &
      &                       Iout, MyType,                              &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -653,7 +653,7 @@
 !
 !  Write out convolved solution.
 !
-          status=nf_fwrite3d(ng, model, TLF(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, TLF(ng)%ncid, idUtlf,           &
      &                       TLF(ng)%Vid(idUtlf),                       &
      &                       Iout, MyType,                              &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -723,7 +723,7 @@
 !
 !  Write out convolved solution.
 !
-          status=nf_fwrite3d(ng, model, TLF(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, TLF(ng)%ncid, idVtlf,           &
      &                       TLF(ng)%Vid(idVtlf),                       &
      &                       Iout, MyType,                              &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -797,7 +797,7 @@
 !
 !  Write out convolved solution.
 !
-            status=nf_fwrite3d(ng, model, TLF(ng)%ncid,                 &
+            status=nf_fwrite3d(ng, model, TLF(ng)%ncid, idTtlf(itrc),   &
      &                         TLF(ng)%Tid(itrc),                       &
      &                         Iout, MyType,                            &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
@@ -1258,7 +1258,7 @@
 !
 !  Write out convolved solution.
 !
-          status=nf_fwrite2d(ng, model, TLF(ng)%pioFile,                &
+          status=nf_fwrite2d(ng, model, TLF(ng)%pioFile, idZtlf,        &
      &                       TLF(ng)%pioVar(idZtlf),                    &
      &                       Iout, ioDesc,                              &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1329,7 +1329,7 @@
 !
 !  Write out convolved solution.
 !
-          status=nf_fwrite2d(ng, model, TLF(ng)%pioFile,                &
+          status=nf_fwrite2d(ng, model, TLF(ng)%pioFile, idUbtf,        &
      &                       TLF(ng)%pioVar(idUbtf),                    &
      &                       Iout, ioDesc,                              &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1400,7 +1400,7 @@
 !
 !  Write out convolved solution.
 !
-          status=nf_fwrite2d(ng, model, TLF(ng)%pioFile,                &
+          status=nf_fwrite2d(ng, model, TLF(ng)%pioFile, idVbtf,        &
      &                       TLF(ng)%pioVar(idVbtf),                    &
      &                       Iout, ioDesc,                              &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1477,7 +1477,7 @@
 !
 !  Write out convolved solution.
 !
-          status=nf_fwrite3d(ng, model, TLF(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, TLF(ng)%pioFile, idUtlf,        &
      &                       TLF(ng)%pioVar(idUtlf),                    &
      &                       Iout, ioDesc,                              &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1552,7 +1552,7 @@
 !
 !  Write out convolved solution.
 !
-          status=nf_fwrite3d(ng, model, TLF(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, TLF(ng)%pioFile, idVtlf,        &
      &                       TLF(ng)%pioVar(idVtlf),                    &
      &                       Iout, ioDesc,                              &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1632,7 +1632,7 @@
 !  Write out convolved solution.
 !
             status=nf_fwrite3d(ng, model, TLF(ng)%pioFile,              &
-     &                         TLF(ng)%pioTrc(itrc),                    &
+     &                         idTtlf(itrc), TLF(ng)%pioTrc(itrc),      &
      &                         Iout, ioDesc,                            &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
 #  ifdef MASKING

--- a/ROMS/Utility/wrt_aug_imp.F
+++ b/ROMS/Utility/wrt_aug_imp.F
@@ -3,7 +3,7 @@
 #if defined WEAK_CONSTRAINT && defined RPCG
 !
 !git $Id$
-!svn $Id: wrt_aug_imp.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: wrt_aug_imp.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -116,6 +116,10 @@
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
+!  Report.
+!
+      IF (Master)  WRITE (stdout,10) Iout, TRIM(TLF(ng)%name)
+!
 !  Set grid type factor to write full (gfactor=1) fields or water
 !  points (gfactor=-1) fields only.
 !
@@ -129,7 +133,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, model, TLF(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, TLF(ng)%ncid, idZtlf,               &
      &                   TLF(ng)%Vid(idZtlf),                           &
      &                   Iout, gtype,                                   &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -139,7 +143,7 @@
      &                   OCEAN(ng) % tl_zeta(:,:,Iinp))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idZtlf)), Iout,                &
+          WRITE (stdout,20) TRIM(Vname(1,idZtlf)), Iout,                &
      &                      TRIM(TLF(ng)%name)
         END IF
         exit_flag=3
@@ -153,7 +157,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*u2dvar
-      status=nf_fwrite2d(ng, model, TLF(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, TLF(ng)%ncid, idUbtf,               &
      &                   TLF(ng)%Vid(idUbtf),                           &
      &                   Iout, gype,                                    &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -163,7 +167,7 @@
      &                   OCEAN(ng) % tl_ubar(:,:,Iinp))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUbtf)), Iout,                &
+          WRITE (stdout,20) TRIM(Vname(1,idUbtf)), Iout,                &
      &                      TRIM(TLF(ng)%name)
         END IF
         exit_flag=3
@@ -175,7 +179,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*v2dvar
-      status=nf_fwrite2d(ng, model, TLF(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, TLF(ng)%ncid, idVbtf,               &
      &                   TLF(ng)%Vid(idVbtf),                           &
      &                   Iout, gtype,                                   &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -185,7 +189,7 @@
      &                   OCEAN(ng) % tl_vbar(:,:,Iinp))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVbtf)), Iout,                &
+          WRITE (stdout,20) TRIM(Vname(1,idVbtf)), Iout,                &
      &                      TRIM(TLF(ng)%name)
         END IF
         exit_flag=3
@@ -199,7 +203,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, model, TLF(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, TLF(ng)%ncid, idUtlf,               &
      &                   TLF(ng)%Vid(idUtlf),                           &
      &                   Iout, gtype,                                   &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -209,7 +213,7 @@
      &                   OCEAN(ng) % tl_u(:,:,:,Iinp))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUtlf)), Iout,                &
+          WRITE (stdout,20) TRIM(Vname(1,idUtlf)), Iout,                &
      &                      TRIM(TLF(ng)%name)
         END IF
         exit_flag=3
@@ -221,7 +225,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, model, TLF(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, TLF(ng)%ncid, idVtlf,               &
      &                   TLF(ng)%Vid(idVtlf),                           &
      &                   Iout, gtype,                                   &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -231,7 +235,7 @@
      &                   OCEAN(ng) % tl_v(:,:,:,Iinp))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVtlf)), Iout,                &
+          WRITE (stdout,20) TRIM(Vname(1,idVtlf)), Iout,                &
      &                      TRIM(TLF(ng)%name)
         END IF
         exit_flag=3
@@ -244,7 +248,7 @@
       scale=1.0_dp
       gtype=gfactor*r3dvar
       DO itrc=1,NT(ng)
-        status=nf_fwrite3d(ng, model, TLF(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, TLF(ng)%ncid, idTtlf(itrc),       &
      &                     TLF(ng)%Tid(itrc),                           &
      &                     Iout, gtype,                                 &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -254,7 +258,7 @@
      &                     OCEAN(ng) % tl_t(:,:,:,Iinp,itrc))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTtlf(itrc))), Iout,        &
+            WRITE (stdout,20) TRIM(Vname(1,idTtlf(itrc))), Iout,        &
      &                        TRIM(TLF(ng)%name)
           END IF
           exit_flag=3
@@ -271,14 +275,12 @@
 !
       CALL netcdf_sync (ng, model, TLF(ng)%name, TLF(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-      IF (Master)  WRITE (stdout,20) Iout, TRIM(TLF(ng)%name)
 !
-  10  FORMAT (/,' WRT_AUG_IMP_NF90 - error while writing variable: ',a, &
+  10  FORMAT (2x,'WRT_AUG_IMP_NF90 - writing augmented adjoint',        &
+     &        ' impulses, record: ',i0,/,22x,'file: ',a)
+  20  FORMAT (/,' WRT_AUG_IMP_NF90 - error while writing variable: ',a, &
      &        2x,'at time record = ',i0,                                &
      &        /,20x,'into NetCDF file: ',a)
-  20  FORMAT (2x,'WRT_AUG_IMP_NF90 - wrote augmented adjoint',          &
-     &        ' impulses, record: ',i0,/,22x,'file: ',a)
 !
       RETURN
       END SUBROUTINE wrt_aug_imp_nf90
@@ -318,6 +320,10 @@
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
+!  Report.
+!
+      IF (Master)  WRITE (stdout,20) Iout, TRIM(TLF(ng)%name)
+!
 !  Process free-surface weak-constraint impulse forcing.
 !
       scale=1.0_dp
@@ -327,7 +333,7 @@
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, model, TLF(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, TLF(ng)%pioFile, idZtlf,            &
      &                   TLF(ng)%pioVar(idZtlf), Iout,                  &
      &                   ioDesc,                                        &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -337,7 +343,7 @@
      &                   OCEAN(ng) % tl_zeta(:,:,Iinp))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idZtlf)), Iout,                &
+          WRITE (stdout,20) TRIM(Vname(1,idZtlf)), Iout,                &
      &                      TRIM(TLF(ng)%name)
         END IF
         exit_flag=3
@@ -356,7 +362,7 @@
         ioDesc => ioDesc_sp_u2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, model, TLF(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, TLF(ng)%pioFile, idUbtf,            &
      &                   TLF(ng)%pioVar(idUbtf), Iout,                  &
      &                   ioDesc,                                        &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -366,7 +372,7 @@
      &                   OCEAN(ng) % tl_ubar(:,:,Iinp))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUbtf)), Iout,                &
+          WRITE (stdout,20) TRIM(Vname(1,idUbtf)), Iout,                &
      &                      TRIM(TLF(ng)%name)
         END IF
         exit_flag=3
@@ -383,7 +389,7 @@
         ioDesc => ioDesc_sp_v2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, model, TLF(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, TLF(ng)%pioFile, idVbtf,            &
      &                   TLF(ng)%pioVar(idVbtf), Iout,                  &
      &                   ioDesc,                                        &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -393,7 +399,7 @@
      &                   OCEAN(ng) % tl_vbar(:,:,Iinp))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVbtf)), Iout,                &
+          WRITE (stdout,20) TRIM(Vname(1,idVbtf)), Iout,                &
      &                      TRIM(TLF(ng)%name)
         END IF
         exit_flag=3
@@ -412,7 +418,7 @@
         ioDesc => ioDesc_sp_u3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, model, TLF(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, TLF(ng)%pioFile, idUtlf,            &
      &                   TLF(ng)%pioVar(idUtlf), Iout,                  &
      &                   ioDesc,                                        &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -422,7 +428,7 @@
      &                   OCEAN(ng) % tl_u(:,:,:,Iinp))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUtlf)), Iout,                &
+          WRITE (stdout,20) TRIM(Vname(1,idUtlf)), Iout,                &
      &                      TRIM(TLF(ng)%name)
         END IF
         exit_flag=3
@@ -439,7 +445,7 @@
         ioDesc => ioDesc_sp_v3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, model, TLF(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, TLF(ng)%pioFile, idVtlf,            &
      &                   TLF(ng)%pioVar(idVtlf), Iout,                  &
      &                   ioDesc,                                        &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -449,7 +455,7 @@
      &                   OCEAN(ng) % tl_v(:,:,:,Iinp))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVtlf)), Iout,                &
+          WRITE (stdout,20) TRIM(Vname(1,idVtlf)), Iout,                &
      &                      TRIM(TLF(ng)%name)
         END IF
         exit_flag=3
@@ -467,7 +473,7 @@
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, model, TLF(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, TLF(ng)%pioFile, idTtlf(itrc),    &
      &                     TLF(ng)%pioTrc(itrc), Iout,                  &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -477,7 +483,7 @@
      &                     OCEAN(ng) % tl_t(:,:,:,Iinp,itrc))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTtlf(itrc))), Iout,        &
+            WRITE (stdout,20) TRIM(Vname(1,idTtlf(itrc))), Iout,        &
      &                        TRIM(TLF(ng)%name)
           END IF
           exit_flag=3
@@ -494,14 +500,12 @@
 !
       CALL pio_netcdf_sync (ng, model, TLF(ng)%name, TLF(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-      IF (Master)  WRITE (stdout,20) Iout, TRIM(TLF(ng)%name)
 !
-  10  FORMAT (/,' WRT_AUG_IMP_PIO - error while writing variable: ',a,  &
+  10  FORMAT (2x,'WRT_AUG_IMP_PIO  - writing augmented adjoint',        &
+     &        ' impulses, record: ',i0,/,22x,'file: ',a)
+  20  FORMAT (/,' WRT_AUG_IMP_PIO - error while writing variable: ',a,  &
      &        2x,'at time record = ',i0,                                &
      &        /,20x,'into NetCDF file: ',a)
-  20  FORMAT (2x,'WRT_AUG_IMP_PIO  - wrote augmented adjoint',          &
-     &        ' impulses, record: ',i0,/,22x,'file: ',a)
 !
       RETURN
       END SUBROUTINE wrt_aug_imp_pio

--- a/ROMS/Utility/wrt_avg.F
+++ b/ROMS/Utility/wrt_avg.F
@@ -6,7 +6,7 @@
    (defined TL_AVERAGES && defined TANGENT)
 !
 !git $Id$
-!svn $Id: wrt_avg.F 1185 2023-08-01 21:42:38Z arango $
+!svn $Id: wrt_avg.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -169,6 +169,14 @@
       Fcount=AVG(ng)%load
       AVG(ng)%Nrec(Fcount)=AVG(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+#ifdef NESTING
+      IF (Master) WRITE (stdout,10) AVG(ng)%Rindex, ng
+#else
+      IF (Master) WRITE (stdout,10) AVG(ng)%Rindex
+#endif
+!
 !  Write out averaged time.
 !
       CALL netcdf_put_fvar (ng, model, AVG(ng)%name,                    &
@@ -183,7 +191,7 @@
       IF (Aout(idFsur,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idFsur,             &
      &                     AVG(ng)%Vid(idFsur),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -193,7 +201,7 @@
      &                     AVERAGE(ng) % avgzeta)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idFsur)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idFsur)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -208,7 +216,7 @@
       IF (Aout(idFsuD,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idFsuD,             &
      &                     AVG(ng)%Vid(idFsuD),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -218,7 +226,7 @@
      &                     TIDES(ng) % zeta_detided)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idFsuD)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idFsuD)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -232,7 +240,7 @@
       IF (Aout(idUbar,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idUbar,             &
      &                     AVG(ng)%Vid(idUbar),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -242,7 +250,7 @@
      &                     AVERAGE(ng) % avgu2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbar)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbar)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -257,7 +265,7 @@
       IF (Aout(idu2dD,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idu2dD,             &
      &                     AVG(ng)%Vid(idu2dD),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -267,7 +275,7 @@
      &                     TIDES(ng) % ubar_detided)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu2dD)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu2dD)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -281,7 +289,7 @@
       IF (Aout(idVbar,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idVbar,             &
      &                     AVG(ng)%Vid(idVbar),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -291,7 +299,7 @@
      &                     AVERAGE(ng) % avgv2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbar)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbar)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -306,7 +314,7 @@
       IF (Aout(idv2dD,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idv2dD,             &
      &                     AVG(ng)%Vid(idv2dD),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -316,7 +324,7 @@
      &                     TIDES(ng) % vbar_detided)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv2dD)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv2dD)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -330,7 +338,7 @@
       IF (Aout(idu2dE,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idu2dE,             &
      &                     AVG(ng)%Vid(idu2dE),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -340,7 +348,7 @@
      &                     AVERAGE(ng) % avgu2dE)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu2dE)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu2dE)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -353,7 +361,7 @@
       IF (Aout(idv2dN,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idv2dN,             &
      &                     AVG(ng)%Vid(idv2dN),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -363,7 +371,7 @@
      &                     AVERAGE(ng) % avgv2dN)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv2dN)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv2dN)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -378,7 +386,7 @@
       IF (Aout(idUfx1,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idUfx1,             &
      &                     AVG(ng)%Vid(idUfx1),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -388,7 +396,7 @@
      &                     AVERAGE(ng) % avgDU_avg1)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUfx1)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUfx1)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -399,7 +407,7 @@
       IF (Aout(idUfx2,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idUfx2,             &
      &                     AVG(ng)%Vid(idUfx2),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -409,7 +417,7 @@
      &                     AVERAGE(ng) % avgDU_avg2)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUfx2)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUfx2)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -420,7 +428,7 @@
       IF (Aout(idVfx1,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idVfx1,             &
      &                     AVG(ng)%Vid(idVfx1),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -430,7 +438,7 @@
      &                     AVERAGE(ng) % avgDV_avg1)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVfx1)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVfx1)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -441,7 +449,7 @@
       IF (Aout(idVfx2,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idVfx2,             &
      &                     AVG(ng)%Vid(idVfx2),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -451,7 +459,7 @@
      &                     AVERAGE(ng) % avgDV_avg2)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVfx2)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVfx2)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -467,7 +475,7 @@
       IF (Aout(idUvel,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idUvel,             &
      &                     AVG(ng)%Vid(idUvel),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -477,7 +485,7 @@
      &                     AVERAGE(ng) % avgu3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUvel)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUvel)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -492,7 +500,7 @@
       IF (Aout(idu3dD,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idu3dD,             &
      &                     AVG(ng)%Vid(idu3dD),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -502,7 +510,7 @@
      &                     TIDES(ng) % u_detided)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu3dD)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu3dD)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -516,7 +524,7 @@
       IF (Aout(idVvel,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idVvel,             &
      &                     AVG(ng)%Vid(idVvel),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -526,7 +534,7 @@
      &                     AVERAGE(ng) % avgv3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvel)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvel)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -541,7 +549,7 @@
       IF (Aout(idv3dD,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idv3dD,             &
      &                     AVG(ng)%Vid(idv3dD),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -551,7 +559,7 @@
      &                     TIDES(ng) % v_detided)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv3dD)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv3dD)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -565,7 +573,7 @@
       IF (Aout(idu3dE,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idu3dE,             &
      &                     AVG(ng)%Vid(idu3dE),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -575,7 +583,7 @@
      &                     AVERAGE(ng) % avgu3dE)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu3dE)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu3dE)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -588,7 +596,7 @@
       IF (Aout(idv3dN,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idv3dN,             &
      &                     AVG(ng)%Vid(idv3dN),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -598,7 +606,7 @@
      &                     AVERAGE(ng) % avgv3dN)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv3dN)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv3dN)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -611,7 +619,7 @@
       IF (Aout(idOvel,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idOvel,             &
      &                     AVG(ng)%Vid(idOvel),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -621,7 +629,7 @@
      &                     AVERAGE(ng) % avgw3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idOvel)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idOvel)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -634,7 +642,7 @@
       IF (Aout(idWvel,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idWvel,             &
      &                     AVG(ng)%Vid(idWvel),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -644,7 +652,7 @@
      &                     AVERAGE(ng) % avgwvel)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idOvel)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idOvel)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -658,7 +666,7 @@
         IF (Aout(idTvar(itrc),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idTvar(itrc),     &
      &                       AVG(ng)%Tid(itrc),                         &
      &                       AVG(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -668,7 +676,7 @@
      &                       AVERAGE(ng) % avgt(:,:,:,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),            &
      &                          AVG(ng)%Rindex
             END IF
             exit_flag=3
@@ -686,7 +694,7 @@
         IF (Aout(idTrcD(itrc),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idTrcD(itrc),     &
      &                       AVG(ng)%Vid(idTrcD(itrc)),                 &
      &                       AVG(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -696,7 +704,7 @@
      &                       TIDES(ng) % t_detided(:,:,:,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTrcD(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTrcD(itrc))),            &
      &                          AVG(ng)%Rindex
             END IF
             exit_flag=3
@@ -712,7 +720,7 @@
       IF (Aout(idDano,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idDano,             &
      &                     AVG(ng)%Vid(idDano),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -722,7 +730,7 @@
      &                     AVERAGE(ng) % avgrho)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idDano)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idDano)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -737,7 +745,7 @@
       IF (Aout(idHsbl,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idHsbl,             &
      &                     AVG(ng)%Vid(idHsbl),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -747,7 +755,7 @@
      &                     AVERAGE(ng) % avghsbl)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHsbl)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHsbl)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -762,7 +770,7 @@
       IF (Aout(idHbbl,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idHbbl,             &
      &                     AVG(ng)%Vid(idHbbl),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -772,7 +780,7 @@
      &                     AVERAGE(ng) % avghbbl)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHbbl)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHbbl)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -787,7 +795,7 @@
       IF (Aout(id2dPV,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*p2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, id2dPV,             &
      &                     AVG(ng)%Vid(id2dPV),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -797,7 +805,7 @@
      &                     AVERAGE(ng) % avgpvor2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,id2dPV)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,id2dPV)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -810,7 +818,7 @@
       IF (Aout(id2dRV,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*p2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, id2dRV,             &
      &                     AVG(ng)%Vid(id2dRV),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -820,7 +828,7 @@
      &                     AVERAGE(ng) % avgrvor2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,id2dRV)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,id2dRV)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -835,7 +843,7 @@
       IF (Aout(id3dPV,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*p3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, id3dPV,             &
      &                     AVG(ng)%Vid(id3dPV),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -845,7 +853,7 @@
      &                     AVERAGE(ng) % avgpvor3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,id3dPV)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,id3dPV)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -858,7 +866,7 @@
       IF (Aout(id3dRV,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*p3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, id3dRV,             &
      &                     AVG(ng)%Vid(id3dRV),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -868,7 +876,7 @@
      &                     AVERAGE(ng) % avgrvor3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,id3dRV)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,id3dRV)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -882,7 +890,7 @@
       IF (Aout(idZZav,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idZZav,             &
      &                     AVG(ng)%Vid(idZZav),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -892,7 +900,7 @@
      &                     AVERAGE(ng) % avgZZ)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idZZav)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idZZav)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -905,7 +913,7 @@
       IF (Aout(idU2av,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idU2av,             &
      &                     AVG(ng)%Vid(idU2av),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -915,7 +923,7 @@
      &                     AVERAGE(ng) % avgU2)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idU2av)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idU2av)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -928,7 +936,7 @@
       IF (Aout(idV2av,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idV2av,             &
      &                     AVG(ng)%Vid(idV2av),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -938,7 +946,7 @@
      &                     AVERAGE(ng) % avgV2)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idV2av)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idV2av)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -953,7 +961,7 @@
       IF (Aout(idHUav,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idHUav,             &
      &                     AVG(ng)%Vid(idHUav),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -963,7 +971,7 @@
      &                     AVERAGE(ng) % avgHuon)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHUav)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHUav)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -976,7 +984,7 @@
       IF (Aout(idHVav,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idHVav,             &
      &                     AVG(ng)%Vid(idHVav),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -986,7 +994,7 @@
      &                     AVERAGE(ng) % avgHvom)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHVav)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHVav)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -999,7 +1007,7 @@
       IF (Aout(idUUav,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idUUav,             &
      &                     AVG(ng)%Vid(idUUav),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1009,7 +1017,7 @@
      &                     AVERAGE(ng) % avgUU)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUUav)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUUav)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1022,7 +1030,7 @@
       IF (Aout(idUVav,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idUVav,             &
      &                     AVG(ng)%Vid(idUVav),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1032,7 +1040,7 @@
      &                     AVERAGE(ng) % avgUV)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUVav)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUVav)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1045,7 +1053,7 @@
       IF (Aout(idVVav,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idVVav,             &
      &                     AVG(ng)%Vid(idVVav),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1055,7 +1063,7 @@
      &                     AVERAGE(ng) % avgVV)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVVav)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVVav)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1069,7 +1077,7 @@
         IF (Aout(idTTav(i),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idTTav(i),        &
      &                       AVG(ng)%Vid(idTTav(i)),                    &
      &                       AVG(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1079,7 +1087,7 @@
      &                       AVERAGE(ng) % avgTT(:,:,:,i))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTTav(i))), AVG(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idTTav(i))), AVG(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1094,7 +1102,7 @@
         IF (Aout(iHUTav(i),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*u3dvar
-          status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, AVG(ng)%ncid, iHUTav(i),        &
      &                       AVG(ng)%Vid(iHUTav(i)),                    &
      &                       AVG(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1104,7 +1112,7 @@
      &                       AVERAGE(ng) % avgHuonT(:,:,:,i))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,iHUTav(i))), AVG(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,iHUTav(i))), AVG(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1115,7 +1123,7 @@
         IF (Aout(iHVTav(i),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*v3dvar
-          status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, AVG(ng)%ncid, iHVTav(i),        &
      &                       AVG(ng)%Vid(iHVTav(i)),                    &
      &                       AVG(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1125,7 +1133,7 @@
      &                       AVERAGE(ng) % avgHvomT(:,:,:,i))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,iHVTav(i))), AVG(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,iHVTav(i))), AVG(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1140,7 +1148,7 @@
         IF (Aout(idUTav(i),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*u3dvar
-          status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idUTav(i),        &
      &                       AVG(ng)%Vid(idUTav(i)),                    &
      &                       AVG(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1150,7 +1158,7 @@
      &                       AVERAGE(ng) % avgUT(:,:,:,i))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idUTav(i))), AVG(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idUTav(i))), AVG(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1161,7 +1169,7 @@
         IF (Aout(idVTav(i),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*v3dvar
-          status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idVTav(i),        &
      &                       AVG(ng)%Vid(idVTav(i)),                    &
      &                       AVG(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1171,7 +1179,7 @@
      &                       AVERAGE(ng) % avgVT(:,:,:,i))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idVTav(i))), AVG(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idVTav(i))), AVG(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1187,7 +1195,7 @@
       IF (Aout(idVvis,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idVvis,             &
      &                     AVG(ng)%Vid(idVvis),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1198,7 +1206,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvis)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvis)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1211,7 +1219,7 @@
       IF (Aout(idTdif,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idTdif,             &
      &                     AVG(ng)%Vid(idTdif),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1222,7 +1230,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTdif)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTdif)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1237,7 +1245,7 @@
       IF (Aout(idSdif,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, AVG(ng)%ncid, idSdif,             &
      &                     AVG(ng)%Vid(idSdif),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1248,7 +1256,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSdif)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSdif)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1264,7 +1272,7 @@
       IF (Aout(idPair,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idPair,             &
      &                     AVG(ng)%Vid(idPair),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1274,7 +1282,7 @@
      &                     AVERAGE(ng) % avgPair)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idPair)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idPair)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1289,7 +1297,7 @@
       IF (Aout(idTair,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idTair,             &
      &                     AVG(ng)%Vid(idTair),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1299,7 +1307,7 @@
      &                     AVERAGE(ng) % avgTair)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTair)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTair)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1314,7 +1322,7 @@
       IF (Aout(idUair,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idUair,             &
      &                     AVG(ng)%Vid(idUair),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1324,7 +1332,7 @@
      &                     AVERAGE(ng) % avgUwind)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUair)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUair)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1335,7 +1343,7 @@
       IF (Aout(idVair,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idVair,             &
      &                     AVG(ng)%Vid(idVair),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1345,7 +1353,7 @@
      &                     AVERAGE(ng) % avgVwind)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVair)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVair)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1358,7 +1366,7 @@
       IF (Aout(idUaiE,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idUaiE,             &
      &                     AVG(ng)%Vid(idUaiE),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1368,7 +1376,7 @@
      &                     AVERAGE(ng) % avguwindE)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUaiE)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUaiE)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1379,7 +1387,7 @@
       IF (Aout(idVaiN,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idVaiN,             &
      &                     AVG(ng)%Vid(idVaiN),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1389,7 +1397,7 @@
      &                     AVERAGE(ng) % avgvwindN)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVaiN)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVaiN)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1412,7 +1420,7 @@
         scale=rho0*Cp
 #  endif
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idTsur(itemp),      &
      &                     AVG(ng)%Vid(idTsur(itemp)),                  &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1422,7 +1430,7 @@
      &                     AVERAGE(ng) % avgstf)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTsur(itemp))),             &
+            WRITE (stdout,20) TRIM(Vname(1,idTsur(itemp))),             &
      &                        AVG(ng)%Rindex
           END IF
           exit_flag=3
@@ -1438,7 +1446,7 @@
       IF (Aout(idTsur(isalt),ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idTsur(isalt),      &
      &                     AVG(ng)%Vid(idTsur(isalt)),                  &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1448,7 +1456,7 @@
      &                     AVERAGE(ng) % avgswf)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTsur(isalt))),             &
+            WRITE (stdout,20) TRIM(Vname(1,idTsur(isalt))),             &
      &                        AVG(ng)%Rindex
           END IF
           exit_flag=3
@@ -1469,7 +1477,7 @@
         scale=rho0*Cp
 #   endif
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idLhea,             &
      &                     AVG(ng)%Vid(idLhea),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1479,7 +1487,7 @@
      &                     AVERAGE(ng) % avglhf)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idLhea)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idLhea)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1496,7 +1504,7 @@
         scale=rho0*Cp
 #   endif
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idShea,             &
      &                     AVG(ng)%Vid(idShea),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1506,7 +1514,7 @@
      &                     AVERAGE(ng) % avgshf)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idShea)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idShea)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1523,7 +1531,7 @@
         scale=rho0*Cp
 #   endif
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idLrad,             &
      &                     AVG(ng)%Vid(idLrad),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1533,7 +1541,7 @@
      &                     AVERAGE(ng) % avglrf)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idLrad)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idLrad)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1550,7 +1558,7 @@
       IF (Aout(idevap,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idevap,             &
      &                     AVG(ng)%Vid(idevap),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1560,7 +1568,7 @@
      &                     AVERAGE(ng) % avgevap)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idevap)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idevap)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1573,7 +1581,7 @@
       IF (Aout(idrain,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idrain,             &
      &                     AVG(ng)%Vid(idrain),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1583,7 +1591,7 @@
      &                     AVERAGE(ng) % avgrain)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idrain)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idrain)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1603,7 +1611,7 @@
         scale=rho0*Cp
 #    endif
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idSrad,             &
      &                     AVG(ng)%Vid(idSrad),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1613,7 +1621,7 @@
      &                     AVERAGE(ng) % avgsrf)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSrad)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSrad)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1637,7 +1645,7 @@
         scale=rho0
 # endif
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idUsms,             &
      &                     AVG(ng)%Vid(idUsms),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1647,7 +1655,7 @@
      &                     AVERAGE(ng) % avgsus)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUsms)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUsms)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1669,7 +1677,7 @@
         scale=rho0
 # endif
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idVsms,             &
      &                     AVG(ng)%Vid(idVsms),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1679,7 +1687,7 @@
      &                     AVERAGE(ng) % avgsvs)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVsms)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVsms)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1701,7 +1709,7 @@
         scale=rho0
 # endif
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idUbms,             &
      &                     AVG(ng)%Vid(idUbms),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1711,7 +1719,7 @@
      &                     AVERAGE(ng) % avgbus)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbms)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbms)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1733,7 +1741,7 @@
         scale=rho0
 # endif
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, AVG(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, AVG(ng)%ncid, idVbms,             &
      &                     AVG(ng)%Vid(idVbms),                         &
      &                     AVG(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1743,7 +1751,7 @@
      &                     AVERAGE(ng) % avgbvs)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbms)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbms)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1806,21 +1814,15 @@
 !
       CALL netcdf_sync (ng, model, AVG(ng)%name, AVG(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-#ifdef NESTING
-      IF (Master) WRITE (stdout,20) AVG(ng)%Rindex, ng
-#else
-      IF (Master) WRITE (stdout,20) AVG(ng)%Rindex
-#endif
 !
-  10  FORMAT (/,' WRT_AVG_NF90 - error while writing variable: ',a,     &
-     &        /,16x,'into averages NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'WRT_AVG_NF90     - wrote averaged',t40,'fields',t59,  &
+  10  FORMAT (2x,'WRT_AVG_NF90     - writing averaged',t42,'fields',t61,&
 # ifdef NESTING
      &        'in record = ',i0,t92,i2.2)
 # else
      &        'in record = ',i0)
 # endif
+  20  FORMAT (/,' WRT_AVG_NF90 - error while writing variable: ',a,     &
+     &        /,16x,'into averages NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_avg_nf90
@@ -1864,6 +1866,14 @@
       Fcount=AVG(ng)%load
       AVG(ng)%Nrec(Fcount)=AVG(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) AVG(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) AVG(ng)%Rindex
+#  endif
+!
 !  Write out averaged time.
 !
       CALL pio_netcdf_put_fvar (ng, model, AVG(ng)%name,                &
@@ -1882,7 +1892,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idFsur,          &
      &                     AVG(ng)%pioVar(idFsur),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1893,7 +1903,7 @@
      &                     AVERAGE(ng) % avgzeta)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idFsur)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idFsur)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1912,7 +1922,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idFsuD,          &
      &                     AVG(ng)%pioVar(idFsuD),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1923,7 +1933,7 @@
      &                     TIDES(ng) % zeta_detided)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idFsuD)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idFsuD)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1941,7 +1951,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idUbar,          &
      &                     AVG(ng)%pioVar(idUbar),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1952,7 +1962,7 @@
      &                     AVERAGE(ng) % avgu2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbar)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbar)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1971,7 +1981,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idu2dD,          &
      &                     AVG(ng)%pioVar(idu2dD),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1982,7 +1992,7 @@
      &                     TIDES(ng) % ubar_detided)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu2dD)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu2dD)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2000,7 +2010,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idVbar,          &
      &                     AVG(ng)%pioVar(idVbar),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2011,7 +2021,7 @@
      &                     AVERAGE(ng) % avgv2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbar)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbar)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2030,7 +2040,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idv2dD,          &
      &                     AVG(ng)%pioVar(idv2dD),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2041,7 +2051,7 @@
      &                     TIDES(ng) % vbar_detided)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv2dD)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv2dD)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2059,7 +2069,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idu2dE,          &
      &                     AVG(ng)%pioVar(idu2dE),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2070,7 +2080,7 @@
      &                     AVERAGE(ng) % avgu2dE)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu2dE)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu2dE)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2087,7 +2097,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idv2dN,          &
      &                     AVG(ng)%pioVar(idv2dN),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2098,7 +2108,7 @@
      &                     AVERAGE(ng) % avgv2dN)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv2dN)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv2dN)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2117,7 +2127,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idUfx1,          &
      &                     AVG(ng)%pioVar(idUfx1),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2128,7 +2138,7 @@
      &                     AVERAGE(ng) % avgDU_avg1)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUfx1)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUfx1)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2143,7 +2153,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idUfx2,          &
      &                     AVG(ng)%pioVar(idUfx2),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2154,7 +2164,7 @@
      &                     AVERAGE(ng) % avgDU_avg2)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUfx2)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUfx2)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2169,7 +2179,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idVfx1,          &
      &                     AVG(ng)%pioVar(idVfx1),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2180,7 +2190,7 @@
      &                     AVERAGE(ng) % avgDV_avg1)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVfx1)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVfx1)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2195,7 +2205,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idVfx2,          &
      &                     AVG(ng)%pioVar(idVfx2),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2206,7 +2216,7 @@
      &                     AVERAGE(ng) % avgDV_avg2)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVfx2)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVfx2)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2226,7 +2236,7 @@
         ELSE
           ioDesc => ioDesc_sp_u3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idUvel,          &
      &                     AVG(ng)%pioVar(idUvel),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2237,7 +2247,7 @@
      &                     AVERAGE(ng) % avgu3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUvel)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUvel)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2256,7 +2266,7 @@
         ELSE
           ioDesc => ioDesc_sp_u3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idu3dD,          &
      &                     AVG(ng)%pioVar(idu3dD),                      &
      &                     ioDesc,                                      &
      &                     AVG(ng)%Rindex,                              &
@@ -2267,7 +2277,7 @@
      &                     TIDES(ng) % u_detided)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu3dD)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu3dD)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2285,7 +2295,7 @@
         ELSE
           ioDesc => ioDesc_sp_v3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idVvel,          &
      &                     AVG(ng)%pioVar(idVvel),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2296,7 +2306,7 @@
      &                     AVERAGE(ng) % avgv3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvel)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvel)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2315,7 +2325,7 @@
         ELSE
           ioDesc => ioDesc_sp_v3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idv3dD,          &
      &                     AVG(ng)%pioVar(idv3dD),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2326,7 +2336,7 @@
      &                     TIDES(ng) % v_detided)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv3dD)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv3dD)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2344,7 +2354,7 @@
         ELSE
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idu3dE,          &
      &                     AVG(ng)%pioVar(idu3dE),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2355,7 +2365,7 @@
      &                     AVERAGE(ng) % avgu3dE)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu3dE)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu3dE)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2372,7 +2382,7 @@
         ELSE
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idv3dN,          &
      &                     AVG(ng)%pioVar(idv3dN),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2383,7 +2393,7 @@
      &                     AVERAGE(ng) % avgv3dN)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv3dN)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv3dN)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2400,7 +2410,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idOvel,          &
      &                     AVG(ng)%pioVar(idOvel),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2411,7 +2421,7 @@
      &                     AVERAGE(ng) % avgw3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idOvel)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idOvel)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2428,7 +2438,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idWvel,          &
      &                     AVG(ng)%pioVar(idWvel),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2439,7 +2449,7 @@
      &                     AVERAGE(ng) % avgwvel)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idOvel)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idOvel)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2457,7 +2467,7 @@
           ELSE
             ioDesc => ioDesc_sp_r3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idTvar(itrc),  &
      &                       AVG(ng)%pioTrc(itrc),                      &
      &                       AVG(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -2468,7 +2478,7 @@
      &                       AVERAGE(ng) % avgt(:,:,:,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),            &
      &                          AVG(ng)%Rindex
             END IF
             exit_flag=3
@@ -2490,7 +2500,7 @@
           ELSE
             ioDesc => ioDesc_sp_r3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idTrcD(itrc),  &
      &                       AVG(ng)%pioVar(idTrcD(itrc)),              &
      &                       AVG(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -2501,7 +2511,7 @@
      &                       TIDES(ng) % t_detided(:,:,:,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTrcD(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTrcD(itrc))),            &
      &                          AVG(ng)%Rindex
             END IF
             exit_flag=3
@@ -2521,7 +2531,7 @@
         ELSE
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idDano,          &
      &                     AVG(ng)%pioVar(idDano),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2532,7 +2542,7 @@
      &                     AVERAGE(ng) % avgrho)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idDano)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idDano)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2551,7 +2561,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idHsbl,          &
      &                     AVG(ng)%pioVar(idHsbl),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2562,7 +2572,7 @@
      &                     AVERAGE(ng) % avghsbl)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHsbl)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHsbl)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2581,7 +2591,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idHbbl,          &
      &                     AVG(ng)%pioVar(idHbbl),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2592,7 +2602,7 @@
      &                     AVERAGE(ng) % avghbbl)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHbbl)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHbbl)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2611,7 +2621,7 @@
         ELSE
           ioDesc => ioDesc_sp_p2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, id2dPV,          &
      &                     AVG(ng)%pioVar(id2dPV),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2622,7 +2632,7 @@
      &                     AVERAGE(ng) % avgpvor2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,id2dPV)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,id2dPV)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2639,7 +2649,7 @@
         ELSE
           ioDesc => ioDesc_sp_p2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, id2dRV,          &
      &                     AVG(ng)%pioVar(id2dRV),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2650,7 +2660,7 @@
      &                     AVERAGE(ng) % avgrvor2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,id2dRV)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,id2dRV)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2669,7 +2679,7 @@
         ELSE
           ioDesc => ioDesc_sp_p3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, id3dPV,          &
      &                     AVG(ng)%pioVar(id3dPV),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2680,7 +2690,7 @@
      &                     AVERAGE(ng) % avgpvor3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,id3dPV)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,id3dPV)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2697,7 +2707,7 @@
         ELSE
           ioDesc => ioDesc_sp_p3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, id3dRV,          &
      &                     AVG(ng)%pioVar(id3dRV),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2708,7 +2718,7 @@
      &                     AVERAGE(ng) % avgrvor3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,id3dRV)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,id3dRV)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2726,7 +2736,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idZZav,          &
      &                     AVG(ng)%pioVar(idZZav),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2737,7 +2747,7 @@
      &                     AVERAGE(ng) % avgZZ)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idZZav)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idZZav)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2754,7 +2764,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idU2av,          &
      &                     AVG(ng)%pioVar(idU2av),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2765,7 +2775,7 @@
      &                     AVERAGE(ng) % avgU2)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idU2av)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idU2av)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2782,7 +2792,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idV2av,          &
      &                     AVG(ng)%pioVar(idV2av),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2793,7 +2803,7 @@
      &                     AVERAGE(ng) % avgV2)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idV2av)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idV2av)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2812,7 +2822,7 @@
         ELSE
           ioDesc => ioDesc_sp_u3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idHUav,          &
      &                     AVG(ng)%pioVar(idHUav),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2823,7 +2833,7 @@
      &                     AVERAGE(ng) % avgHuon)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHUav)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHUav)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2840,7 +2850,7 @@
         ELSE
           ioDesc => ioDesc_sp_v3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idHVav,          &
      &                     AVG(ng)%pioVar(idHVav),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2851,7 +2861,7 @@
      &                     AVERAGE(ng) % avgHvom)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHVav)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHVav)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2868,7 +2878,7 @@
         ELSE
           ioDesc => ioDesc_sp_u3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idUUav,          &
      &                     AVG(ng)%pioVar(idUUav),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2879,7 +2889,7 @@
      &                     AVERAGE(ng) % avgUU)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUUav)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUUav)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2896,7 +2906,7 @@
         ELSE
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idUVav,          &
      &                     AVG(ng)%pioVar(idUVav),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2907,7 +2917,7 @@
      &                     AVERAGE(ng) % avgUV)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUVav)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUVav)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2924,7 +2934,7 @@
         ELSE
           ioDesc => ioDesc_sp_v3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idVVav,          &
      &                     AVG(ng)%pioVar(idVVav),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2935,7 +2945,7 @@
      &                     AVERAGE(ng) % avgVV)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVVav)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVVav)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2953,7 +2963,7 @@
           ELSE
             ioDesc => ioDesc_sp_r3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idTTav(i),     &
      &                       AVG(ng)%pioVar(idTTav(i)),                 &
      &                       AVG(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -2964,7 +2974,7 @@
      &                       AVERAGE(ng) % avgTT(:,:,:,i))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTTav(i))), AVG(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idTTav(i))), AVG(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -2983,7 +2993,7 @@
           ELSE
             ioDesc => ioDesc_sp_u3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, iHUTav(i),     &
      &                       AVG(ng)%pioVar(iHUTav(i)),                 &
      &                       AVG(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -2994,7 +3004,7 @@
      &                       AVERAGE(ng) % avgHuonT(:,:,:,i))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,iHUTav(i))), AVG(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,iHUTav(i))), AVG(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -3009,7 +3019,7 @@
           ELSE
             ioDesc => ioDesc_sp_v3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, iHVTav(i),     &
      &                       AVG(ng)%pioVar(iHVTav(i)),                 &
      &                       AVG(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -3020,7 +3030,7 @@
      &                       AVERAGE(ng) % avgHvomT(:,:,:,i))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,iHVTav(i))), AVG(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,iHVTav(i))), AVG(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -3039,7 +3049,7 @@
           ELSE
             ioDesc => ioDesc_sp_u3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idUTav(i),     &
      &                       AVG(ng)%pioVar(idUTav(i)),                 &
      &                       AVG(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -3050,7 +3060,7 @@
      &                       AVERAGE(ng) % avgUT(:,:,:,i))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idUTav(i))), AVG(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idUTav(i))), AVG(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -3065,7 +3075,7 @@
           ELSE
             ioDesc => ioDesc_sp_v3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idVTav(i),     &
      &                       AVG(ng)%pioVar(idVTav(i)),                 &
      &                       AVG(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -3076,7 +3086,7 @@
      &                       AVERAGE(ng) % avgVT(:,:,:,i))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idVTav(i))), AVG(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idVTav(i))), AVG(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -3096,7 +3106,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idVvis,          &
      &                     AVG(ng)%pioVar(idVvis),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3108,7 +3118,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvis)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvis)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3125,7 +3135,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idTdif,          &
      &                     AVG(ng)%pioVar(idTdif),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3137,7 +3147,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTdif)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTdif)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3156,7 +3166,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, AVG(ng)%pioFile, idSdif,          &
      &                     AVG(ng)%pioVar(idSdif),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3168,7 +3178,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSdif)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSdif)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3188,7 +3198,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idPair,          &
      &                     AVG(ng)%pioVar(idPair),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3199,7 +3209,7 @@
      &                     AVERAGE(ng) % avgPair)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idPair)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idPair)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3218,7 +3228,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idTair,          &
      &                     AVG(ng)%pioVar(idTair),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3229,7 +3239,7 @@
      &                     AVERAGE(ng) % avgTair)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTair)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTair)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3248,7 +3258,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idUair,          &
      &                     AVG(ng)%pioVar(idUair),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3259,7 +3269,7 @@
      &                     AVERAGE(ng) % avgUwind)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUair)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUair)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3274,7 +3284,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idVair,          &
      &                     AVG(ng)%pioVar(idVair),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3285,7 +3295,7 @@
      &                     AVERAGE(ng) % avgVwind)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVair)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVair)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3302,7 +3312,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idUaiE,          &
      &                     AVG(ng)%pioVar(idUaiE),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3313,7 +3323,7 @@
      &                     AVERAGE(ng) % avguwindE)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUaiE)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUaiE)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3328,7 +3338,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idVaiN,          &
      &                     AVG(ng)%pioVar(idVaiN),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3339,7 +3349,7 @@
      &                     AVERAGE(ng) % avgvwindN)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVaiN)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVaiN)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3366,7 +3376,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idTsur(itemp),   &
      &                     AVG(ng)%pioVar(idTsur(itemp)),               &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3377,7 +3387,7 @@
      &                     AVERAGE(ng) % avgstf)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTsur(itemp))),             &
+            WRITE (stdout,20) TRIM(Vname(1,idTsur(itemp))),             &
      &                        AVG(ng)%Rindex
           END IF
           exit_flag=3
@@ -3397,7 +3407,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idTsur(isalt),   &
      &                     AVG(ng)%pioVar(idTsur(isalt)),               &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3408,7 +3418,7 @@
      &                     AVERAGE(ng) % avgswf)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTsur(isalt))),             &
+            WRITE (stdout,20) TRIM(Vname(1,idTsur(isalt))),             &
      &                        AVG(ng)%Rindex
           END IF
           exit_flag=3
@@ -3433,7 +3443,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idLhea,          &
      &                     AVG(ng)%pioVar(idLhea),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3444,7 +3454,7 @@
      &                     AVERAGE(ng) % avglhf)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idLhea)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idLhea)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3465,7 +3475,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idShea,          &
      &                     AVG(ng)%pioVar(idShea),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3476,7 +3486,7 @@
      &                     AVERAGE(ng) % avgshf)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idShea)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idShea)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3497,7 +3507,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idLrad,          &
      &                     AVG(ng)%pioVar(idLrad),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3508,7 +3518,7 @@
      &                     AVERAGE(ng) % avglrf)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idLrad)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idLrad)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3529,7 +3539,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idevap,          &
      &                     AVG(ng)%pioVar(idevap),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3540,7 +3550,7 @@
      &                     AVERAGE(ng) % avgevap)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idevap)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idevap)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3557,7 +3567,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idrain,          &
      &                     AVG(ng)%pioVar(idrain),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3568,7 +3578,7 @@
      &                     AVERAGE(ng) % avgrain)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idrain)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idrain)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3592,7 +3602,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idSrad,          &
      &                     AVG(ng)%pioVar(idSrad),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3603,7 +3613,7 @@
      &                     AVERAGE(ng) % avgsrf)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSrad)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSrad)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3631,7 +3641,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idUsms,          &
      &                     AVG(ng)%pioVar(idUsms),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3642,7 +3652,7 @@
      &                     AVERAGE(ng) % avgsus)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUsms)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUsms)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3668,7 +3678,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idVsms,          &
      &                     AVG(ng)%pioVar(idVsms),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3679,7 +3689,7 @@
      &                     AVERAGE(ng) % avgsvs)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVsms)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVsms)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3705,7 +3715,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idUbms,          &
      &                     AVG(ng)%pioVar(idUbms),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3716,7 +3726,7 @@
      &                     AVERAGE(ng) % avgbus)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbms)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbms)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3742,7 +3752,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, AVG(ng)%pioFile, idVbms,          &
      &                     AVG(ng)%pioVar(idVbms),                      &
      &                     AVG(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3753,7 +3763,7 @@
      &                     AVERAGE(ng) % avgbvs)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbms)), AVG(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbms)), AVG(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3816,26 +3826,18 @@
 !
       CALL pio_netcdf_sync (ng, model, AVG(ng)%name, AVG(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) AVG(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) AVG(ng)%Rindex
-#  endif
 !
-  10  FORMAT (/,' WRT_AVG_PIO - error while writing variable: ',a,      &
-     &        /,16x,'into averages NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'WRT_AVG_PIO      - wrote averaged',t40,'fields',t59,  &
+  10  FORMAT (2x,'WRT_AVG_PIO      - writing averaged',t42,'fields',t61,&
 #  ifdef NESTING
      &        'in record = ',i0,t92,i2.2)
 #  else
      &        'in record = ',i0)
 #  endif
+  20  FORMAT (/,' WRT_AVG_PIO - error while writing variable: ',a,      &
+     &        /,16x,'into averages NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_avg_pio
 # endif
-
-
 #endif
       END MODULE wrt_avg_mod

--- a/ROMS/Utility/wrt_dai.F
+++ b/ROMS/Utility/wrt_dai.F
@@ -3,7 +3,7 @@
 #if defined FOUR_DVAR || defined ENKF_RESTART
 !
 !git $Id$
-!svn $Id: wrt_dai.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: wrt_dai.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -134,6 +134,22 @@
 !  file.
 !
       DAI(ng)%Rindex=MOD(DAI(ng)%Rindex-1,2)+1
+!
+!  Report.
+!
+# ifdef SOLVE3D
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, DAI(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, DAI(ng)%Rindex
+#  endif
+# else
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, DAI(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) KOUT, DAI(ng)%Rindex
+#  endif
+# endif
 
 # ifdef SOLVE3D
 !
@@ -141,7 +157,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*r3dvar
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Vid(idpthR),   &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, idpthR,                &
+     &                   DAI(ng)%Vid(idpthR),                           &
      &                   0, gtype,                                      &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -151,7 +168,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idpthR))
+          WRITE (stdout,20) TRIM(Vname(1,idpthR))
         END IF
         exit_flag=3
         ioerror=status
@@ -170,7 +187,8 @@
           END DO
         END DO
       END DO
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Vid(idpthU),   &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, idpthU,                &
+     &                   DAI(ng)%Vid(idpthU),                           &
      &                   0, gtype,                                      &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -180,7 +198,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idpthU))
+          WRITE (stdout,20) TRIM(Vname(1,idpthU))
         END IF
         exit_flag=3
         ioerror=status
@@ -199,7 +217,8 @@
           END DO
         END DO
       END DO
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Vid(idpthV),   &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, idpthV,                &
+     &                   DAI(ng)%Vid(idpthV),                           &
      &                   0, gtype,                                      &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -209,7 +228,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idpthV))
+          WRITE (stdout,20) TRIM(Vname(1,idpthV))
         END IF
         exit_flag=3
         ioerror=status
@@ -220,7 +239,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Vid(idpthW),   &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, idpthW,                &
+     &                   DAI(ng)%Vid(idpthW),                           &
      &                   0, gtype,                                      &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
 #  ifdef MASKING
@@ -230,7 +250,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idpthW))
+          WRITE (stdout,20) TRIM(Vname(1,idpthW))
         END IF
         exit_flag=3
         ioerror=status
@@ -251,7 +271,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Vid(idFsur),   &
+      status=nf_fwrite2d(ng, iNLM, DAI(ng)%ncid, idFsur,                &
+     &                   DAI(ng)%Vid(idFsur),                           &
      &                   DAI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -274,7 +295,7 @@
 # endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idFsur)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idFsur)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -285,7 +306,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u2dvar
-      status=nf_fwrite2d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Vid(idUbar),   &
+      status=nf_fwrite2d(ng, iNLM, DAI(ng)%ncid, idUbar,                &
+     &                   DAI(ng)%Vid(idUbar),                           &
      &                   DAI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -298,7 +320,7 @@
 # endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idUbar)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idUbar)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -309,7 +331,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v2dvar
-      status=nf_fwrite2d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Vid(idVbar),   &
+      status=nf_fwrite2d(ng, iNLM, DAI(ng)%ncid, idVbar,                &
+     &                   DAI(ng)%Vid(idVbar),                           &
      &                   DAI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -322,7 +345,7 @@
 # endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idVbar)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idVbar)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -335,7 +358,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Vid(idUvel),   &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, idUvel,                &
+     &                   DAI(ng)%Vid(idUvel),                           &
      &                   DAI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -348,7 +372,7 @@
 #  endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idUvel)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idUvel)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -359,7 +383,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Vid(idVvel),   &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, idVvel,                &
+     &                   DAI(ng)%Vid(idVvel),                           &
      &                   DAI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -372,7 +397,7 @@
 #  endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idVvel)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idVvel)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -384,7 +409,8 @@
       DO itrc=1,NT(ng)
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Tid(itrc),   &
+        status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, idTvar(itrc),        &
+     &                     DAI(ng)%Tid(itrc),                           &
      &                     DAI(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -397,7 +423,7 @@
 #  endif
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))), DAI(ng)%Rindex
+            WRITE (stdout,30) TRIM(Vname(1,idTvar(itrc))), DAI(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -409,7 +435,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Vid(idVvis),   &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, idVvis,                &
+     &                   DAI(ng)%Vid(idVvis),                           &
      &                   DAI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
 #  ifdef MASKING
@@ -419,7 +446,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idVvis)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idVvis)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -430,7 +457,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Vid(idTdif),   &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, idTdif,                &
+     &                   DAI(ng)%Vid(idTdif),                           &
      &                   DAI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
 #  ifdef MASKING
@@ -440,7 +468,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idTdif)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idTdif)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -453,7 +481,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, DAI(ng)%Vid(idSdif),   &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%ncid, idSdif,                &
+     &                   DAI(ng)%Vid(idSdif),                           &
      &                   DAI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
 #   ifdef MASKING
@@ -463,7 +492,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idSdif)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idSdif)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -478,41 +507,26 @@
 !
       CALL netcdf_sync (ng, iNLM, DAI(ng)%name, DAI(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-# ifdef SOLVE3D
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,30) KOUT, NOUT, DAI(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,30) KOUT, NOUT, DAI(ng)%Rindex
-#  endif
-# else
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,30) KOUT, DAI(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,30) KOUT, DAI(ng)%Rindex
-#  endif
-# endif
 !
-  10  FORMAT (/,' WRT_DAI_NF90 - error while writing variable: ',a,     &
-     &        /,11x,'into DA initial/restart NetCDF file.')
-  20  FORMAT (/,' WRT_DAI_NF90 - error while writing variable: ',a,     &
-     &        /,11x,'into DA initial/rstart NetCDF file for time ',     &
-     &         'record: ',i0)
+  10  FORMAT (2x,'WRT_DAI_NF90     - writing DA INI/RST', t42,          &
 # ifdef SOLVE3D
-  30  FORMAT (2x,'WRT_DAI_NF90     - wrote DA INI/RST', t40,            &
 #  ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
 #  else
      &        'fields (Index=',i1,',',i1,') in record = ',i0)
 #  endif
 # else
-  30  FORMAT (2x,'WRT_DAI_NF90     - wrote DA INI/RST', t40,            &
 #  ifdef NESTING
      &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
 #  else
      &        'fields (Index=',i1,')   in record = ',i0)
 #  endif
 # endif
+  20  FORMAT (/,' WRT_DAI_NF90 - error while writing variable: ',a,     &
+     &        /,11x,'into DA initial/restart NetCDF file.')
+  30  FORMAT (/,' WRT_DAI_NF90 - error while writing variable: ',a,     &
+     &        /,11x,'into DA initial/rstart NetCDF file for time ',     &
+     &         'record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_dai_nf90
@@ -563,6 +577,22 @@
 !  file.
 !
       DAI(ng)%Rindex=MOD(DAI(ng)%Rindex-1,2)+1
+!
+!  Report
+!
+#  ifdef SOLVE3D
+#   ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, DAI(ng)%Rindex, ng
+#   else
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, DAI(ng)%Rindex
+#   endif
+#  else
+#   ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, DAI(ng)%Rindex, ng
+#   else
+      IF (Master) WRITE (stdout,10) KOUT, DAI(ng)%Rindex
+#   endif
+#  endif
 
 #  ifdef SOLVE3D
 !
@@ -575,7 +605,7 @@
         ioDesc => ioDesc_sp_r3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile, idpthR,             &
      &                   DAI(ng)%pioVar(idpthR), 0,                     &
      &                   ioDesc,                                        &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -586,7 +616,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idpthR))
+          WRITE (stdout,20) TRIM(Vname(1,idpthR))
         END IF
         exit_flag=3
         ioerror=status
@@ -611,7 +641,7 @@
         ioDesc => ioDesc_sp_u3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile, idpthU,             &
      &                   DAI(ng)%pioVar(idpthU), 0,                     &
      &                   ioDesc,                                        &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -622,7 +652,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idpthU))
+          WRITE (stdout,20) TRIM(Vname(1,idpthU))
         END IF
         exit_flag=3
         ioerror=status
@@ -646,7 +676,7 @@
       ELSE
         ioDesc => ioDesc_sp_v3dvar(ng)
       END IF
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile, idpthV,             &
      &                   DAI(ng)%pioVar(idpthV), 0,                     &
      &                   ioDesc,                                        &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -657,7 +687,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idpthV))
+          WRITE (stdout,20) TRIM(Vname(1,idpthV))
         END IF
         exit_flag=3
         ioerror=status
@@ -673,7 +703,7 @@
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile, idpthW,             &
      &                   DAI(ng)%pioVar(idpthW), 0,                     &
      &                   ioDesc,                                        &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
@@ -684,7 +714,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idpthW))
+          WRITE (stdout,20) TRIM(Vname(1,idpthW))
         END IF
         exit_flag=3
         ioerror=status
@@ -710,7 +740,7 @@
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iNLM, DAI(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iNLM, DAI(ng)%pioFile, idFsur,             &
      &                   DAI(ng)%pioVar(idFsur),                        &
      &                   DAI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -735,7 +765,7 @@
 #  endif
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idFsur)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idFsur)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -751,7 +781,7 @@
         ioDesc => ioDesc_sp_u2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iNLM, DAI(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iNLM, DAI(ng)%pioFile, idUbar,             &
      &                   DAI(ng)%pioVar(idUbar),                        &
      &                   DAI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -766,7 +796,7 @@
 #  endif
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idUbar)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idUbar)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -782,7 +812,7 @@
         ioDesc => ioDesc_sp_v2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iNLM, DAI(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iNLM, DAI(ng)%pioFile, idVbar,             &
      &                   DAI(ng)%pioVar(idVbar),                        &
      &                   DAI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -797,7 +827,7 @@
 #  endif
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idVbar)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idVbar)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -815,7 +845,7 @@
         ioDesc => ioDesc_sp_u3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile, idUvel,             &
      &                   DAI(ng)%pioVar(idUvel),                        &
      &                   DAI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -830,7 +860,7 @@
 #   endif
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idUvel)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idUvel)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -846,7 +876,7 @@
         ioDesc => ioDesc_sp_v3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile, idVvel,             &
      &                   DAI(ng)%pioVar(idVvel),                        &
      &                   DAI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -861,7 +891,7 @@
 #   endif
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idVvel)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idVvel)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -878,7 +908,7 @@
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile, idTvar(itrc),     &
      &                     DAI(ng)%pioTrc(itrc),                        &
      &                     DAI(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -893,7 +923,7 @@
 #   endif
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))), DAI(ng)%Rindex
+            WRITE (stdout,30) TRIM(Vname(1,idTvar(itrc))), DAI(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -910,7 +940,7 @@
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile, idVvis,             &
      &                   DAI(ng)%pioVar(idVvis),                        &
      &                   DAI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -922,7 +952,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idVvis)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idVvis)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -938,7 +968,7 @@
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile, idTdif,             &
      &                   DAI(ng)%pioVar(idTdif),                        &
      &                   DAI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -950,7 +980,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idTdif)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idTdif)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -968,7 +998,7 @@
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, DAI(ng)%pioFile, idSdif,             &
      &                   DAI(ng)%pioVar(idSdif),                        &
      &                   DAI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -980,7 +1010,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,20) TRIM(Vname(1,idSdif)), DAI(ng)%Rindex
+          WRITE (stdout,30) TRIM(Vname(1,idSdif)), DAI(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -995,41 +1025,26 @@
 !
       CALL pio_netcdf_sync (ng, iNLM, DAI(ng)%name, DAI(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-#  ifdef SOLVE3D
-#   ifdef NESTING
-      IF (Master) WRITE (stdout,30) KOUT, NOUT, DAI(ng)%Rindex, ng
-#   else
-      IF (Master) WRITE (stdout,30) KOUT, NOUT, DAI(ng)%Rindex
-#   endif
-#  else
-#   ifdef NESTING
-      IF (Master) WRITE (stdout,30) KOUT, DAI(ng)%Rindex, ng
-#   else
-      IF (Master) WRITE (stdout,30) KOUT, DAI(ng)%Rindex
-#   endif
-#  endif
 !
-  10  FORMAT (/,' WRT_DAI_PIO - error while writing variable: ',a,      &
-     &        /,11x,'into DA initial/restart NetCDF file.')
-  20  FORMAT (/,' WRT_DAI_PIO - error while writing variable: ',a,      &
-     &        /,11x,'into DA initial/rstart NetCDF file for time ',     &
-     &         'record: ',i0)
+  10  FORMAT (2x,'WRT_DAI_PIO      - writing DA INI/RST', t42,          &
 #  ifdef SOLVE3D
-  30  FORMAT (2x,'WRT_DAI_PIO      - wrote DA INI/RST', t40,            &
 #   ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
 #   else
      &        'fields (Index=',i1,',',i1,') in record = ',i0)
 #   endif
 #  else
-  30  FORMAT (2x,'WRT_DAI_PIO      - wrote DA INI/RST', t40,            &
 #   ifdef NESTING
      &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
 #   else
      &        'fields (Index=',i1,')   in record = ',i0)
 #   endif
 #  endif
+  20  FORMAT (/,' WRT_DAI_PIO - error while writing variable: ',a,      &
+     &        /,11x,'into DA initial/restart NetCDF file.')
+  30  FORMAT (/,' WRT_DAI_PIO - error while writing variable: ',a,      &
+     &        /,11x,'into DA initial/rstart NetCDF file for time ',     &
+     &         'record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_dai_pio

--- a/ROMS/Utility/wrt_diags.F
+++ b/ROMS/Utility/wrt_diags.F
@@ -3,7 +3,7 @@
 #ifdef DIAGNOSTICS
 !
 !git $Id$
-!svn $Id: wrt_diags.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: wrt_diags.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -140,6 +140,14 @@
       Fcount=DIA(ng)%load
       DIA(ng)%Nrec(Fcount)=DIA(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+# ifdef NESTING
+      IF (Master) WRITE (stdout,10) DIA(ng)%Rindex, ng
+# else
+      IF (Master) WRITE (stdout,10) DIA(ng)%Rindex
+# endif
+!
 !  Write out averaged time.
 !
       CALL netcdf_put_fvar (ng, iNLM, DIA(ng)%name,                     &
@@ -153,7 +161,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, iNLM, DIA(ng)%ncid, DIA(ng)%Vid(idFsur),   &
+      status=nf_fwrite2d(ng, iNLM, DIA(ng)%ncid, idFsur,                &
+     &                   DIA(ng)%Vid(idFsur),                           &
      &                   DIA(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -162,7 +171,7 @@
      &                   DIAGS(ng) % avgzeta)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idFsur)), DIA(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idFsur)), DIA(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -178,7 +187,7 @@
         IF (Dout(ifield,ng)) THEN
           scale=1.0_dp/dt(ng)
           gtype=gfactor*u2dvar
-          status=nf_fwrite2d(ng, iNLM, DIA(ng)%ncid,                    &
+          status=nf_fwrite2d(ng, iNLM, DIA(ng)%ncid, ifield,            &
      &                       DIA(ng)%Vid(ifield),                       &
      &                       DIA(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -189,7 +198,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -201,7 +210,7 @@
         IF (Dout(ifield,ng)) THEN
           scale=1.0_dp/dt(ng)
           gtype=gfactor*v2dvar
-          status=nf_fwrite2d(ng, iNLM, DIA(ng)%ncid,                    &
+          status=nf_fwrite2d(ng, iNLM, DIA(ng)%ncid, ifield,            &
      &                       DIA(ng)%Vid(ifield),                       &
      &                       DIA(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -212,7 +221,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -230,7 +239,7 @@
         IF (Dout(ifield,ng)) THEN
           scale=1.0_dp/dt(ng)
           gtype=gfactor*u3dvar
-          status=nf_fwrite3d(ng, iNLM, DIA(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iNLM, DIA(ng)%ncid, ifield,            &
      &                       DIA(ng)%Vid(ifield),                       &
      &                       DIA(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -241,7 +250,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -253,7 +262,7 @@
         IF (Dout(ifield,ng)) THEN
           scale=1.0_dp/dt(ng)
           gtype=gfactor*v3dvar
-          status=nf_fwrite3d(ng, iNLM, DIA(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iNLM, DIA(ng)%ncid, ifield,            &
      &                       DIA(ng)%Vid(ifield),                       &
      &                       DIA(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -264,7 +273,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -284,7 +293,7 @@
           IF (Dout(ifield,ng)) THEN
             scale=1.0_dp/dt(ng)
             gtype=gfactor*r3dvar
-            status=nf_fwrite3d(ng, iNLM, DIA(ng)%ncid,                  &
+            status=nf_fwrite3d(ng, iNLM, DIA(ng)%ncid, ifield,          &
      &                         DIA(ng)%Vid(ifield),                     &
      &                         DIA(ng)%Rindex, gtype,                   &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
@@ -295,7 +304,7 @@
      &                         SetFillVal = .FALSE.)
             IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
               IF (Master) THEN
-                WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+                WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
               END IF
               exit_flag=3
               ioerror=status
@@ -321,7 +330,7 @@
             scale=1.0_dp/dtBIO                       ! mmole m-2 day-1
           END IF
           gtype=gfactor*r2dvar
-          status=nf_fwrite2d(ng, iNLM, DIA(ng)%ncid,                    &
+          status=nf_fwrite2d(ng, iNLM, DIA(ng)%ncid, ifield,            &
      &                       DIA(ng)%Vid(ifield),                       &
      &                       DIA(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -332,7 +341,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -350,7 +359,7 @@
         IF (Dout(ifield,ng)) THEN
           scale=1.0_dp/dtBIO                         ! mmole m-3 day-1
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, iNLM, DIA(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iNLM, DIA(ng)%ncid, ifield,            &
      &                       DIA(ng)%Vid(ifield),                       &
      &                       DIA(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -361,7 +370,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -380,7 +389,7 @@
         IF (Dout(ifield,ng)) THEN
           scale=1.0_dp                               ! micromole m-2 s-1
           gtype=gfactor*l3dvar
-          status=nf_fwrite3d(ng, iNLM, DIA(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iNLM, DIA(ng)%ncid, ifield,            &
      &                       DIA(ng)%Vid(ifield),                       &
      &                       DIA(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, NDbands, scale,     &
@@ -391,7 +400,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -408,7 +417,7 @@
         IF (Dout(ifield,ng)) THEN
           scale=1.0_dp                   ! micromole m-2 s-1 or m-1
           gtype=gfactor*l4dvar
-          status=nf_fwrite4d(ng, iNLM, DIA(ng)%ncid,                    &
+          status=nf_fwrite4d(ng, iNLM, DIA(ng)%ncid, ifield,            &
      &                       DIA(ng)%Vid(ifield),                       &
      &                       DIA(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), 1, NDbands,  &
@@ -420,7 +429,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -436,21 +445,15 @@
 !
       CALL netcdf_sync (ng, iNLM, DIA(ng)%name, DIA(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-# ifdef NESTING
-      IF (Master) WRITE (stdout,20) DIA(ng)%Rindex, ng
-# else
-      IF (Master) WRITE (stdout,20) DIA(ng)%Rindex
-# endif
 !
-  10  FORMAT (/,' WRT_DIAGS_NF90 - error while writing variable: ',a,   &
-     &        /,18x,'into diagnostics NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'WRT_DIAGS_NF90   - wrote diagnostics fields',t59,     &
+  10  FORMAT (2x,'WRT_DIAGS_NF90   - writing diagnostics fields',t61,   &
 # ifdef NESTING
      &        'in record = ',i0,t92,i2.2)
 # else
      &        'in record = ',i0)
 # endif
+  20  FORMAT (/,' WRT_DIAGS_NF90 - error while writing variable: ',a,   &
+     &        /,18x,'into diagnostics NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_diags_nf90
@@ -497,6 +500,14 @@
       Fcount=DIA(ng)%load
       DIA(ng)%Nrec(Fcount)=DIA(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) DIA(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) DIA(ng)%Rindex
+#  endif
+!
 !  Write out averaged time.
 !
       CALL pio_netcdf_put_fvar (ng, iNLM, DIA(ng)%name,                 &
@@ -514,7 +525,7 @@
       ELSE
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, iNLM, DIA(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iNLM, DIA(ng)%pioFile, idFsur,             &
      &                   DIA(ng)%pioVar(idFsur),                        &
      &                   DIA(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -525,7 +536,7 @@
      &                   DIAGS(ng) % avgzeta)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idFsur)), DIA(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idFsur)), DIA(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -545,7 +556,7 @@
           ELSE
             ioDesc => ioDesc_sp_u2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, iNLM, DIA(ng)%pioFile,                 &
+          status=nf_fwrite2d(ng, iNLM, DIA(ng)%pioFile, ifield,         &
      &                       DIA(ng)%pioVar(ifield),                    &
      &                       DIA(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -557,7 +568,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -573,7 +584,7 @@
           ELSE
             ioDesc => ioDesc_sp_v2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, iNLM, DIA(ng)%pioFile,                 &
+          status=nf_fwrite2d(ng, iNLM, DIA(ng)%pioFile, ifield,         &
      &                       DIA(ng)%pioVar(ifield),                    &
      &                       DIA(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -585,7 +596,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -607,7 +618,7 @@
           ELSE
             ioDesc => ioDesc_sp_u3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, iNLM, DIA(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iNLM, DIA(ng)%pioFile, ifield,         &
      &                       DIA(ng)%pioVar(ifield),                    &
      &                       DIA(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -619,7 +630,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -635,7 +646,7 @@
           ELSE
             ioDesc => ioDesc_sp_v3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, iNLM, DIA(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iNLM, DIA(ng)%pioFile, ifield,         &
      &                       DIA(ng)%pioVar(ifield),                    &
      &                       DIA(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -647,7 +658,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -671,7 +682,7 @@
             ELSE
               ioDesc => ioDesc_sp_r3dvar(ng)
             END IF
-            status=nf_fwrite3d(ng, iNLM, DIA(ng)%pioFile,               &
+            status=nf_fwrite3d(ng, iNLM, DIA(ng)%pioFile, ifield,       &
      &                         DIA(ng)%pioVar(ifield),                  &
      &                         DIA(ng)%Rindex,                          &
      &                         ioDesc,                                  &
@@ -683,7 +694,7 @@
      &                         SetFillVal = .FALSE.)
             IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
               IF (Master) THEN
-                WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+                WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
               END IF
               exit_flag=3
               ioerror=status
@@ -713,7 +724,7 @@
           ELSE
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, iNLM, DIA(ng)%pioFile,                 &
+          status=nf_fwrite2d(ng, iNLM, DIA(ng)%pioFile, ifield,         &
      &                       DIA(ng)%pioVar(ifield),                    &
      &                       DIA(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -725,7 +736,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -747,7 +758,7 @@
           ELSE
             ioDesc => ioDesc_sp_r3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, iNLM, DIA(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iNLM, DIA(ng)%pioFile, ifield,         &
      &                       DIA(ng)%pioVar(ifield),                    &
      &                       DIA(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -759,7 +770,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -782,7 +793,7 @@
           ELSE
             ioDesc => ioDesc_sp_l3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, iNLM, DIA(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iNLM, DIA(ng)%pioFile, ifield,         &
      &                       DIA(ng)%pioVar(ifield),                    &
      &                       DIA(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -794,7 +805,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -815,7 +826,7 @@
           ELSE
             ioDesc => ioDesc_sp_l4dvar(ng)
           END IF
-          status=nf_fwrite4d(ng, iNLM, DIA(ng)%pioFile,                 &
+          status=nf_fwrite4d(ng, iNLM, DIA(ng)%pioFile, ifield,         &
      &                       DIA(ng)%pioVar(ifield),                    &
      &                       DIA(ng)%Rindex, gtype,                     &
      &                       ioDesc,                                    &
@@ -828,7 +839,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), DIA(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -844,21 +855,15 @@
 !
       CALL pio_netcdf_sync (ng, iNLM, DIA(ng)%name, DIA(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) DIA(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) DIA(ng)%Rindex
-#  endif
 !
-  10  FORMAT (/,' WRT_DIAGS_PIO - error while writing variable: ',a,    &
-     &        /,18x,'into diagnostics NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'WRT_DIAGS_PIO    - wrote diagnostics fields',t59,     &
+  10  FORMAT (2x,'WRT_DIAGS_PIO    - writing diagnostics fields',t61,   &
 #  ifdef NESTING
      &        'in record = ',i0,t92,i2.2)
 #  else
      &        'in record = ',i0)
 #  endif
+  20  FORMAT (/,' WRT_DIAGS_PIO - error while writing variable: ',a,    &
+     &        /,18x,'into diagnostics NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_diags_pio

--- a/ROMS/Utility/wrt_error.F
+++ b/ROMS/Utility/wrt_error.F
@@ -4,7 +4,7 @@
    (defined POSTERIOR_ERROR_F || defined POSTERIOR_ERROR_I)
 !
 !git $Id$
-!svn $Id: wrt_error.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: wrt_error.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -170,6 +170,22 @@
       Fcount=ERR(ng)%Fcount
       ERR(ng)%Nrec(Fcount)=ERR(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+# ifdef SOLVE3D
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, nout, ERR(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) kout, nout, ERR(ng)%Rindex
+#  endif
+# else
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, ERR(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) kout, ERR(ng)%Rindex
+#  endif
+# endif
+!
 !  Write out model time (s).
 !
       CALL netcdf_put_fvar (ng, iTLM, ERR(ng)%name,                     &
@@ -203,7 +219,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(idFsur),   &
+      status=nf_fwrite2d(ng, iTLM, ERR(ng)%ncid, idFsur,                &
+     &                   ERR(ng)%Vid(idFsur),                           &
      &                   ERR(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -212,7 +229,7 @@
      &                   OCEAN(ng)% tl_zeta(:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idFsur)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idFsur)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -234,7 +251,7 @@
      &                                                     kout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))),            &
      &                        ERR(ng)%Rindex
           END IF
           exit_flag=3
@@ -248,7 +265,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u2dvar
-      status=nf_fwrite2d(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(idUbar),   &
+      status=nf_fwrite2d(ng, iTLM, ERR(ng)%ncid, idUbar,                &
+     &                   ERR(ng)%Vid(idUbar),                           &
      &                   ERR(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -257,7 +275,7 @@
      &                   OCEAN(ng) % tl_ubar(:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUbar)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUbar)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -279,7 +297,7 @@
      &                                                     kout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))),            &
      &                        ERR(ng)%Rindex
           END IF
           exit_flag=3
@@ -293,7 +311,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v2dvar
-      status=nf_fwrite2d(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(idVbar),   &
+      status=nf_fwrite2d(ng, iTLM, ERR(ng)%ncid, idVbar,                &
+     &                   ERR(ng)%Vid(idVbar),                           &
      &                   ERR(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -302,7 +321,7 @@
      &                   OCEAN(ng) % tl_vbar(:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVbar)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVbar)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -324,7 +343,7 @@
      &                                                     kout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))),            &
      &                        ERR(ng)%Rindex
           END IF
           exit_flag=3
@@ -340,7 +359,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(idUvel),   &
+      status=nf_fwrite3d(ng, iTLM, ERR(ng)%ncid, idUvel,                &
+     &                   ERR(ng)%Vid(idUvel),                           &
      &                   ERR(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -349,7 +369,7 @@
      &                   OCEAN(ng) % tl_u(:,:,:,nout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUvel)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUvel)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -371,7 +391,7 @@
      &                                                  nout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))),            &
      &                        ERR(ng)%Rindex
           END IF
           exit_flag=3
@@ -385,7 +405,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(idVvel),   &
+      status=nf_fwrite3d(ng, iTLM, ERR(ng)%ncid, idVvel,                &
+     &                   ERR(ng)%Vid(idVvel),                           &
      &                   ERR(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -394,7 +415,7 @@
      &                   OCEAN(ng) % tl_v(:,:,:,nout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVvel)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVvel)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -416,7 +437,7 @@
      &                                                  nout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))),            &
      &                        ERR(ng)%Rindex
           END IF
           exit_flag=3
@@ -431,7 +452,8 @@
       DO itrc=1,NT(ng)
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Tid(itrc),   &
+        status=nf_fwrite3d(ng, iTLM, ERR(ng)%ncid, idTvar(itrc),        &
+     &                     ERR(ng)%Tid(itrc),                           &
      &                     ERR(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -440,7 +462,7 @@
      &                     OCEAN(ng) % tl_t(:,:,:,nout,itrc))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),              &
+            WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),              &
      &                        ERR(ng)%Rindex
           END IF
           exit_flag=3
@@ -466,7 +488,7 @@
      &                                                    nout,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
+              WRITE (stdout,20) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
      &                          ERR(ng)%Rindex
             END IF
             exit_flag=3
@@ -487,7 +509,7 @@
         IF (Lstflux(itrc,ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, iTLM, ERR(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iTLM, ERR(ng)%ncid, idTsur(itrc),      &
      &                       ERR(ng)%Vid(idTsur(itrc)),                 &
      &                       ERR(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -497,7 +519,7 @@
      &                       FORCES(ng) % tl_tflux(:,:,:,kout,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          ERR(ng)%Rindex
             END IF
             exit_flag=3
@@ -516,7 +538,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(idUsms),   &
+      status=nf_fwrite3d(ng, iTLM, ERR(ng)%ncid, idUsms,                &
+     &                   ERR(ng)%Vid(idUsms),                           &
      &                   ERR(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -525,7 +548,7 @@
      &                   FORCES(ng) % tl_ustr(:,:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -536,7 +559,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(idVsms),   &
+      status=nf_fwrite3d(ng, iTLM, ERR(ng)%ncid, idVsms,                &
+     &                   ERR(ng)%Vid(idVsms),                           &
      &                   ERR(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -545,7 +569,7 @@
      &                   FORCES(ng) % tl_vstr(:,:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -560,38 +584,23 @@
 !
       CALL netcdf_sync (ng, iTLM, ERR(ng)%name, ERR(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-# ifdef SOLVE3D
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, nout, ERR(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) kout, nout, ERR(ng)%Rindex
-#  endif
-# else
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, ERR(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) kout, ERR(ng)%Rindex
-#  endif
-# endif
 !
-  10  FORMAT (/,' WRT_ERROR_NF90 - error while writing variable: ',a,   &
+  10  FORMAT (2x,'WRT_ERROR_NF90   - writing error', t42,               &
+#  ifdef SOLVE3D
+#   ifdef NESTING
+     &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
+#   else
+     &        'fields (Index=',i1,',',i1,') in record = ',i0)
+#   endif
+#  else
+#   ifdef NESTING
+     &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
+#   else
+     &        'fields (Index=',i1,')   in record = ',i0)
+#   endif
+#  endif
+  20  FORMAT (/,' WRT_ERROR_NF90 - error while writing variable: ',a,   &
      &        /,18x,'into 4DVar error NetCDF file for time record: ',i0)
-# ifdef SOLVE3D
-  20  FORMAT (2x,'WRT_ERROR_NF90   - wrote error    fields (Index=', i1,&
-#  ifdef NESTING
-     &        ',',i1,') into time record = ',i0,2x,i2.2)
-#  else
-     &        ',',i1,') into time record = ',i0)
-#  endif
-# else
-  20  FORMAT (2x,'WRT_ERROR_NF90   - wrote error    fields (Index=', i1,&
-#  ifdef NESTING
-     &        ') into time record = ',i0,2x,i2.2)
-#  else
-     &        ') into time record = ',i0)
-#  endif
-# endif
 !
       RETURN
       END SUBROUTINE wrt_error_nf90
@@ -644,6 +653,22 @@
       Fcount=ERR(ng)%Fcount
       ERR(ng)%Nrec(Fcount)=ERR(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+#  ifdef SOLVE3D
+#   ifdef NESTING
+      IF (Master) WRITE (stdout,20) kout, nout, ERR(ng)%Rindex, ng
+#   else
+      IF (Master) WRITE (stdout,20) kout, nout, ERR(ng)%Rindex
+#   endif
+#  else
+#   ifdef NESTING
+      IF (Master) WRITE (stdout,20) kout, ERR(ng)%Rindex, ng
+#   else
+      IF (Master) WRITE (stdout,20) kout, ERR(ng)%Rindex
+#   endif
+#  endif
+!
 !  Write out model time (s).
 !
       CALL pio_netcdf_put_fvar (ng, iTLM, ERR(ng)%name,                 &
@@ -682,7 +707,7 @@
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iTLM, ERR(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iTLM, ERR(ng)%pioFile, idFsur,             &
      &                   ERR(ng)%pioVar(idFsur),                        &
      &                   ERR(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -693,7 +718,7 @@
      &                   OCEAN(ng)% tl_zeta(:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idFsur)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idFsur)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -723,7 +748,7 @@
      &                                                     kout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))),            &
      &                        ERR(ng)%Rindex
           END IF
           exit_flag=3
@@ -742,7 +767,7 @@
         ioDesc => ioDesc_sp_u2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iTLM, ERR(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iTLM, ERR(ng)%pioFile, idUbar,             &
      &                   ERR(ng)%pioVar(idUbar),                        &
      &                   ERR(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -753,7 +778,7 @@
      &                   OCEAN(ng) % tl_ubar(:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUbar)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUbar)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -783,7 +808,7 @@
      &                                                     kout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))),            &
      &                        ERR(ng)%Rindex
           END IF
           exit_flag=3
@@ -802,7 +827,7 @@
         ioDesc => ioDesc_sp_v2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iTLM, ERR(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iTLM, ERR(ng)%pioFile, idVbar,             &
      &                   ERR(ng)%pioVar(idVbar),                        &
      &                   ERR(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -813,7 +838,7 @@
      &                   OCEAN(ng) % tl_vbar(:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVbar)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVbar)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -843,7 +868,7 @@
      &                                                     kout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))),            &
      &                        ERR(ng)%Rindex
           END IF
           exit_flag=3
@@ -864,7 +889,7 @@
         ioDesc => ioDesc_sp_u3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iTLM, ERR(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iTLM, ERR(ng)%pioFile, idUvel,             &
      &                   ERR(ng)%pioVar(idUvel),                        &
      &                   ERR(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -875,7 +900,7 @@
      &                   OCEAN(ng) % tl_u(:,:,:,nout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUvel)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUvel)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -905,7 +930,7 @@
      &                                                  nout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))),            &
      &                        ERR(ng)%Rindex
           END IF
           exit_flag=3
@@ -924,7 +949,7 @@
         ioDesc => ioDesc_sp_v3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iTLM, ERR(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iTLM, ERR(ng)%pioFile, idVvel,             &
      &                   ERR(ng)%pioVar(idVvel),                        &
      &                   ERR(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -935,7 +960,7 @@
      &                   OCEAN(ng) % tl_v(:,:,:,nout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVvel)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVvel)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -965,7 +990,7 @@
      &                                                  nout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))),            &
      &                        ERR(ng)%Rindex
           END IF
           exit_flag=3
@@ -985,7 +1010,7 @@
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iTLM, ERR(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iTLM, ERR(ng)%pioFile, idTvar(itrc),     &
      &                     ERR(ng)%pioTrc(itrc),                        &
      &                     ERR(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -996,7 +1021,7 @@
      &                     OCEAN(ng) % tl_t(:,:,:,nout,itrc))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),              &
+            WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),              &
      &                        ERR(ng)%Rindex
           END IF
           exit_flag=3
@@ -1031,7 +1056,7 @@
      &                                                    nout,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield), ERR(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield), ERR(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1056,7 +1081,7 @@
             ioDesc => ioDesc_sp_r2dfrc(ng)
           END IF
 !
-          status=nf_fwrite3d(ng, iTLM, ERR(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iTLM, ERR(ng)%pioFile, idTsur(itrc),   &
      &                       ERR(ng)%pioVar(idTsur(itrc)),              &
      &                       ERR(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -1067,7 +1092,7 @@
      &                       FORCES(ng) % tl_tflux(:,:,:,kout,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          ERR(ng)%Rindex
             END IF
             exit_flag=3
@@ -1091,7 +1116,7 @@
         ioDesc => ioDesc_sp_u2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iTLM, ERR(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iTLM, ERR(ng)%pioFile, idUsms,             &
      &                   ERR(ng)%pioVar(idUsms),                        &
      &                   ERR(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1102,7 +1127,7 @@
      &                   FORCES(ng) % tl_ustr(:,:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1118,7 +1143,7 @@
         ioDesc => ioDesc_sp_v2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iTLM, ERR(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iTLM, ERR(ng)%pioFile, idVsms,             &
      &                   ERR(ng)%pioVar(idVsms),                        &
      &                   ERR(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1129,7 +1154,7 @@
      &                   FORCES(ng) % tl_vstr(:,:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), ERR(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), ERR(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1144,38 +1169,23 @@
 !
       CALL pio_netcdf_sync (ng, iTLM, ERR(ng)%name, ERR(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-#  ifdef SOLVE3D
-#   ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, nout, ERR(ng)%Rindex, ng
-#   else
-      IF (Master) WRITE (stdout,20) kout, nout, ERR(ng)%Rindex
-#   endif
-#  else
-#   ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, ERR(ng)%Rindex, ng
-#   else
-      IF (Master) WRITE (stdout,20) kout, ERR(ng)%Rindex
-#   endif
-#  endif
 !
-  10  FORMAT (/,' WRT_ERROR_PIO - error while writing variable: ',a,    &
-     &        /,18x,'into 4DVar error NetCDF file for time record: ',i0)
+  10  FORMAT (2x,'WRT_ERROR_PIO    - writing error', t42,               &
 #  ifdef SOLVE3D
-  20  FORMAT (2x,'WRT_ERROR_PIO    - wrote error    fields (Index=', i1,&
 #   ifdef NESTING
-     &        ',',i1,') into time record = ',i0,2x,i2.2)
+     &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
 #   else
-     &        ',',i1,') into time record = ',i0)
+     &        'fields (Index=',i1,',',i1,') in record = ',i0)
 #   endif
 #  else
-  20  FORMAT (2x,'WRT_ERROR_PIO    - wrote error    fields (Index=', i1,&
 #   ifdef NESTING
-     &        ') into time record = ',i0,2x,i2.2)
+     &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
 #   else
-     &        ') into time record = ',i0)
+     &        'fields (Index=',i1,')   in record = ',i0)
 #   endif
 #  endif
+  20  FORMAT (/,' WRT_ERROR_PIO - error while writing variable: ',a,    &
+     &        /,18x,'into 4DVar error NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_error_pio

--- a/ROMS/Utility/wrt_evolved.F
+++ b/ROMS/Utility/wrt_evolved.F
@@ -3,7 +3,7 @@
 #if (defined I4DVAR && defined EVOLVED_LCZ) || defined LCZ_FINAL
 !
 !git $Id$
-!svn $Id: wrt_evolved.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: wrt_evolved.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -163,6 +163,22 @@
       Fcount=LZE(ng)%Fcount
       LZE(ng)%Nrec(Fcount)=LZE(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+# ifdef SOLVE3D
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, nout, LZE(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) kout, nout, LZE(ng)%Rindex
+#  endif
+# else
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, LZE(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) kout, LZE(ng)%Rindex
+#  endif
+# endif
+!
 !  Write out model time (s).
 !
       CALL netcdf_put_fvar (ng, iADM, LZE(ng)%name,                     &
@@ -176,7 +192,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, iADM, LZE(ng)%ncid, LZE(ng)%Vid(idFsur),   &
+      status=nf_fwrite2d(ng, iADM, LZE(ng)%ncid, idFsur,                &
+     &                   LZE(ng)%Vid(idFsur),                           &
      &                   LZE(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -185,7 +202,7 @@
      &                   OCEAN(ng)% tl_zeta(:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idFsur)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idFsur)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -207,7 +224,7 @@
      &                                                     kout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))),            &
      &                        LZE(ng)%Rindex
           END IF
           exit_flag=3
@@ -221,7 +238,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u2dvar
-      status=nf_fwrite2d(ng, iADM, LZE(ng)%ncid, LZE(ng)%Vid(idUbar),   &
+      status=nf_fwrite2d(ng, iADM, LZE(ng)%ncid, idUbar,                &
+     &                   LZE(ng)%Vid(idUbar),                           &
      &                   LZE(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -230,7 +248,7 @@
      &                   OCEAN(ng) % tl_ubar(:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUbar)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUbar)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -252,7 +270,7 @@
      &                                                     kout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))),            &
      &                        LZE(ng)%Rindex
           END IF
           exit_flag=3
@@ -266,7 +284,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v2dvar
-      status=nf_fwrite2d(ng, iADM, LZE(ng)%ncid, LZE(ng)%Vid(idVbar),   &
+      status=nf_fwrite2d(ng, iADM, LZE(ng)%ncid, idVbar,                &
+     &                   LZE(ng)%Vid(idVbar),                           &
      &                   LZE(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -275,7 +294,7 @@
      &                   OCEAN(ng) % tl_vbar(:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVbar)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVbar)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -297,7 +316,7 @@
      &                                                     kout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))),            &
      &                        LZE(ng)%Rindex
           END IF
           exit_flag=3
@@ -313,7 +332,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iADM, LZE(ng)%ncid, LZE(ng)%Vid(idUvel),   &
+      status=nf_fwrite3d(ng, iADM, LZE(ng)%ncid, idUvel,                &
+     &                   LZE(ng)%Vid(idUvel),                           &
      &                   LZE(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -322,7 +342,7 @@
      &                   OCEAN(ng) % tl_u(:,:,:,nout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUvel)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUvel)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -344,7 +364,7 @@
      &                                                  nout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))),            &
      &                        LZE(ng)%Rindex
           END IF
           exit_flag=3
@@ -358,7 +378,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iADM, LZE(ng)%ncid, LZE(ng)%Vid(idVvel),   &
+      status=nf_fwrite3d(ng, iADM, LZE(ng)%ncid, idVvel,                &
+     &                   LZE(ng)%Vid(idVvel),                           &
      &                   LZE(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -367,7 +388,7 @@
      &                   OCEAN(ng) % tl_v(:,:,:,nout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVvel)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVvel)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -389,7 +410,7 @@
      &                                                  nout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))),            &
      &                        LZE(ng)%Rindex
           END IF
           exit_flag=3
@@ -404,7 +425,8 @@
       DO itrc=1,NT(ng)
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, iADM, LZE(ng)%ncid, LZE(ng)%Tid(itrc),   &
+        status=nf_fwrite3d(ng, iADM, LZE(ng)%ncid, idTvar(itrc),        &
+     &                     LZE(ng)%Tid(itrc),                           &
      &                     LZE(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -413,7 +435,7 @@
      &                     OCEAN(ng) % tl_t(:,:,:,nout,itrc))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),              &
+            WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),              &
      &                        LZE(ng)%Rindex
           END IF
           exit_flag=3
@@ -439,7 +461,7 @@
      &                                                    nout,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
+              WRITE (stdout,20) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
      &                          LZE(ng)%Rindex
             END IF
             exit_flag=3
@@ -460,7 +482,7 @@
         IF (Lstflux(itrc,ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, iADM, LZE(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iADM, LZE(ng)%ncid, idTsur(itrc),      &
      &                       LZE(ng)%Vid(idTsur(itrc)),                 &
      &                       LZE(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -470,7 +492,7 @@
      &                       FORCES(ng) % tl_tflux(:,:,:,kout,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          LZE(ng)%Rindex
             END IF
             exit_flag=3
@@ -489,7 +511,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iADM, LZE(ng)%ncid, LZE(ng)%Vid(idUsms),   &
+      status=nf_fwrite3d(ng, iADM, LZE(ng)%ncid, idUsms,                &
+     &                   LZE(ng)%Vid(idUsms),                           &
      &                   LZE(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -498,7 +521,7 @@
      &                   FORCES(ng) % tl_ustr(:,:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -509,7 +532,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iADM, LZE(ng)%ncid, LZE(ng)%Vid(idVsms),   &
+      status=nf_fwrite3d(ng, iADM, LZE(ng)%ncid, idVsms,                &
+     &                   LZE(ng)%Vid(idVsms),                           &
      &                   LZE(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -518,7 +542,7 @@
      &                   FORCES(ng) % tl_vstr(:,:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -533,38 +557,23 @@
 !
       CALL netcdf_sync (ng, iADM, LZE(ng)%name, LZE(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-# ifdef SOLVE3D
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, nout, LZE(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) kout, nout, LZE(ng)%Rindex
-#  endif
-# else
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, LZE(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) kout, LZE(ng)%Rindex
-#  endif
-# endif
 !
-  10  FORMAT (/,' WRT_EVOLVED_NF90 - error while writing variable: ',a, &
-     &        /,20x,'into evolved LCZ NetCDF file for time record: ',i0)
+  10  FORMAT (2x,'WRT_EVOLVED_NF90 - writing evolved LCZ',t42,          &
 # ifdef SOLVE3D
-  20  FORMAT (2x,'WRT_EVOLVED_NF90 - wrote evolved LCZ',t40,            &
 #  ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
 #  else
      &        'fields (Index=',i1,',',i1,') in record = ',i0)
 #  endif
 # else
-  20  FORMAT (2x,'WRT_EVOLVED_NF90 - wrote evolved LCZ',t40,            &
 #  ifdef NESTING
      &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
 #  else
      &        'fields (Index=',i1,')   in record = ',i0)
 #  endif
 # endif
+  20  FORMAT (/,' WRT_EVOLVED_NF90 - error while writing variable: ',a, &
+     &        /,20x,'into evolved LCZ NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_evolved_nf90
@@ -617,6 +626,22 @@
       Fcount=LZE(ng)%Fcount
       LZE(ng)%Nrec(Fcount)=LZE(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+#  ifdef SOLVE3D
+#   ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, nout, LZE(ng)%Rindex, ng
+#   else
+      IF (Master) WRITE (stdout,10) kout, nout, LZE(ng)%Rindex
+#   endif
+#  else
+#   ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, LZE(ng)%Rindex, ng
+#   else
+      IF (Master) WRITE (stdout,10) kout, LZE(ng)%Rindex
+#   endif
+#  endif
+!
 !  Write out model time (s).
 !
       CALL pio_netcdf_put_fvar (ng, iADM, LZE(ng)%name,                 &
@@ -635,7 +660,7 @@
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iADM, LZE(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iADM, LZE(ng)%pioFile, idFsur,             &
      &                   LZE(ng)%pioVar(idFsur),                        &
      &                   LZE(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -646,7 +671,7 @@
      &                   OCEAN(ng)% tl_zeta(:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idFsur)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idFsur)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -676,7 +701,7 @@
      &                                                     kout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))),            &
      &                        LZE(ng)%Rindex
           END IF
           exit_flag=3
@@ -695,7 +720,7 @@
         ioDesc => ioDesc_sp_u2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iADM, LZE(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iADM, LZE(ng)%pioFile, idUbar,             &
      &                   LZE(ng)%pioVar(idUbar),                        &
      &                   LZE(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -706,7 +731,7 @@
      &                   OCEAN(ng) % tl_ubar(:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUbar)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUbar)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -736,7 +761,7 @@
      &                                                     kout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))),            &
      &                        LZE(ng)%Rindex
           END IF
           exit_flag=3
@@ -755,7 +780,7 @@
         ioDesc => ioDesc_sp_v2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iADM, LZE(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iADM, LZE(ng)%pioFile, idVbar,             &
      &                   LZE(ng)%pioVar(idVbar),                        &
      &                   LZE(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -766,7 +791,7 @@
      &                   OCEAN(ng) % tl_vbar(:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVbar)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVbar)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -796,7 +821,7 @@
      &                                                     kout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))),            &
      &                        LZE(ng)%Rindex
           END IF
           exit_flag=3
@@ -817,7 +842,7 @@
         ioDesc => ioDesc_sp_u3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iADM, LZE(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iADM, LZE(ng)%pioFile, idUvel,             &
      &                   LZE(ng)%pioVar(idUvel),                        &
      &                   LZE(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -828,7 +853,7 @@
      &                   OCEAN(ng) % tl_u(:,:,:,nout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUvel)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUvel)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -858,7 +883,7 @@
      &                                                  nout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))),            &
      &                        LZE(ng)%Rindex
           END IF
           exit_flag=3
@@ -877,7 +902,7 @@
         ioDesc => ioDesc_sp_v3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iADM, LZE(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iADM, LZE(ng)%pioFile, idVvel,             &
      &                   LZE(ng)%pioVar(idVvel),                        &
      &                   LZE(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -888,7 +913,7 @@
      &                   OCEAN(ng) % tl_v(:,:,:,nout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVvel)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVvel)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -918,7 +943,7 @@
      &                                                  nout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))),            &
      &                        LZE(ng)%Rindex
           END IF
           exit_flag=3
@@ -938,7 +963,7 @@
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iADM, LZE(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iADM, LZE(ng)%pioFile, idTvar(itrc),     &
      &                     LZE(ng)%pioTrc(itrc),                        &
      &                     LZE(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -949,7 +974,7 @@
      &                     OCEAN(ng) % tl_t(:,:,:,nout,itrc))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),              &
+            WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),              &
      &                        LZE(ng)%Rindex
           END IF
           exit_flag=3
@@ -984,7 +1009,7 @@
      &                                                    nout,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield), LZE(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield), LZE(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1009,7 +1034,7 @@
             ioDesc => ioDesc_sp_r2dfrc(ng)
           END IF
 !
-          status=nf_fwrite3d(ng, iADM, LZE(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iADM, LZE(ng)%pioFile, idTsur(itrc),   &
      &                       LZE(ng)%pioVar(idTsur(itrc)),              &
      &                       LZE(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -1020,7 +1045,7 @@
      &                       FORCES(ng) % tl_tflux(:,:,:,kout,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          LZE(ng)%Rindex
             END IF
             exit_flag=3
@@ -1044,7 +1069,7 @@
         ioDesc => ioDesc_sp_u2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iADM, LZE(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iADM, LZE(ng)%pioFile, idUsms,             &
      &                   LZE(ng)%pioVar(idUsms),                        &
      &                   LZE(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1055,7 +1080,7 @@
      &                   FORCES(ng) % tl_ustr(:,:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1071,7 +1096,7 @@
         ioDesc => ioDesc_sp_v2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iADM, LZE(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iADM, LZE(ng)%pioFile, idVsms,             &
      &                   LZE(ng)%pioVar(idVsms),                        &
      &                   LZE(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1082,7 +1107,7 @@
      &                   FORCES(ng) % tl_vstr(:,:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), LZE(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), LZE(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1097,38 +1122,23 @@
 !
       CALL pio_netcdf_sync (ng, iADM, LZE(ng)%name, LZE(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-#  ifdef SOLVE3D
-#   ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, nout, LZE(ng)%Rindex, ng
-#   else
-      IF (Master) WRITE (stdout,20) kout, nout, LZE(ng)%Rindex
-#   endif
-#  else
-#   ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, LZE(ng)%Rindex, ng
-#   else
-      IF (Master) WRITE (stdout,20) kout, LZE(ng)%Rindex
-#   endif
-#  endif
 !
-  10  FORMAT (/,' WRT_EVOLVED_PIO - error while writing variable: ',a,  &
-     &        /,20x,'into evolved LCZ NetCDF file for time record: ',i0)
+  10  FORMAT (2x,'WRT_EVOLVED_PIO  - writing evolved LCZ',t42,          &
 #  ifdef SOLVE3D
-  20  FORMAT (2x,'WRT_EVOLVED_PIO  - wrote evolved LCZ',t40,            &
 #   ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
 #   else
      &        'fields (Index=',i1,',',i1,') in record = ',i0)
 #   endif
 #  else
-  20  FORMAT (2x,'WRT_EVOLVED_PIO  - wrote evolved LCZ',t40,            &
 #   ifdef NESTING
      &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
 #   else
      &        'fields (Index=',i1,')   in record = ',i0)
 #   endif
 #  endif
+  20  FORMAT (/,' WRT_EVOLVED_PIO - error while writing variable: ',a,  &
+     &        /,20x,'into evolved LCZ NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_evolved_pio

--- a/ROMS/Utility/wrt_gst.F
+++ b/ROMS/Utility/wrt_gst.F
@@ -3,7 +3,7 @@
 #if defined PROPAGATOR && defined CHECKPOINTING
 !
 !git $Id$
-!svn $Id: wrt_gst.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: wrt_gst.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -110,6 +110,10 @@
 !-----------------------------------------------------------------------
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+!
+!  Report.
+!
+      IF (Master) WRITE (stdout,10) Nrun+1
 !
 !  Write out number of eigenvalues to compute.
 !
@@ -311,10 +315,8 @@
 !
       CALL netcdf_sync (ng, model, GST(ng)%name, GST(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-      IF (Master) WRITE (stdout,10) Nrun+1
 !
-  10  FORMAT (2x,'WRT_GST_NF90     - wrote GST checkpointing fields',   &
+  10  FORMAT (2x,'WRT_GST_NF90     - writing GST checkpointing fields', &
      &        ' at iteration: ', i0)
 
       RETURN
@@ -354,6 +356,10 @@
 !-----------------------------------------------------------------------
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+!
+!  Report.
+!
+      IF (Master) WRITE (stdout,10) Nrun+1
 !
 !  Write out number of eigenvalues to compute.
 !
@@ -595,10 +601,8 @@
 !
       CALL pio_netcdf_sync (ng, model, GST(ng)%name, GST(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-      IF (Master) WRITE (stdout,10) Nrun+1
 !
-  10  FORMAT (2x,'WRT_GST_PIO      - wrote GST checkpointing fields',   &
+  10  FORMAT (2x,'WRT_GST_PIO      - writing GST checkpointing fields', &
      &        ' at iteration: ', i0)
 
       RETURN

--- a/ROMS/Utility/wrt_hessian.F
+++ b/ROMS/Utility/wrt_hessian.F
@@ -6,7 +6,7 @@
       defined POSTERIOR_ERROR_F)) || defined LCZ_FINAL
 !
 !git $Id$
-!svn $Id: wrt_hessian.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: wrt_hessian.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -170,6 +170,22 @@
       Fcount=HSS(ng)%Fcount
       HSS(ng)%Nrec(Fcount)=HSS(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+# ifdef SOLVE3D
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, nout, HSS(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) kout, nout, HSS(ng)%Rindex
+#  endif
+# else
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, HSS(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) kout, HSS(ng)%Rindex
+#  endif
+# endif
+!
 !  Write out model time (s).
 !
       CALL netcdf_put_fvar (ng, iADM, HSS(ng)%name,                     &
@@ -183,7 +199,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(idFsur),   &
+      status=nf_fwrite2d(ng, iADM, HSS(ng)%ncid, idFsur,                &
+     &                   HSS(ng)%Vid(idFsur),                           &
      &                   HSS(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -192,7 +209,7 @@
      &                   OCEAN(ng)% ad_zeta(:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idFsur)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idFsur)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -214,7 +231,7 @@
      &                                                     kout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))),            &
      &                        HSS(ng)%Rindex
           END IF
           exit_flag=3
@@ -228,7 +245,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u2dvar
-      status=nf_fwrite2d(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(idUbar),   &
+      status=nf_fwrite2d(ng, iADM, HSS(ng)%ncid, idUbar,                &
+     &                   HSS(ng)%Vid(idUbar),                           &
      &                   HSS(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -237,7 +255,7 @@
      &                   OCEAN(ng) % ad_ubar(:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUbar)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUbar)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -259,7 +277,7 @@
      &                                                     kout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))),            &
      &                        HSS(ng)%Rindex
           END IF
           exit_flag=3
@@ -273,7 +291,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v2dvar
-      status=nf_fwrite2d(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(idVbar),   &
+      status=nf_fwrite2d(ng, iADM, HSS(ng)%ncid, idVbar,                &
+     &                   HSS(ng)%Vid(idVbar),                           &
      &                   HSS(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -282,7 +301,7 @@
      &                   OCEAN(ng) % ad_vbar(:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVbar)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVbar)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -304,7 +323,7 @@
      &                                                     kout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))),            &
      &                        HSS(ng)%Rindex
           END IF
           exit_flag=3
@@ -320,7 +339,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(idUvel),   &
+      status=nf_fwrite3d(ng, iADM, HSS(ng)%ncid, idUvel,                &
+     &                   HSS(ng)%Vid(idUvel),                           &
      &                   HSS(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -329,7 +349,7 @@
      &                   OCEAN(ng) % ad_u(:,:,:,nout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUvel)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUvel)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -351,7 +371,7 @@
      &                                                  nout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))),            &
      &                        HSS(ng)%Rindex
           END IF
           exit_flag=3
@@ -365,7 +385,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(idVvel),   &
+      status=nf_fwrite3d(ng, iADM, HSS(ng)%ncid, idVvel,                &
+     &                   HSS(ng)%Vid(idVvel),                           &
      &                   HSS(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -374,7 +395,7 @@
      &                   OCEAN(ng) % ad_v(:,:,:,nout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVvel)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVvel)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -396,7 +417,7 @@
      &                                                  nout))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))),            &
      &                        HSS(ng)%Rindex
           END IF
           exit_flag=3
@@ -411,7 +432,8 @@
       DO itrc=1,NT(ng)
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, iADM, HSS(ng)%ncid, HSS(ng)%Tid(itrc),   &
+        status=nf_fwrite3d(ng, iADM, HSS(ng)%ncid, idTvar(itrc),        &
+     &                     HSS(ng)%Tid(itrc),                           &
      &                     HSS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -420,7 +442,7 @@
      &                     OCEAN(ng) % ad_t(:,:,:,nout,itrc))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),              &
+            WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),              &
      &                        HSS(ng)%Rindex
           END IF
           exit_flag=3
@@ -446,7 +468,7 @@
      &                                                    nout,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
+              WRITE (stdout,20) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
      &                          HSS(ng)%Rindex
             END IF
             exit_flag=3
@@ -467,7 +489,7 @@
         IF (Lstflux(itrc,ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, iADM, HSS(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iADM, HSS(ng)%ncid, idTsur(itrc),      &
      &                       HSS(ng)%Vid(idTsur(itrc)),                 &
      &                       HSS(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -477,7 +499,7 @@
      &                       FORCES(ng) % ad_tflux(:,:,:,kout,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          HSS(ng)%Rindex
             END IF
             exit_flag=3
@@ -496,7 +518,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(idUsms),   &
+      status=nf_fwrite3d(ng, iADM, HSS(ng)%ncid, idUsms,                &
+     &                   HSS(ng)%Vid(idUsms),                           &
      &                   HSS(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -505,7 +528,7 @@
      &                   FORCES(ng) % ad_ustr(:,:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -516,7 +539,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(idVsms),   &
+      status=nf_fwrite3d(ng, iADM, HSS(ng)%ncid, idVsms,                &
+     &                   HSS(ng)%Vid(idVsms),                           &
      &                   HSS(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #  ifdef MASKING
@@ -525,7 +549,7 @@
      &                   FORCES(ng) % ad_vstr(:,:,:,kout))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -540,38 +564,23 @@
 !
       CALL netcdf_sync (ng, iADM, HSS(ng)%name, HSS(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-# ifdef SOLVE3D
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, nout, HSS(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) kout, nout, HSS(ng)%Rindex
-#  endif
-# else
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, HSS(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) kout, HSS(ng)%Rindex
-#  endif
-# endif
 !
-  10  FORMAT (/,' WRT_HESSIAN_NF90 - error while writing variable: ',a, &
-     &        /,20x,'into Hessian NetCDF file for time record: ',i0)
+  10  FORMAT (2x,'WRT_HESSIAN_NF90 - writing Hessian', t42,             &
 # ifdef SOLVE3D
-  20  FORMAT (2x,'WRT_HESSIAN_NF90 - wrote Hessian', t40,               &
 #  ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
 #  else
      &        'fields (Index=',i1,',',i1,') in record = ',i0)
 #  endif
 # else
-  20  FORMAT (2x,'WRT_HESSIAN_NF90 - wrote Hessian', t40,               &
 #  ifdef NESTING
      &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
 #  else
      &        'fields (Index=',i1,')   in record = ',i0)
 #  endif
 # endif
+  20  FORMAT (/,' WRT_HESSIAN_NF90 - error while writing variable: ',a, &
+     &        /,20x,'into Hessian NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_hessian_nf90
@@ -624,6 +633,22 @@
       Fcount=HSS(ng)%Fcount
       HSS(ng)%Nrec(Fcount)=HSS(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+#  ifdef SOLVE3D
+#   ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, nout, HSS(ng)%Rindex, ng
+#   else
+      IF (Master) WRITE (stdout,10) kout, nout, HSS(ng)%Rindex
+#   endif
+#  else
+#   ifdef NESTING
+      IF (Master) WRITE (stdout,10) kout, HSS(ng)%Rindex, ng
+#   else
+      IF (Master) WRITE (stdout,10) kout, HSS(ng)%Rindex
+#   endif
+#  endif
+!
 !  Write out model time (s).
 !
       CALL pio_netcdf_put_fvar (ng, iADM, HSS(ng)%name,                 &
@@ -642,7 +667,7 @@
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iADM, HSS(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iADM, HSS(ng)%pioFile, idFsur,             &
      &                   HSS(ng)%pioVar(idFsur),                        &
      &                   HSS(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -653,7 +678,7 @@
      &                   OCEAN(ng)% ad_zeta(:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idFsur)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idFsur)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -683,7 +708,7 @@
      &                                                     kout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))),            &
      &                        HSS(ng)%Rindex
           END IF
           exit_flag=3
@@ -702,7 +727,7 @@
         ioDesc => ioDesc_sp_u2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iADM, HSS(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iADM, HSS(ng)%pioFile, idUbar,             &
      &                   HSS(ng)%pioVar(idUbar),                        &
      &                   HSS(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -713,7 +738,7 @@
      &                   OCEAN(ng) % ad_ubar(:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUbar)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUbar)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -743,7 +768,7 @@
      &                                                     kout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))),            &
      &                        HSS(ng)%Rindex
           END IF
           exit_flag=3
@@ -762,7 +787,7 @@
         ioDesc => ioDesc_sp_v2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iADM, HSS(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iADM, HSS(ng)%pioFile, idVbar,             &
      &                   HSS(ng)%pioVar(idVbar),                        &
      &                   HSS(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -773,7 +798,7 @@
      &                   OCEAN(ng) % ad_vbar(:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVbar)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVbar)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -803,7 +828,7 @@
      &                                                     kout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))),            &
      &                        HSS(ng)%Rindex
           END IF
           exit_flag=3
@@ -824,7 +849,7 @@
         ioDesc => ioDesc_sp_u3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iADM, HSS(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iADM, HSS(ng)%pioFile, idUvel,             &
      &                   HSS(ng)%pioVar(idUvel),                        &
      &                   HSS(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -835,7 +860,7 @@
      &                   OCEAN(ng) % ad_u(:,:,:,nout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUvel)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUvel)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -865,7 +890,7 @@
      &                                                  nout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))),            &
      &                        HSS(ng)%Rindex
           END IF
           exit_flag=3
@@ -884,7 +909,7 @@
         ioDesc => ioDesc_sp_v3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iADM, HSS(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iADM, HSS(ng)%pioFile, idVvel,             &
      &                   HSS(ng)%pioVar(idVvel),                        &
      &                   HSS(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -895,7 +920,7 @@
      &                   OCEAN(ng) % ad_v(:,:,:,nout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVvel)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVvel)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -925,7 +950,7 @@
      &                                                  nout))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))),            &
      &                        HSS(ng)%Rindex
           END IF
           exit_flag=3
@@ -945,7 +970,7 @@
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iADM, HSS(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iADM, HSS(ng)%pioFile, idTvar(itrc),     &
      &                     HSS(ng)%pioTrc(itrc),                        &
      &                     HSS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -956,7 +981,7 @@
      &                     OCEAN(ng) % ad_t(:,:,:,nout,itrc))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),              &
+            WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),              &
      &                        HSS(ng)%Rindex
           END IF
           exit_flag=3
@@ -991,7 +1016,7 @@
      &                                                    nout,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), HSS(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), HSS(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1016,7 +1041,7 @@
             ioDesc => ioDesc_sp_r2dfrc(ng)
           END IF
 !
-          status=nf_fwrite3d(ng, iADM, HSS(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iADM, HSS(ng)%pioFile, idTsur(itrc),   &
      &                       HSS(ng)%pioVar(idTsur(itrc)),              &
      &                       HSS(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -1027,7 +1052,7 @@
      &                       FORCES(ng) % ad_tflux(:,:,:,kout,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          HSS(ng)%Rindex
             END IF
             exit_flag=3
@@ -1051,7 +1076,7 @@
         ioDesc => ioDesc_sp_u2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iADM, HSS(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iADM, HSS(ng)%pioFile, idUsms,             &
      &                   HSS(ng)%pioVar(idUsms),                        &
      &                   HSS(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1062,7 +1087,7 @@
      &                   FORCES(ng) % ad_ustr(:,:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1078,7 +1103,7 @@
         ioDesc => ioDesc_sp_v2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iADM, HSS(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iADM, HSS(ng)%pioFile, idVsms,             &
      &                   HSS(ng)%pioVar(idVsms),                        &
      &                   HSS(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1089,7 +1114,7 @@
      &                   FORCES(ng) % ad_vstr(:,:,:,kout))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), HSS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), HSS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1104,38 +1129,23 @@
 !
       CALL pio_netcdf_sync (ng, iADM, HSS(ng)%name, HSS(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-#  ifdef SOLVE3D
-#   ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, nout, HSS(ng)%Rindex, ng
-#   else
-      IF (Master) WRITE (stdout,20) kout, nout, HSS(ng)%Rindex
-#   endif
-#  else
-#   ifdef NESTING
-      IF (Master) WRITE (stdout,20) kout, HSS(ng)%Rindex, ng
-#   else
-      IF (Master) WRITE (stdout,20) kout, HSS(ng)%Rindex
-#   endif
-#  endif
 !
-  10  FORMAT (/,' WRT_HESSIAN_PIO - error while writing variable: ',a,  &
-     &        /,19x,'into Hessian NetCDF file for time record: ',i0)
+  10  FORMAT (2x,'WRT_HESSIAN_PIO  - writing Hessian', t42,            &
 #  ifdef SOLVE3D
-  20  FORMAT (2x,'WRT_HESSIAN_PIO  - wrote Hessian', t40,               &
 #   ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
 #   else
      &        'fields (Index=',i1,',',i1,') in record = ',i0)
 #   endif
 #  else
-  20  FORMAT (2x,'WRT_HESSIAN_PIO - wrote Hessian', t40,                &
 #   ifdef NESTING
      &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
 #   else
      &        'fields (Index=',i1,')   in record = ',i0)
 #   endif
 #  endif
+  20  FORMAT (/,' WRT_HESSIAN_PIO - error while writing variable: ',a,  &
+     &        /,19x,'into Hessian NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_hessian_pio

--- a/ROMS/Utility/wrt_his.F
+++ b/ROMS/Utility/wrt_his.F
@@ -2,7 +2,7 @@
       MODULE wrt_his_mod
 !
 !git $Id$
-!svn $Id: wrt_his.F 1185 2023-08-01 21:42:38Z arango $
+!svn $Id: wrt_his.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -216,6 +216,22 @@
       Fcount=HIS(ng)%load
       HIS(ng)%Nrec(Fcount)=HIS(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+#ifdef SOLVE3D
+# ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, HIS(ng)%Rindex, ng
+# else
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, HIS(ng)%Rindex
+# endif
+#else
+# ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, HIS(ng)%Rindex, ng
+# else
+      IF (Master) WRITE (stdout,10) KOUT, HIS(ng)%Rindex
+# endif
+#endif
+!
 !  Write out model time (s).
 !
       CALL netcdf_put_fvar (ng, model, HIS(ng)%name,                    &
@@ -231,7 +247,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*p2dvar
-      status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idPwet,               &
      &                   HIS(ng)%Vid(idPwet),                           &
      &                   HIS(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -242,7 +258,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idPwet)), HIS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idPwet)), HIS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -253,7 +269,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idRwet,               &
      &                   HIS(ng)%Vid(idRwet),                           &
      &                   HIS(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -264,7 +280,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRwet)), HIS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRwet)), HIS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -275,7 +291,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*u2dvar
-      status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idUwet,               &
      &                   HIS(ng)%Vid(idUwet),                           &
      &                   HIS(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -286,7 +302,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUwet)), HIS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUwet)), HIS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -297,7 +313,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*v2dvar
-      status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idVwet,               &
      &                   HIS(ng)%Vid(idVwet),                           &
      &                   HIS(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -308,7 +324,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVwet)), HIS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVwet)), HIS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -322,7 +338,7 @@
       IF (Hout(idpthR,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idpthR,             &
      &                     HIS(ng)%Vid(idpthR),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -333,7 +349,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthR)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthR)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -354,7 +370,7 @@
             END DO
           END DO
         END DO
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idpthU,             &
      &                     HIS(ng)%Vid(idpthU),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -365,7 +381,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthU)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthU)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -386,7 +402,7 @@
             END DO
           END DO
         END DO
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idpthV,             &
      &                     HIS(ng)%Vid(idpthV),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -397,7 +413,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthV)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthV)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -410,7 +426,7 @@
       IF (Hout(idpthW,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idpthW,             &
      &                     HIS(ng)%Vid(idpthW),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -421,7 +437,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthW)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthW)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -435,7 +451,7 @@
       IF (Hout(idFsur,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idFsur,             &
      &                     HIS(ng)%Vid(idFsur),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -450,14 +466,14 @@
 #endif
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idFsur)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idFsur)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
 #if defined FORWARD_WRITE && defined FORWARD_RHS
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idRzet,             &
      &                     HIS(ng)%Vid(idRzet),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -467,7 +483,7 @@
      &                     OCEAN(ng) % rzeta(:,:,KOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRzet)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRzet)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -490,7 +506,7 @@
      &                                                  Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))),            &
      &                        HIS(ng)%Rindex
           END IF
           exit_flag=3
@@ -505,7 +521,7 @@
       IF (Hout(idUbar,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idUbar,             &
      &                     HIS(ng)%Vid(idUbar),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -515,7 +531,7 @@
      &                     OCEAN(ng) % ubar(:,:,KOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbar)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbar)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -523,7 +539,7 @@
         END IF
 #ifdef FORWARD_WRITE
 # ifdef FORWARD_RHS
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idRu2d,             &
      &                     HIS(ng)%Vid(idRu2d),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -533,7 +549,7 @@
      &                     OCEAN(ng) % rubar(:,:,KOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRu2d)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRu2d)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -542,7 +558,7 @@
 # endif
 # ifdef SOLVE3D
 #  ifdef FORWARD_RHS
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idRuct,             &
      &                     HIS(ng)%Vid(idRuct),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -552,14 +568,14 @@
      &                     COUPLING(ng) % rufrc)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRuct)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRuct)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
 #  endif
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idUfx1,             &
      &                     HIS(ng)%Vid(idUfx1),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -569,13 +585,13 @@
      &                     COUPLING(ng) % DU_avg1)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUfx1)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUfx1)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idUfx2,             &
      &                     HIS(ng)%Vid(idUfx2),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -585,7 +601,7 @@
      &                     COUPLING(ng) % DU_avg2)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUfx2)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUfx2)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -609,7 +625,7 @@
      &                                                  Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))),            &
      &                        HIS(ng)%Rindex
           END IF
           exit_flag=3
@@ -624,7 +640,7 @@
       IF (Hout(idVbar,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idVbar,             &
      &                     HIS(ng)%Vid(idVbar),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -634,7 +650,7 @@
      &                     OCEAN(ng) % vbar(:,:,KOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbar)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbar)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -642,7 +658,7 @@
         END IF
 #ifdef FORWARD_WRITE
 # ifdef FORWARD_RHS
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idRv2d,             &
      &                     HIS(ng)%Vid(idRv2d),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -652,7 +668,7 @@
      &                     OCEAN(ng) % rvbar(:,:,KOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRv2d)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRv2d)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -661,7 +677,7 @@
 # endif
 # ifdef SOLVE3D
 #  ifdef FORWARD_RHS
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idRvct,             &
      &                     HIS(ng)%Vid(idRvct),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -671,14 +687,14 @@
      &                     COUPLING(ng) % rvfrc)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRvct)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRvct)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
 #  endif
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idVfx1,             &
      &                     HIS(ng)%Vid(idVfx1),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -688,13 +704,13 @@
      &                     COUPLING(ng) % DV_avg1)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVfx1)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVfx1)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idVfx2,             &
      &                     HIS(ng)%Vid(idVfx2),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -704,7 +720,7 @@
      &                     COUPLING(ng) % DV_avg2)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVfx2)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVfx2)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -728,7 +744,7 @@
      &                                                  Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))),            &
      &                        HIS(ng)%Rindex
           END IF
           exit_flag=3
@@ -763,7 +779,7 @@
 
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idu2dE,             &
      &                     HIS(ng)%Vid(idu2dE),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -773,14 +789,14 @@
      &                     Ur2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu2dE)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu2dE)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
 
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idv2dN,             &
      &                     HIS(ng)%Vid(idv2dN),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -790,7 +806,7 @@
      &                     Vr2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv2dN)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv2dN)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -807,7 +823,7 @@
       IF (Hout(idUvel,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idUvel,             &
      &                     HIS(ng)%Vid(idUvel),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -817,14 +833,14 @@
      &                     OCEAN(ng) % u(:,:,:,NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUvel)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUvel)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
 # if defined FORWARD_WRITE && defined FORWARD_RHS
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idRu3d,             &
      &                     HIS(ng)%Vid(idRu3d),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -834,7 +850,7 @@
      &                     OCEAN(ng) % ru(:,:,:,NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRu3d)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRu3d)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -857,7 +873,7 @@
      &                                               Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))),            &
      &                        HIS(ng)%Rindex
           END IF
           exit_flag=3
@@ -872,7 +888,7 @@
       IF (Hout(idVvel,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idVvel,             &
      &                     HIS(ng)%Vid(idVvel),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -882,14 +898,14 @@
      &                     OCEAN(ng) % v(:,:,:,NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvel)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvel)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
 # if defined FORWARD_WRITE && defined FORWARD_RHS
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idRv3d,             &
      &                     HIS(ng)%Vid(idRv3d),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -899,7 +915,7 @@
      &                     OCEAN(ng) % rv(:,:,:,NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRv3d)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRv3d)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -922,7 +938,7 @@
      &                                               Lbout(ng)))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))),            &
      &                        HIS(ng)%Rindex
           END IF
           exit_flag=3
@@ -957,7 +973,7 @@
 
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idu3dE,             &
      &                     HIS(ng)%Vid(idu3dE),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -967,14 +983,14 @@
      &                     Ur3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu3dE)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu3dE)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
 
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idv3dN,             &
      &                     HIS(ng)%Vid(idv3dN),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -984,7 +1000,7 @@
      &                     Vr3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv3dN)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv3dN)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1008,7 +1024,7 @@
      &                    GRID(ng) % pn,                                &
      &                    OCEAN(ng) % W,                                &
      &                    Wr3d)
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idOvel,             &
      &                     HIS(ng)%Vid(idOvel),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1018,7 +1034,7 @@
      &                     Wr3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idOvel)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idOvel)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1031,7 +1047,7 @@
 !
 !  Write out S-coordinate implicit vertical "omega" momentum component.
 !
-      IF (Hout(idOvel,ng)) THEN
+      IF (Hout(idOvil,ng)) THEN
         IF (.not.allocated(Wr3d)) THEN
           allocate (Wr3d(LBi:UBi,LBj:UBj,0:N(ng)))
           Wr3d(LBi:UBi,LBj:UBj,0:N(ng))=0.0_r8
@@ -1043,7 +1059,7 @@
      &                    GRID(ng) % pn,                                &
      &                    OCEAN(ng) % Wi,                               &
      &                    Wr3d)
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idOvil,             &
      &                     HIS(ng)%Vid(idOvil),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1053,7 +1069,7 @@
      &                     Wr3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idOvil)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idOvil)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1068,7 +1084,7 @@
       IF (Hout(idWvel,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idWvel,             &
      &                     HIS(ng)%Vid(idWvel),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1078,7 +1094,7 @@
      &                     OCEAN(ng) % wvel)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idWvel)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idWvel)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1092,7 +1108,7 @@
         IF (Hout(idTvar(itrc),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idTvar(itrc),     &
      &                       HIS(ng)%Tid(itrc),                         &
      &                       HIS(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1102,7 +1118,7 @@
      &                       OCEAN(ng) % t(:,:,:,NOUT,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),            &
      &                          HIS(ng)%Rindex
             END IF
             exit_flag=3
@@ -1130,7 +1146,7 @@
      &                                                 Lbout(ng),itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), HIS(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), HIS(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1145,7 +1161,7 @@
       IF (Hout(idDano,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idDano,             &
      &                     HIS(ng)%Vid(idDano),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1155,7 +1171,7 @@
      &                     OCEAN(ng) % rho)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idDano)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idDano)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1169,7 +1185,7 @@
       IF (Hout(idHsbl,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idHsbl,             &
      &                     HIS(ng)%Vid(idHsbl),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1179,7 +1195,7 @@
      &                     MIXING(ng) % hsbl)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHsbl)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHsbl)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1194,7 +1210,7 @@
       IF (Hout(idHbbl,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idHbbl,             &
      &                     HIS(ng)%Vid(idHbbl),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1204,7 +1220,7 @@
      &                     MIXING(ng) % hbbl)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHbbl)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHbbl)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1220,7 +1236,7 @@
         IF (Hout(idGhat(i),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*w3dvar
-          status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idGhat(i),        &
      &                       HIS(ng)%Vid(idGhat(i)),                    &
      &                       HIS(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 0, N(ng), scale,       &
@@ -1230,7 +1246,7 @@
      &                       MIXING(ng) % ghats(:,:,:,i))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idGhat(i))), HIS(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idGhat(i))), HIS(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -1245,7 +1261,7 @@
       IF (Hout(idVvis,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idVvis,             &
      &                     HIS(ng)%Vid(idVvis),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1256,7 +1272,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvis)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvis)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1269,7 +1285,7 @@
       IF (Hout(idTdif,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idTdif,             &
      &                     HIS(ng)%Vid(idTdif),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1280,7 +1296,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTdif)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTdif)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1294,7 +1310,7 @@
       IF (Hout(idSdif,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idSdif,             &
      &                     HIS(ng)%Vid(idSdif),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1305,7 +1321,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSdif)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSdif)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1320,7 +1336,7 @@
       IF (Hout(idMtke,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idMtke,             &
      &                     HIS(ng)%Vid(idMtke),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1331,7 +1347,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idMtke)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idMtke)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1340,7 +1356,7 @@
 #  ifdef FORWARD_WRITE
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idVmKK,             &
      &                     HIS(ng)%Vid(idVmKK),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1350,7 +1366,7 @@
      &                     MIXING(ng) % Akk)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVmKK)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVmKK)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1364,7 +1380,7 @@
       IF (Hout(idMtls,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idMtls,             &
      &                     HIS(ng)%Vid(idMtls),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1375,7 +1391,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idMtls)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idMtls)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1384,7 +1400,7 @@
 #  ifdef FORWARD_WRITE
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idVmLS,             &
      &                     HIS(ng)%Vid(idVmLS),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1394,7 +1410,7 @@
      &                     MIXING(ng) % Lscale)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVmLS)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVmLS)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1404,7 +1420,7 @@
 #  if defined FORWARD_WRITE && defined GLS_MIXING
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idVmKP,             &
      &                     HIS(ng)%Vid(idVmKP),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1414,7 +1430,7 @@
      &                     MIXING(ng) % Akp)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVmKP)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVmKP)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1430,7 +1446,7 @@
       IF (Hout(idPair,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idPair,             &
      &                     HIS(ng)%Vid(idPair),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1440,7 +1456,7 @@
      &                     FORCES(ng) % Pair)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idPair)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idPair)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1455,7 +1471,7 @@
       IF (Hout(idTair,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idTair,             &
      &                     HIS(ng)%Vid(idTair),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1465,7 +1481,7 @@
      &                     FORCES(ng) % Tair)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTair)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTair)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1480,7 +1496,7 @@
       IF (Hout(idUair,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idUair,             &
      &                     HIS(ng)%Vid(idUair),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1490,7 +1506,7 @@
      &                     FORCES(ng) % Uwind)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUair)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUair)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1501,7 +1517,7 @@
       IF (Hout(idVair,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idVair,             &
      &                     HIS(ng)%Vid(idVair),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1511,7 +1527,7 @@
      &                     FORCES(ng) % Vwind)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVair)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVair)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1534,7 +1550,7 @@
             scale=1.0_dp
           END IF
           gtype=gfactor*r2dvar
-          status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                   &
+          status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idTsur(itrc),     &
      &                       HIS(ng)%Vid(idTsur(itrc)),                 &
      &                       HIS(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1544,7 +1560,7 @@
      &                       FORCES(ng) % stflx(:,:,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          HIS(ng)%Rindex
             END IF
             exit_flag=3
@@ -1561,7 +1577,7 @@
       IF (Hout(idLhea,ng)) THEN
         scale=rho0*Cp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idLhea,             &
      &                     HIS(ng)%Vid(idLhea),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1571,7 +1587,7 @@
      &                     FORCES(ng) % lhflx)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idLhea)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idLhea)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1584,7 +1600,7 @@
       IF (Hout(idShea,ng)) THEN
         scale=rho0*Cp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idShea,             &
      &                     HIS(ng)%Vid(idShea),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1594,7 +1610,7 @@
      &                     FORCES(ng) % shflx)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idShea)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idShea)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1607,7 +1623,7 @@
       IF (Hout(idLrad,ng)) THEN
         scale=rho0*Cp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idLrad,             &
      &                     HIS(ng)%Vid(idLrad),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1617,7 +1633,7 @@
      &                     FORCES(ng) % lrflx)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idLrad)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idLrad)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1634,7 +1650,7 @@
       IF (Hout(idevap,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idevap,             &
      &                     HIS(ng)%Vid(idevap),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1644,7 +1660,7 @@
      &                     FORCES(ng) % evap)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idevap)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idevap)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1657,7 +1673,7 @@
       IF (Hout(idrain,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idrain,             &
      &                     HIS(ng)%Vid(idrain),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1667,7 +1683,7 @@
      &                     FORCES(ng) % rain)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idrain)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idrain)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1682,7 +1698,7 @@
       IF (Hout(idEmPf,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idEmPf,             &
      &                     HIS(ng)%Vid(idEmPf),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1692,7 +1708,7 @@
      &                     FORCES(ng) % stflux(:,:,isalt))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idEmPf)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idEmPf)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1706,7 +1722,7 @@
       IF (Hout(idSrad,ng)) THEN
         scale=rho0*Cp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idSrad,             &
      &                     HIS(ng)%Vid(idSrad),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1716,7 +1732,7 @@
      &                     FORCES(ng) % srflx)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSrad)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSrad)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1735,7 +1751,7 @@
         scale=rho0                          ! m2/s2 to Pa
 #endif
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idUsms,             &
      &                     HIS(ng)%Vid(idUsms),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1745,7 +1761,7 @@
      &                     FORCES(ng) % sustr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUsms)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUsms)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1762,7 +1778,7 @@
         scale=rho0
 #endif
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idVsms,             &
      &                     HIS(ng)%Vid(idVsms),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1772,7 +1788,7 @@
      &                     FORCES(ng) % svstr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVsms)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVsms)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1785,7 +1801,7 @@
       IF (Hout(idUbms,ng)) THEN
         scale=-rho0
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idUbms,             &
      &                     HIS(ng)%Vid(idUbms),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1795,7 +1811,7 @@
      &                     FORCES(ng) % bustr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbms)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbms)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1808,7 +1824,7 @@
       IF (Hout(idVbms,ng)) THEN
         scale=-rho0
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, HIS(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, HIS(ng)%ncid, idVbms,             &
      &                     HIS(ng)%Vid(idVbms),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1818,7 +1834,7 @@
      &                     FORCES(ng) % bvstr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbms)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbms)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1882,23 +1898,7 @@
       CALL netcdf_sync (ng, model, HIS(ng)%name, HIS(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-#ifdef SOLVE3D
-# ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, HIS(ng)%Rindex, ng
-# else
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, HIS(ng)%Rindex
-# endif
-#else
-# ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, HIS(ng)%Rindex, ng
-# else
-      IF (Master) WRITE (stdout,20) KOUT, HIS(ng)%Rindex
-# endif
-#endif
-!
-  10  FORMAT (/,' WRT_HIS_NF90 - error while writing variable: ',a,     &
-     &        /,16x,'into history NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'WRT_HIS_NF90     - wrote history', t40,               &
+  10  FORMAT (2x,'WRT_HIS_NF90     - writing history', t42,             &
 #ifdef SOLVE3D
 # ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
@@ -1912,6 +1912,8 @@
      &        'fields (Index=',i1,')   in record = ',i0)
 # endif
 #endif
+  20  FORMAT (/,' WRT_HIS_NF90 - error while writing variable: ',a,     &
+     &        /,16x,'into history NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_his_nf90
@@ -1974,6 +1976,22 @@
       Fcount=HIS(ng)%load
       HIS(ng)%Nrec(Fcount)=HIS(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+# ifdef SOLVE3D
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, HIS(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, HIS(ng)%Rindex
+#  endif
+# else
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, HIS(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) KOUT, HIS(ng)%Rindex
+#  endif
+# endif
+!
 !  Write out model time (s).
 !
       CALL pio_netcdf_put_fvar (ng, model, HIS(ng)%name,                &
@@ -1993,7 +2011,7 @@
       ELSE
         ioDesc => ioDesc_sp_p2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idPwet,            &
      &                   HIS(ng)%pioVar(idPwet),                        &
      &                   HIS(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -2005,7 +2023,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idPwet)), HIS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idPwet)), HIS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -2020,7 +2038,7 @@
       ELSE
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idRwet,            &
      &                   HIS(ng)%pioVar(idRwet),                        &
      &                   HIS(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -2032,7 +2050,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRwet)), HIS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRwet)), HIS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -2047,7 +2065,7 @@
       ELSE
         ioDesc => ioDesc_sp_u2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idUwet,            &
      &                   HIS(ng)%pioVar(idUwet),                        &
      &                   HIS(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -2059,7 +2077,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUwet)), HIS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUwet)), HIS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -2074,7 +2092,7 @@
       ELSE
         ioDesc => ioDesc_sp_v2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idVwet,            &
      &                   HIS(ng)%pioVar(idVwet),                        &
      &                   HIS(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -2086,7 +2104,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVwet)), HIS(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVwet)), HIS(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -2104,7 +2122,7 @@
         ELSE
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idpthR,          &
      &                     HIS(ng)%pioVar(idpthR),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2116,7 +2134,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthR)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthR)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2141,7 +2159,7 @@
         ELSE
           ioDesc => ioDesc_sp_u3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idpthU,          &
      &                     HIS(ng)%pioVar(idpthU),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2153,7 +2171,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthU)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthU)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2178,7 +2196,7 @@
         ELSE
           ioDesc => ioDesc_sp_v3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idpthV,          &
      &                     HIS(ng)%pioVar(idpthV),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2190,7 +2208,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthV)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthV)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2207,7 +2225,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idpthW,          &
      &                     HIS(ng)%pioVar(idpthW),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2219,7 +2237,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthW)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthW)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2237,7 +2255,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idFsur,          &
      &                     HIS(ng)%pioVar(idFsur),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2253,7 +2271,7 @@
 # endif
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idFsur)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idFsur)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2267,7 +2285,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idRzet,          &
      &                     HIS(ng)%pioVar(idRzet),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2278,7 +2296,7 @@
      &                     OCEAN(ng) % rzeta(:,:,KOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRzet)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRzet)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2309,7 +2327,7 @@
      &                                                  Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))),            &
      &                        HIS(ng)%Rindex
           END IF
           exit_flag=3
@@ -2328,7 +2346,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idUbar,          &
      &                     HIS(ng)%pioVar(idUbar),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2339,7 +2357,7 @@
      &                     OCEAN(ng) % ubar(:,:,KOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbar)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbar)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2354,7 +2372,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idRu2d,          &
      &                     HIS(ng)%pioVar(idRu2d),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2365,7 +2383,7 @@
      &                     OCEAN(ng) % rubar(:,:,KOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRu2d)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRu2d)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2380,7 +2398,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idRuct,          &
      &                     HIS(ng)%pioVar(idRuct),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2391,7 +2409,7 @@
      &                     COUPLING(ng) % rufrc)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRuct)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRuct)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2404,7 +2422,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idUfx1,          &
      &                     HIS(ng)%pioVar(idUfx1),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2415,7 +2433,7 @@
      &                     COUPLING(ng) % DU_avg1)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUfx1)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUfx1)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2427,7 +2445,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idUfx2,          &
      &                     HIS(ng)%pioVar(idUfx2),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2438,7 +2456,7 @@
      &                     COUPLING(ng) % DU_avg2)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUfx2)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUfx2)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2470,7 +2488,7 @@
      &                                                  Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))),            &
      &                        HIS(ng)%Rindex
           END IF
           exit_flag=3
@@ -2489,7 +2507,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idVbar,          &
      &                     HIS(ng)%pioVar(idVbar),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2500,7 +2518,7 @@
      &                     OCEAN(ng) % vbar(:,:,KOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbar)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbar)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2515,7 +2533,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idRv2d,          &
      &                     HIS(ng)%pioVar(idRv2d),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2526,7 +2544,7 @@
      &                     OCEAN(ng) % rvbar(:,:,KOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRv2d)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRv2d)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2541,7 +2559,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idRvct,          &
      &                     HIS(ng)%pioVar(idRvct),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2552,7 +2570,7 @@
      &                     COUPLING(ng) % rvfrc)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRvct)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRvct)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2565,7 +2583,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idVfx1,          &
      &                     HIS(ng)%pioVar(idVfx1),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2576,7 +2594,7 @@
      &                     COUPLING(ng) % DV_avg1)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVfx1)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVfx1)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2588,7 +2606,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idVfx2,          &
      &                     HIS(ng)%pioVar(idVfx2),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2599,7 +2617,7 @@
      &                     COUPLING(ng) % DV_avg2)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVfx2)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVfx2)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2631,7 +2649,7 @@
      &                                                  Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))),            &
      &                        HIS(ng)%Rindex
           END IF
           exit_flag=3
@@ -2670,7 +2688,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idu2dE,          &
      &                     HIS(ng)%pioVar(idu2dE),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2681,7 +2699,7 @@
      &                     Ur2d)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu2dE)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu2dE)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2693,7 +2711,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idv2dN,          &
      &                     HIS(ng)%pioVar(idv2dN),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2704,7 +2722,7 @@
      &                     Vr2d)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv2dN)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv2dN)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2725,7 +2743,7 @@
         ELSE
           ioDesc => ioDesc_sp_u3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idUvel,          &
      &                     HIS(ng)%pioVar(idUvel),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2736,7 +2754,7 @@
      &                     OCEAN(ng) % u(:,:,:,NOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUvel)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUvel)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2750,7 +2768,7 @@
         ELSE
           ioDesc => ioDesc_sp_u3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idRu3d,          &
      &                     HIS(ng)%pioVar(idRu3d),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2761,7 +2779,7 @@
      &                     OCEAN(ng) % ru(:,:,:,NOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRu3d)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRu3d)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2792,7 +2810,7 @@
      &                                               Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))),            &
      &                        HIS(ng)%Rindex
           END IF
           exit_flag=3
@@ -2811,7 +2829,7 @@
         ELSE
           ioDesc => ioDesc_sp_v3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idVvel,          &
      &                     HIS(ng)%pioVar(idVvel),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2822,7 +2840,7 @@
      &                     OCEAN(ng) % v(:,:,:,NOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvel)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvel)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2836,7 +2854,7 @@
         ELSE
           ioDesc => ioDesc_sp_v3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idRv3d,          &
      &                     HIS(ng)%pioVar(idRv3d),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2847,7 +2865,7 @@
      &                     OCEAN(ng) % rv(:,:,:,NOUT))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idRv3d)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRv3d)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2878,7 +2896,7 @@
      &                                               Lbout(ng)))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))),            &
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))),            &
      &                        HIS(ng)%Rindex
           END IF
           exit_flag=3
@@ -2917,7 +2935,7 @@
         ELSE
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idu3dE,          &
      &                     HIS(ng)%pioVar(idu3dE),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2928,7 +2946,7 @@
      &                     Ur3d)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu3dE)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu3dE)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2940,7 +2958,7 @@
         ELSE
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idv3dN,          &
      &                     HIS(ng)%pioVar(idv3dN),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2951,7 +2969,7 @@
      &                     Vr3d)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv3dN)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv3dN)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2980,7 +2998,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idOvel,          &
      &                     HIS(ng)%pioVar(idOvel),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2991,7 +3009,7 @@
      &                     Wr3d)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idOvel)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idOvel)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3004,7 +3022,7 @@
 !
 !  Write out S-coordinate implicit omega vertical velocity (m/s).
 !
-      IF (Hout(idOvel,ng)) THEN
+      IF (Hout(idOvil,ng)) THEN
         IF (.not.allocated(Wr3d)) THEN
           allocate (Wr3d(LBi:UBi,LBj:UBj,0:N(ng)))
           Wr3d(LBi:UBi,LBj:UBj,0:N(ng))=0.0_r8
@@ -3021,7 +3039,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idOvil,          &
      &                     HIS(ng)%pioVar(idOvil),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3032,7 +3050,7 @@
      &                     Wr3d)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idOvil)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idOvil)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3051,7 +3069,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idWvel,          &
      &                     HIS(ng)%pioVar(idWvel),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3062,7 +3080,7 @@
      &                     OCEAN(ng) % wvel)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idWvel)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idWvel)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3080,7 +3098,7 @@
           ELSE
             ioDesc => ioDesc_sp_r3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idTvar(itrc),  &
      &                       HIS(ng)%pioTrc(itrc),                      &
      &                       HIS(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -3091,7 +3109,7 @@
      &                       OCEAN(ng) % t(:,:,:,NOUT,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),            &
      &                          HIS(ng)%Rindex
             END IF
             exit_flag=3
@@ -3126,7 +3144,7 @@
      &                                                 Lbout(ng),itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,ifield)), HIS(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,ifield)), HIS(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -3145,7 +3163,7 @@
         ELSE
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idDano,          &
      &                     HIS(ng)%pioVar(idDano),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3156,7 +3174,7 @@
      &                     OCEAN(ng) % rho)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idDano)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idDano)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3175,7 +3193,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idHsbl,          &
      &                     HIS(ng)%pioVar(idHsbl),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3186,7 +3204,7 @@
      &                     MIXING(ng) % hsbl)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHsbl)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHsbl)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3205,7 +3223,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idHbbl,          &
      &                     HIS(ng)%pioVar(idHbbl),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3216,7 +3234,7 @@
      &                     MIXING(ng) % hbbl)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHbbl)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHbbl)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3236,7 +3254,7 @@
           ELSE
             ioDesc => ioDesc_sp_w3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idGhat(i),     &
      &                       HIS(ng)%pioVar(idGhat(i)),                 &
      &                       HIS(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -3247,7 +3265,7 @@
      &                       MIXING(ng) % ghats(:,:,:,i))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idGhat(i))), HIS(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idGhat(i))), HIS(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -3266,7 +3284,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idVvis,          &
      &                     HIS(ng)%pioVar(idVvis),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3278,7 +3296,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvis)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvis)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3295,7 +3313,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idTdif,          &
      &                     HIS(ng)%pioVar(idTdif),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3307,7 +3325,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTdif)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTdif)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3326,7 +3344,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idSdif,          &
      &                     HIS(ng)%pioVar(idSdif),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3338,7 +3356,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSdif)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSdif)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3357,7 +3375,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idMtke,          &
      &                     HIS(ng)%pioVar(idMtke),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3369,7 +3387,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idMtke)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idMtke)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3384,7 +3402,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idVmKK,          &
      &                     HIS(ng)%pioVar(idVmKK),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3395,7 +3413,7 @@
      &                     MIXING(ng) % Akk)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVmKK)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVmKK)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3413,7 +3431,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idMtls,          &
      &                     HIS(ng)%pioVar(idMtls),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3425,7 +3443,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idMtls)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idMtls)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3440,7 +3458,7 @@
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
         scale=1.0_dp
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idVmLS,          &
      &                     HIS(ng)%pioVar(idVmLS),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3451,7 +3469,7 @@
      &                     MIXING(ng) % Lscale)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVmLS)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVmLS)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3466,7 +3484,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idVmKP,          &
      &                     HIS(ng)%pioVar(idVmKP),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3477,7 +3495,7 @@
      &                     MIXING(ng) % Akp)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVmKP)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVmKP)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3497,7 +3515,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idPair,          &
      &                     HIS(ng)%pioVar(idPair),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3508,7 +3526,7 @@
      &                     FORCES(ng) % Pair)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idPair)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idPair)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3527,7 +3545,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idTair,          &
      &                     HIS(ng)%pioVar(idTair),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3538,7 +3556,7 @@
      &                     FORCES(ng) % Tair)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTair)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTair)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3557,7 +3575,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idUair,          &
      &                     HIS(ng)%pioVar(idUair),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3568,7 +3586,7 @@
      &                     FORCES(ng) % Uwind)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUair)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUair)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3583,7 +3601,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idVair,          &
      &                     HIS(ng)%pioVar(idVair),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3594,7 +3612,7 @@
      &                     FORCES(ng) % Vwind)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVair)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVair)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3621,7 +3639,7 @@
           ELSE
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                &
+          status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idTsur(itrc),  &
      &                       HIS(ng)%pioVar(idTsur(itrc)),              &
      &                       HIS(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -3632,7 +3650,7 @@
      &                       FORCES(ng) % stflx(:,:,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          HIS(ng)%Rindex
             END IF
             exit_flag=3
@@ -3653,7 +3671,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idLhea,          &
      &                     HIS(ng)%pioVar(idLhea),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3664,7 +3682,7 @@
      &                     FORCES(ng) % lhflx)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idLhea)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idLhea)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3681,7 +3699,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idShea,          &
      &                     HIS(ng)%pioVar(idShea),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3692,7 +3710,7 @@
      &                     FORCES(ng) % shflx)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idShea)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idShea)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3709,7 +3727,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idLrad,          &
      &                     HIS(ng)%pioVar(idLrad),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3720,7 +3738,7 @@
      &                     FORCES(ng) % lrflx)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idLrad)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idLrad)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3741,7 +3759,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idevap,          &
      &                     HIS(ng)%pioVar(idevap),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3752,7 +3770,7 @@
      &                     FORCES(ng) % evap)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idevap)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idevap)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3769,7 +3787,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idrain,          &
      &                     HIS(ng)%pioVar(idrain),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3780,7 +3798,7 @@
      &                     FORCES(ng) % rain)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idrain)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idrain)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3799,7 +3817,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idEmPf,          &
      &                     HIS(ng)%pioVar(idEmPf),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3810,7 +3828,7 @@
      &                     FORCES(ng) % stflux(:,:,isalt))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idEmPf)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idEmPf)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3829,7 +3847,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idSrad,          &
      &                     HIS(ng)%pioVar(idSrad),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3840,7 +3858,7 @@
      &                     FORCES(ng) % srflx)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSrad)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSrad)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3863,7 +3881,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idUsms,          &
      &                     HIS(ng)%pioVar(idUsms),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3874,7 +3892,7 @@
      &                     FORCES(ng) % sustr)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUsms)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUsms)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3895,7 +3913,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idVsms,          &
      &                     HIS(ng)%pioVar(idVsms),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3906,7 +3924,7 @@
      &                     FORCES(ng) % svstr)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVsms)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVsms)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3923,7 +3941,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idUbms,          &
      &                     HIS(ng)%pioVar(idUbms),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3934,7 +3952,7 @@
      &                     FORCES(ng) % bustr)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbms)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbms)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3951,7 +3969,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, HIS(ng)%pioFile, idVbms,          &
      &                     HIS(ng)%pioVar(idVbms),                      &
      &                     HIS(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3962,7 +3980,7 @@
      &                     FORCES(ng) % bvstr)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbms)), HIS(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbms)), HIS(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -4026,23 +4044,7 @@
       CALL pio_netcdf_sync (ng, model, HIS(ng)%name, HIS(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-# ifdef SOLVE3D
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, HIS(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, HIS(ng)%Rindex
-#  endif
-# else
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, HIS(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) KOUT, HIS(ng)%Rindex
-#  endif
-# endif
-!
-  10  FORMAT (/,' WRT_HIS_PIO - error while writing variable: ',a,      &
-     &        /,15x,'into history NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'WRT_HIS_PIO      - wrote history', t40,               &
+  10  FORMAT (2x,'WRT_HIS_PIO      - writing history', t42,             &
 # ifdef SOLVE3D
 #  ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
@@ -4056,6 +4058,8 @@
      &        'fields (Index=',i1,')   in record = ',i0)
 #  endif
 # endif
+  20  FORMAT (/,' WRT_HIS_PIO - error while writing variable: ',a,      &
+     &        /,15x,'into history NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_his_pio

--- a/ROMS/Utility/wrt_impulse.F
+++ b/ROMS/Utility/wrt_impulse.F
@@ -3,7 +3,7 @@
 #if defined ADJOINT && defined IMPULSE
 !
 !git $Id$
-!svn $Id: wrt_impulse.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: wrt_impulse.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -260,7 +260,7 @@
           END IF
 !
           MyType=gtype
-          status=nf_fwrite2d(ng, model, TLF(ng)%ncid,                   &
+          status=nf_fwrite2d(ng, model, TLF(ng)%ncid, idZtlf,           &
      &                       TLF(ng)%Vid(idZtlf),                       &
      &                       Iout, MyType,                              &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -325,7 +325,7 @@
           END IF
 !
           MyType=gtype
-          status=nf_fwrite2d(ng, model, TLF(ng)%ncid,                   &
+          status=nf_fwrite2d(ng, model, TLF(ng)%ncid, idUbtf,           &
      &                       TLF(ng)%Vid(idUbtf),                       &
      &                       Iout, MyType,                              &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -388,7 +388,7 @@
           END IF
 !
           MyType=gtype
-          status=nf_fwrite2d(ng, model, TLF(ng)%ncid,                   &
+          status=nf_fwrite2d(ng, model, TLF(ng)%ncid, idVbtf,           &
      &                       TLF(ng)%Vid(idVbtf),                       &
      &                       Iout, MyType,                              &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -452,7 +452,7 @@
             END IF
           END IF
 !
-          status=nf_fwrite3d(ng, model, TLF(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, TLF(ng)%ncid, idUtlf,           &
      &                       TLF(ng)%Vid(idUtlf),                       &
      &                       Iout, MyType,                              &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -514,7 +514,7 @@
             END IF
           END IF
 !
-          status=nf_fwrite3d(ng, model, TLF(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, TLF(ng)%ncid, idVtlf,           &
      &                       TLF(ng)%Vid(idVtlf),                       &
      &                       Iout, MyType,                              &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -578,7 +578,8 @@
               END IF
             END IF
 !
-            status=nf_fwrite3d(ng, model, TLF(ng)%ncid, TLF(ng)%Tid(i), &
+            status=nf_fwrite3d(ng, model, TLF(ng)%ncid, idTtlf(i),      &
+     &                         TLF(ng)%Tid(i),                          &
      &                         Iout, MyType,                            &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &
 #  ifdef MASKING
@@ -824,7 +825,7 @@
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
 
-          status=nf_fwrite2d(ng, model, TLF(ng)%pioFile,                &
+          status=nf_fwrite2d(ng, model, TLF(ng)%pioFile, idZtlf,        &
      &                       TLF(ng)%pioVar(idZtlf), Iout,              &
      &                       ioDesc,                                    &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -903,7 +904,7 @@
             ioDesc => ioDesc_sp_u2dvar(ng)
           END IF
 
-          status=nf_fwrite2d(ng, model, TLF(ng)%pioFile,                &
+          status=nf_fwrite2d(ng, model, TLF(ng)%pioFile, idUbtf,        &
      &                       TLF(ng)%pioVar(idUbtf), Iout,              &
      &                       ioDesc,                                    &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -980,7 +981,7 @@
             ioDesc => ioDesc_sp_v2dvar(ng)
           END IF
 
-          status=nf_fwrite2d(ng, model, TLF(ng)%pioFile,                &
+          status=nf_fwrite2d(ng, model, TLF(ng)%pioFile, idVbtf,        &
      &                       TLF(ng)%pioVar(idVbtf), Iout,              &
      &                       ioDesc,                                    &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1059,7 +1060,7 @@
             ioDesc => ioDesc_sp_u3dvar(ng)
           END IF
 
-          status=nf_fwrite3d(ng, model, TLF(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, TLF(ng)%pioFile, idUtlf,        &
      &                       TLF(ng)%pioVar(idUtlf), Iout,              &
      &                       ioDesc,                                    &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1136,7 +1137,7 @@
             ioDesc => ioDesc_sp_v3dvar(ng)
           END IF
 
-          status=nf_fwrite3d(ng, model, TLF(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, TLF(ng)%pioFile, idVtlf,        &
      &                       TLF(ng)%pioVar(idVtlf), Iout,              &
      &                       ioDesc,                                    &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1215,7 +1216,7 @@
               ioDesc => ioDesc_sp_r3dvar(ng)
             END IF
 
-            status=nf_fwrite3d(ng, model, TLF(ng)%pioFile,              &
+            status=nf_fwrite3d(ng, model, TLF(ng)%pioFile, idTtlf(i),   &
      &                         TLF(ng)%pioTrc(i), Iout,                 &
      &                         ioDesc,                                  &
      &                         LBi, UBi, LBj, UBj, 1, N(ng), scale,     &

--- a/ROMS/Utility/wrt_info.F
+++ b/ROMS/Utility/wrt_info.F
@@ -2,7 +2,7 @@
       MODULE wrt_info_mod
 !
 !git $Id$
-!svn $Id: wrt_info.F 1189 2023-08-15 21:26:58Z arango $
+!svn $Id: wrt_info.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -4220,7 +4220,7 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_r2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, idYgdR,          &
+                status=nf_fwrite2d(ng, model, pioFile, idYgrR,          &
      &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING

--- a/ROMS/Utility/wrt_info.F
+++ b/ROMS/Utility/wrt_info.F
@@ -2,7 +2,7 @@
       MODULE wrt_info_mod
 !
 !git $Id$
-!svn $Id: wrt_info.F 1178 2023-07-11 17:50:57Z arango $
+!svn $Id: wrt_info.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -1452,8 +1452,10 @@
         IF (exit_flag.eq.NoError) THEN
           scale=1.0_dp
           IF (ncid.ne.STA(ng)%ncid) THEN
-            IF (find_string(var_name, n_var, 'h', varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,     &
+            IF (find_string(var_name, n_var, TRIM(Vname(1,idtopo)),     &
+     &                      varid)) THEN
+              status=nf_fwrite2d(ng, model, ncid, idtopo,               &
+     &                           varid, 0, r2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
 # ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -1461,12 +1463,14 @@
      &                           GRID(ng) % h,                          &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'h', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idtopo)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'h', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idtopo)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
@@ -1477,7 +1481,7 @@
      &                          scale, GRID(ng)%h,                      &
      &                          Nstation(ng), SCALARS(ng)%SposX,        &
      &                          SCALARS(ng)%SposY, wrk)
-            CALL netcdf_put_fvar (ng, model, ncname, 'h',               &
+            CALL netcdf_put_fvar (ng, model, ncname, Vname(1,idtopo),   &
      &                            wrk, (/1/), (/Nstation(ng)/),         &
      &                            ncid = ncid)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -1491,8 +1495,10 @@
         IF (exit_flag.eq.NoError) THEN
           IF (ncid.ne.STA(ng)%ncid) THEN
             scale=1.0_dp
-            IF (find_string(var_name, n_var, 'f', varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,     &
+            IF (find_string(var_name, n_var, TRIM(Vname(1,idfcor)),     &
+     &                      varid)) THEN
+              status=nf_fwrite2d(ng, model, ncid, idfcor,               &
+     &                           varid, 0, r2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -1500,12 +1506,14 @@
      &                           GRID(ng) % f,                          &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'f', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idfcor)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'f', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idfcor)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
@@ -1517,8 +1525,10 @@
         IF (exit_flag.eq.NoError) THEN
           IF (ncid.ne.STA(ng)%ncid) THEN
             scale=1.0_dp
-            IF (find_string(var_name, n_var, 'pm', varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,     &
+            IF (find_string(var_name, n_var, TRIM(Vname(1,idpmdx)),     &
+     &                      varid)) THEN
+              status=nf_fwrite2d(ng, model, ncid, idpmdx,               &
+     &                           varid, 0, r2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -1526,23 +1536,27 @@
      &                           GRID(ng) % pm,                         &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'pm', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idpmdx)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'pm', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idpmdx)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
           END IF
         END IF
-
+!
         IF (exit_flag.eq.NoError) THEN
           IF (ncid.ne.STA(ng)%ncid) THEN
             scale=1.0_dp
-            IF (find_string(var_name, n_var, 'pn', varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,     &
+            IF (find_string(var_name, n_var, TRIM(Vname(1,idpndy)),     &
+     &                      varid)) THEN
+              status=nf_fwrite2d(ng, model, ncid, idpndy,               &
+     &                           varid, 0, r2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -1550,12 +1564,14 @@
      &                           GRID(ng) % pn,                         &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'pn', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idpndy)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'pn', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idpndy)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
@@ -1568,8 +1584,10 @@
           IF (exit_flag.eq.NoError) THEN
             scale=1.0_dp
             IF (ncid.ne.STA(ng)%ncid) THEN
-              IF (find_string(var_name, n_var, 'lon_rho', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idLonR)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idLonR,             &
+     &                             varid, 0, r2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % rmask,                    &
@@ -1578,12 +1596,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lon_rho', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLonR)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lon_rho', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLonR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -1594,7 +1614,7 @@
      &                            scale, GRID(ng)%lonr,                 &
      &                            Nstation(ng), SCALARS(ng)%SposX,      &
      &                            SCALARS(ng)%SposY, wrk)
-              CALL netcdf_put_fvar (ng, model, ncname, 'lon_rho',       &
+              CALL netcdf_put_fvar (ng, model, ncname, Vname(1,idLonR), &
      &                              wrk, (/1/), (/Nstation(ng)/),       &
      &                              ncid = ncid)
               IF (FoundError(exit_flag, NoError,                        &
@@ -1602,12 +1622,14 @@
 #endif
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             scale=1.0_dp
             IF (ncid.ne.STA(ng)%ncid) THEN
-              IF (find_string(var_name, n_var, 'lat_rho', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idLatR)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idLatR,             &
+     &                             varid, 0, r2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % rmask,                    &
@@ -1616,12 +1638,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lat_rho', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLatR)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lat_rho', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLatR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -1632,7 +1656,7 @@
      &                            scale, GRID(ng)%latr,                 &
      &                            Nstation(ng), SCALARS(ng)%SposX,      &
      &                            SCALARS(ng)%SposY, wrk)
-              CALL netcdf_put_fvar (ng, model, ncname, 'lat_rho',       &
+              CALL netcdf_put_fvar (ng, model, ncname, Vname(1,idLatR), &
      &                              wrk, (/1/), (/Nstation(ng)/),       &
      &                              ncid = ncid)
               IF (FoundError(exit_flag, NoError,                        &
@@ -1646,8 +1670,10 @@
           IF (exit_flag.eq.NoError) THEN
             scale=1.0_dp
             IF (ncid.ne.STA(ng)%ncid) THEN
-              IF (find_string(var_name, n_var, 'x_rho', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idXgrR)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idXgrR,             &
+     &                             varid, 0, r2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % rmask,                    &
@@ -1656,23 +1682,25 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'x_rho', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idXgrR)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'x_rho', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idXgrR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
 #ifdef STATIONS
             ELSE
               CALL extract_sta2d (ng, model, Cgrid, ifield, r2dvar,     &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          scale, GRID(ng)%xr,                     &
-     &                          Nstation(ng), SCALARS(ng)%SposX,        &
-     &                          SCALARS(ng)%SposY, wrk)
-              CALL netcdf_put_fvar (ng, model, ncname, 'x_rho',         &
+     &                            LBi, UBi, LBj, UBj,                   &
+     &                            scale, GRID(ng)%xr,                   &
+     &                            Nstation(ng), SCALARS(ng)%SposX,      &
+     &                            SCALARS(ng)%SposY, wrk)
+              CALL netcdf_put_fvar (ng, model, ncname, Vname(1,idXgrR), &
      &                              wrk, (/1/), (/Nstation(ng)/),       &
      &                              ncid = ncid)
               IF (FoundError(exit_flag, NoError,                        &
@@ -1680,12 +1708,14 @@
 #endif
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             scale=1.0_dp
             IF (ncid.ne.STA(ng)%ncid) THEN
-              IF (find_string(var_name, n_var, 'y_rho', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idYgrR)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idYgrR,             &
+     &                             varid, 0, r2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % rmask,                    &
@@ -1694,12 +1724,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'y_rho', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idYgrR)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'y_rho', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idYgrR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -1710,7 +1742,7 @@
      &                            scale, GRID(ng)%yr,                   &
      &                            Nstation(ng), SCALARS(ng)%SposX,      &
      &                            SCALARS(ng)%SposY, wrk)
-              CALL netcdf_put_fvar (ng, model, ncname, 'y_rho',         &
+              CALL netcdf_put_fvar (ng, model, ncname, Vname(1,idYgrR), &
      &                              wrk, (/1/), (/Nstation(ng)/),       &
      &                              ncid = ncid)
               IF (FoundError(exit_flag, NoError,                        &
@@ -1726,8 +1758,10 @@
           IF (exit_flag.eq.NoError) THEN
             IF (ncid.ne.STA(ng)%ncid) THEN
               scale=1.0_dp
-              IF (find_string(var_name, n_var, 'lon_u', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, u2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idLonU)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idLonU,             &
+     &                             varid, 0, u2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % umask,                    &
@@ -1736,23 +1770,27 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lon_u', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLonU)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lon_u', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLonU)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             IF (ncid.ne.STA(ng)%ncid) THEN
               scale=1.0_dp
-              IF (find_string(var_name, n_var, 'lat_u', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, u2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idLatU)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idLatU,             &
+     &                             varid, 0, u2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % umask,                    &
@@ -1761,12 +1799,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lat_u', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLatU)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lat_u', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLatU)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -1778,8 +1818,10 @@
           IF (exit_flag.eq.NoError) THEN
             IF (ncid.ne.STA(ng)%ncid) THEN
               scale=1.0_dp
-              IF (find_string(var_name, n_var, 'x_u', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, u2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idXgrU)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idXgrU,             &
+     &                             varid, 0, u2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % umask,                    &
@@ -1788,23 +1830,27 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'x_u', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idXgrU)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'x_u', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idXgrU)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             IF (ncid.ne.STA(ng)%ncid) THEN
               scale=1.0_dp
-              IF (find_string(var_name, n_var, 'y_u', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, u2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idYgrU)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idYgrU,             &
+     &                             varid, 0, u2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % umask,                    &
@@ -1813,12 +1859,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'y_u', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idYgrU)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'y_u', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idYgrU)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -1832,8 +1880,10 @@
           IF (exit_flag.eq.NoError) THEN
             IF (ncid.ne.STA(ng)%ncid) THEN
               scale=1.0_dp
-              IF (find_string(var_name, n_var, 'lon_v', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, v2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idLonV)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idLonV,             &
+     &                             varid, 0, v2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % vmask,                    &
@@ -1842,23 +1892,27 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lon_v', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLonV)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,10) 'lon_v', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLonV)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             IF (ncid.ne.STA(ng)%ncid) THEN
               scale=1.0_dp
-              IF (find_string(var_name, n_var, 'lat_v', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, v2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idLatV)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idLatV,             &
+     &                             varid, 0, v2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % vmask,                    &
@@ -1867,12 +1921,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lat_v', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLatV)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lat_v', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLatV)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -1884,8 +1940,10 @@
           IF (exit_flag.eq.NoError) THEN
             IF (ncid.ne.STA(ng)%ncid) THEN
               scale=1.0_dp
-              IF (find_string(var_name, n_var, 'x_v', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, v2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idXgrV)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idXgrV,             &
+     &                             varid, 0, v2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % vmask,                    &
@@ -1894,23 +1952,27 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'x_v', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idXgrV)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,10) 'x_v', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idXgrV)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             IF (ncid.ne.STA(ng)%ncid) THEN
               scale=1.0_dp
-              IF (find_string(var_name, n_var, 'y_v', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, v2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idYgrV)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idYgrV,             &
+     &                             varid, 0, v2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % vmask,                    &
@@ -1919,12 +1981,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'y_v', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idYgrV)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'y_v', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idYgrV)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -1938,8 +2002,10 @@
           IF (exit_flag.eq.NoError) THEN
             IF (ncid.ne.STA(ng)%ncid) THEN
               scale=1.0_dp
-              IF (find_string(var_name, n_var, 'lon_psi', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, p2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idLonP)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idLonP,             &
+     &                             varid, 0, p2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % pmask,                    &
@@ -1948,12 +2014,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lon_psi', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLonP)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lon_psi', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLonP)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -1963,8 +2031,10 @@
           IF (exit_flag.eq.NoError) THEN
             IF (ncid.ne.STA(ng)%ncid) THEN
               scale=1.0_dp
-              IF (find_string(var_name, n_var, 'lat_psi', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, p2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idLatP)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idLatP,             &
+     &                             varid, 0, p2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % pmask,                    &
@@ -1973,12 +2043,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lat_psi', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLatP)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lat_p', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLatP)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -1990,8 +2062,10 @@
           IF (exit_flag.eq.NoError) THEN
             IF (ncid.ne.STA(ng)%ncid) THEN
               scale=1.0_dp
-              IF (find_string(var_name, n_var, 'x_psi', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, p2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idXgrP)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idXgrP,             &
+     &                             varid, 0, p2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % pmask,                    &
@@ -2000,23 +2074,27 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'x_psi', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idXgrP)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'x_psi', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idXgrP)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             IF (ncid.ne.STA(ng)%ncid) THEN
               scale=1.0_dp
-              IF (find_string(var_name, n_var, 'y_psi', varid)) THEN
-                status=nf_fwrite2d(ng, model, ncid, varid, 0, p2dvar,   &
+              IF (find_string(var_name, n_var, TRIM(Vname(1,idYgrP)),   &
+     &                        varid)) THEN
+                status=nf_fwrite2d(ng, model, ncid, idYgrP,             &
+     &                             varid, 0, p2dvar,                    &
      &                             LBi, UBi, LBj, UBj, scale,           &
 #ifdef MASKING
      &                             GRID(ng) % pmask,                    &
@@ -2025,12 +2103,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, nf90_noerr,                      &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'y_psi', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idYgrP)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'y_psi', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idYgrP)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -2045,8 +2125,10 @@
         IF (exit_flag.eq.NoError) THEN
           scale=1.0_dp
           IF (ncid.ne.STA(ng)%ncid) THEN
-            IF (find_string(var_name, n_var, 'angle', varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,     &
+            IF (find_string(var_name, n_var, TRIM(Vname(1,idangR)),     &
+     &                      varid)) THEN
+              status=nf_fwrite2d(ng, model, ncid, idangR,               &
+     &                           varid, 0, r2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
 # ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -2054,12 +2136,14 @@
      &                           GRID(ng) % angler,                     &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'angle', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idangR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'angle', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idangR)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
@@ -2070,7 +2154,7 @@
      &                          scale, GRID(ng)%angler,                 &
      &                          Nstation(ng), SCALARS(ng)%SposX,        &
      &                          SCALARS(ng)%SposY, wrk)
-            CALL netcdf_put_fvar (ng, model, ncname, 'angle',           &
+            CALL netcdf_put_fvar (ng, model, ncname, Vname(1,idangR),   &
      &                            wrk, (/1/), (/Nstation(ng)/),         &
      &                            ncid = ncid)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -2086,85 +2170,101 @@
         IF (exit_flag.eq.NoError) THEN
           IF (ncid.ne.STA(ng)%ncid) THEN
             scale=1.0_dp
-            IF (find_string(var_name, n_var, 'mask_rho', varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,     &
+            IF (find_string(var_name, n_var, TRIM(Vname(1,idmskR)),     &
+     &                      varid)) THEN
+              status=nf_fwrite2d(ng, model, ncid, idmskR,               &
+     &                           varid, 0, r2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
      &                           GRID(ng) % rmask,                      &
      &                           GRID(ng) % rmask,                      &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'mask_rho', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idmskR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'mask_rho', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idmskR)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
           END IF
         END IF
-
+!
         IF (exit_flag.eq.NoError) THEN
           IF (ncid.ne.STA(ng)%ncid) THEN
             scale=1.0_dp
-            IF (find_string(var_name, n_var, 'mask_u', varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, u2dvar,     &
+            IF (find_string(var_name, n_var, TRIM(Vname(1,idmskU)),     &
+     &                      varid)) THEN
+              status=nf_fwrite2d(ng, model, ncid, idmskU,               &
+     &                           varid, 0, u2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
      &                           GRID(ng) % umask,                      &
      &                           GRID(ng) % umask,                      &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'mask_u', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idmskU)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'mask_u', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idmskU)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
           END IF
         END IF
-
+!
         IF (exit_flag.eq.NoError) THEN
           IF (ncid.ne.STA(ng)%ncid) THEN
             scale=1.0_dp
-            IF (find_string(var_name, n_var, 'mask_v', varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, v2dvar,     &
+            IF (find_string(var_name, n_var, TRIM(Vname(1,idmskV)),     &
+     &                      varid)) THEN
+              status=nf_fwrite2d(ng, model, ncid, idmskV,               &
+     &                           varid, 0, v2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
      &                           GRID(ng) % vmask,                      &
      &                           GRID(ng) % vmask,                      &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'mask_v', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idmskV)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'mask_v', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idmskV)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
           END IF
         END IF
-
+!
         IF (exit_flag.eq.NoError) THEN
           IF (ncid.ne.STA(ng)%ncid) THEN
             scale=1.0_dp
-            IF (find_string(var_name, n_var, 'mask_psi', varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, p2dvar,     &
+            IF (find_string(var_name, n_var, TRIM(Vname(1,idmskP)),     &
+     &                      varid)) THEN
+              status=nf_fwrite2d(ng, model, ncid, idmskP,               &
+     &                           varid, 0, p2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
      &                           GRID(ng) % pmask,                      &
      &                           GRID(ng) % pmask,                      &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'mask_psi', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idmskP)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'mask_psi', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idmskP)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
@@ -2181,8 +2281,10 @@
         IF (exit_flag.eq.NoError) THEN
           IF (ncid.ne.STA(ng)%ncid) THEN
             scale=1.0_dp
-            IF (find_string(var_name, n_var, 'scope_rho', varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,     &
+            IF (find_string(var_name, n_var, TRIM(Vname(1,idscoR)),     &
+     &                      varid)) THEN
+              status=nf_fwrite2d(ng, model, ncid, idscoR,               &
+     &                           varid, 0, r2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
 # ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -2190,23 +2292,27 @@
      &                           GRID(ng) % Rscope,                     &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'scope_rho', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idscoR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'scope_rho', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idscoR)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
           END IF
         END IF
-
+!
         IF (exit_flag.eq.NoError) THEN
           IF (ncid.ne.STA(ng)%ncid) THEN
             scale=1.0_dp
-            IF (find_string(var_name, n_var, 'scope_u', varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, u2dvar,     &
+            IF (find_string(var_name, n_var, TRIM(Vname(1,idscoU)),     &
+     &                      varid)) THEN
+              status=nf_fwrite2d(ng, model, ncid, idscoU,               &
+     &                           varid, 0, u2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
 # ifdef MASKING
      &                           GRID(ng) % umask,                      &
@@ -2214,23 +2320,27 @@
      &                           GRID(ng) % Uscope,                     &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'scope_u', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idscoU)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'scope_u', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idscoU)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
           END IF
         END IF
-
+!
         IF (exit_flag.eq.NoError) THEN
           IF (ncid.ne.STA(ng)%ncid) THEN
             scale=1.0_dp
-            IF (find_string(var_name, n_var, 'scope_v', varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, v2dvar,     &
+            IF (find_string(var_name, n_var, TRIM(Vname(1,idscoV)),     &
+     &                      varid)) THEN
+              status=nf_fwrite2d(ng, model, ncid, idscoV,               &
+     &                           varid, 0, v2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
 # ifdef MASKING
      &                           GRID(ng) % vmask,                      &
@@ -2238,12 +2348,14 @@
      &                           GRID(ng) % Vscope,                     &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'scope_v', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idscoV)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'scope_v', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idscoV)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
@@ -2260,7 +2372,8 @@
 # if defined UV_LOGDRAG || defined BBL_MODEL
             IF (find_string(var_name, n_var, TRIM(Vname(1,idZoBL)),     &
      &                      varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,     &
+              status=nf_fwrite2d(ng, model, ncid, idZoBL,               &
+     &                           varid, 0, r2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #  ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -2283,7 +2396,8 @@
 # ifdef UV_LDRAG
             IF (find_string(var_name, n_var, TRIM(Vname(1,idragL)),     &
      &                      varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,     &
+              status=nf_fwrite2d(ng, model, ncid, idragL,               &
+     &                           varid, 0, r2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #  ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -2306,7 +2420,8 @@
 # ifdef UV_QDRAG
             IF (find_string(var_name, n_var, TRIM(Vname(1,idragQ)),     &
      &                      varid)) THEN
-              status=nf_fwrite2d(ng, model, ncid, varid, 0, r2dvar,     &
+              status=nf_fwrite2d(ng, model, ncid, idragQ,               &
+     &                           varid, 0, r2dvar,                      &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #  ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -3767,7 +3882,8 @@
         IF (exit_flag.eq.NoError) THEN
           scale=1.0_dp
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
-            IF (pio_netcdf_find_var(ng, model, pioFile, 'h',            &
+            IF (pio_netcdf_find_var(ng, model, pioFile,                 &
+     &                              TRIM(Vname(1,idtopo)),              &
      &                              pioVar%vd)) THEN
               pioVar%gtype=r2dvar
               IF (PIO_TYPE.eq.PIO_double) THEN
@@ -3777,8 +3893,8 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_r2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idtopo,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #  ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -3786,12 +3902,14 @@
      &                           GRID(ng) % h,                          &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'h', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idtopo)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'h', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idtopo)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
@@ -3802,7 +3920,8 @@
      &                          scale, GRID(ng)%h,                      &
      &                          Nstation(ng), SCALARS(ng)%SposX,        &
      &                          SCALARS(ng)%SposY, wrk)
-            CALL pio_netcdf_put_fvar (ng, model, ncname, 'h',           &
+            CALL pio_netcdf_put_fvar (ng, model, ncname,                &
+     &                                Vname(1,idtopo),                  &
      &                                wrk, (/1/), (/Nstation(ng)/),     &
      &                                pioFile = pioFile)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -3816,7 +3935,8 @@
         IF (exit_flag.eq.NoError) THEN
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             scale=1.0_dp
-            IF (pio_netcdf_find_var(ng, model, pioFile, 'f',            &
+            IF (pio_netcdf_find_var(ng, model, pioFile,                 &
+     &                              TRIM(Vname(1,idfcor)),              &
      &                              pioVar%vd)) THEN
               pioVar%gtype=r2dvar
               IF (PIO_TYPE.eq.PIO_double) THEN
@@ -3826,8 +3946,8 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_r2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idfcor,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
 # ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -3835,12 +3955,14 @@
      &                           GRID(ng) % f,                          &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'f', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idfcor)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'f', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idfcor)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
@@ -3852,7 +3974,8 @@
         IF (exit_flag.eq.NoError) THEN
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             scale=1.0_dp
-            IF (pio_netcdf_find_var(ng, model, pioFile, 'pm',           &
+            IF (pio_netcdf_find_var(ng, model, pioFile,                 &
+     &                              TRIM(Vname(1,idpmdx)),              &
      &                              pioVar%vd)) THEN
               pioVar%gtype=r2dvar
               IF (PIO_TYPE.eq.PIO_double) THEN
@@ -3862,8 +3985,8 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_r2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idpmdx,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
 # ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -3871,22 +3994,25 @@
      &                           GRID(ng) % pm,                         &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'pm', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idpmdx)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'pm', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idpmdx)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
           END IF
         END IF
-
+!
         IF (exit_flag.eq.NoError) THEN
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             scale=1.0_dp
-            IF (pio_netcdf_find_var(ng, model, pioFile, 'pn',           &
+            IF (pio_netcdf_find_var(ng, model, pioFile,                 &
+     &                              TRIM(Vname(1,idpndy)),              &
      &                              pioVar%vd)) THEN
               pioVar%gtype=r2dvar
               IF (PIO_TYPE.eq.PIO_double) THEN
@@ -3896,8 +4022,8 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_r2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idpndy,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
 # ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -3905,12 +4031,14 @@
      &                           GRID(ng) % pn,                         &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'pn', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idpndy)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'pn', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idpndy)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
@@ -3923,7 +4051,8 @@
           IF (exit_flag.eq.NoError) THEN
             scale=1.0_dp
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'lon_rho',    &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idLonR)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=r2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -3933,8 +4062,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_r2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idLonR,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % rmask,                    &
@@ -3943,12 +4072,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lon_rho', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLonR)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lon_rho', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLonR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -3959,7 +4090,8 @@
      &                            scale, GRID(ng)%lonr,                 &
      &                            Nstation(ng), SCALARS(ng)%SposX,      &
      &                            SCALARS(ng)%SposY, wrk)
-              CALL pio_netcdf_put_fvar (ng, model, ncname, 'lon_rho',   &
+              CALL pio_netcdf_put_fvar (ng, model, ncname,              &
+     &                                  Vname(1,idLonR),                &
      &                                  wrk, (/1/), (/Nstation(ng)/),   &
      &                                  pioFile = pioFile)
               IF (FoundError(exit_flag, NoError,                        &
@@ -3967,11 +4099,12 @@
 # endif
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             scale=1.0_dp
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'lat_rho',    &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idLatR)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=r2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -3981,8 +4114,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_r2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idLatR,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % rmask,                    &
@@ -3991,12 +4124,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lat_rho', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLatR)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lat_rho', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLatR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -4007,7 +4142,8 @@
      &                            scale, GRID(ng)%latr,                 &
      &                            Nstation(ng), SCALARS(ng)%SposX,      &
      &                            SCALARS(ng)%SposY, wrk)
-              CALL pio_netcdf_put_fvar (ng, model, ncname, 'lat_rho',   &
+              CALL pio_netcdf_put_fvar (ng, model, ncname,              &
+     &                                  Vname(1,idLatR),                &
      &                                  wrk, (/1/), (/Nstation(ng)/),   &
      &                                  pioFile = pioFile)
               IF (FoundError(exit_flag, NoError,                        &
@@ -4021,7 +4157,8 @@
           IF (exit_flag.eq.NoError) THEN
             scale=1.0_dp
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'x_rho',      &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idXgrR)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=r2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4031,8 +4168,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_r2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idXgrR,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % rmask,                    &
@@ -4041,12 +4178,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'x_rho', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idXgrR)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'x_rho', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idXgrR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -4057,7 +4196,8 @@
      &                          scale, GRID(ng)%xr,                     &
      &                          Nstation(ng), SCALARS(ng)%SposX,        &
      &                          SCALARS(ng)%SposY, wrk)
-              CALL pio_netcdf_put_fvar (ng, model, ncname, 'x_rho',     &
+              CALL pio_netcdf_put_fvar (ng, model, ncname,              &
+     &                                  TRIM(Vname(1,idXgrR)),          &
      &                                  wrk, (/1/), (/Nstation(ng)/),   &
      &                                  pioFile = pioFile)
               IF (FoundError(exit_flag, NoError,                        &
@@ -4065,11 +4205,12 @@
 # endif
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             scale=1.0_dp
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'y_rho',      &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idYgrR)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=r2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4079,8 +4220,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_r2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idYgdR,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % rmask,                    &
@@ -4089,12 +4230,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'y_rho', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idYgrR)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'y_rho', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idYgrR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -4105,7 +4248,8 @@
      &                            scale, GRID(ng)%yr,                   &
      &                            Nstation(ng), SCALARS(ng)%SposX,      &
      &                            SCALARS(ng)%SposY, wrk)
-              CALL pio_netcdf_put_fvar (ng, model, ncname, 'y_rho',     &
+              CALL pio_netcdf_put_fvar (ng, model, ncname,              &
+     &                                  TRIM(Vname(1,idYgrR)),          &
      &                                  wrk, (/1/), (/Nstation(ng)/),   &
      &                                  pioFile = pioFile)
               IF (FoundError(exit_flag, NoError,                        &
@@ -4121,7 +4265,8 @@
           IF (exit_flag.eq.NoError) THEN
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
               scale=1.0_dp
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'lon_u',      &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idLonU)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=u2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4131,8 +4276,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_u2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idLonU,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % umask,                    &
@@ -4141,22 +4286,25 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lon_u', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLonU)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lon_u', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLonU)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
               scale=1.0_dp
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'lat_u',      &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idLatU)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=u2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4166,8 +4314,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_u2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idLatU,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % umask,                    &
@@ -4176,12 +4324,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lat_u', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLatU)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lat_u', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLatU)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -4193,7 +4343,8 @@
           IF (exit_flag.eq.NoError) THEN
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
               scale=1.0_dp
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'x_u',        &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idXgrU)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=u2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4203,8 +4354,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_u2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idXgrU,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % umask,                    &
@@ -4213,22 +4364,25 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'x_u', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idXgrU)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'x_u', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idXgrU)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
               scale=1.0_dp
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'y_u',        &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idYgrU)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=u2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4238,8 +4392,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_u2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idYgrU,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % umask,                    &
@@ -4248,12 +4402,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'y_u', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idXgrU)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'y_u', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idXgrU)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -4267,7 +4423,8 @@
           IF (exit_flag.eq.NoError) THEN
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
               scale=1.0_dp
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'lon_v',      &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idLonV)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=v2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4277,8 +4434,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_v2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idLonV,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % vmask,                    &
@@ -4287,22 +4444,25 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lon_v', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLonV)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,10) 'lon_v', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLonV)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
               scale=1.0_dp
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'lat_v',      &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idLatV)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=v2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4312,8 +4472,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_v2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                          &
+                status=nf_fwrite2d(ng, model, pioFile, idLatV,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % vmask,                    &
@@ -4322,12 +4482,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lat_v', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLatV)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lat_v', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLatV)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -4339,7 +4501,8 @@
           IF (exit_flag.eq.NoError) THEN
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
               scale=1.0_dp
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'x_v',        &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idXgrV)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=v2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4349,8 +4512,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_v2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idXgrV,              &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % vmask,                    &
@@ -4359,22 +4522,25 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'x_v', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idXgrV)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,10) 'x_v', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idXgrV)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
               scale=1.0_dp
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'y_v',        &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idYgrV)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=v2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4384,8 +4550,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_v2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idYgrV,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % vmask,                    &
@@ -4394,12 +4560,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'y_v', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idYgrV)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'y_v', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idYgrV)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -4413,7 +4581,8 @@
           IF (exit_flag.eq.NoError) THEN
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
               scale=1.0_dp
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'lon_psi',    &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idLonP)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=p2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4423,8 +4592,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_p2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idLonP,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % pmask,                    &
@@ -4433,22 +4602,25 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lon_psi', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLonP)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lon_psi', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLonP)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
             END IF
           END IF
-
+!
           IF (exit_flag.eq.NoError) THEN
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
               scale=1.0_dp
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'lat_psi',    &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idLatP)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=p2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4458,8 +4630,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_p2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idLatP,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % pmask,                    &
@@ -4468,12 +4640,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'lat_psi', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idLatP)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'lat_psi', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idLatP)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -4485,7 +4659,8 @@
           IF (exit_flag.eq.NoError) THEN
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
               scale=1.0_dp
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'x_psi',      &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idXgrP)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=p2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4495,8 +4670,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_p2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idXgrP,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % pmask,                    &
@@ -4505,7 +4680,8 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'x_psi', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idXgrP)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
@@ -4520,7 +4696,8 @@
           IF (exit_flag.eq.NoError) THEN
             IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
               scale=1.0_dp
-              IF (pio_netcdf_find_var(ng, model, pioFile, 'y_psi',      &
+              IF (pio_netcdf_find_var(ng, model, pioFile,               &
+     &                                TRIM(Vname(1,idYgrP)),            &
      &                                pioVar%vd)) THEN
                 pioVar%gtype=p2dvar
                 IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4530,8 +4707,8 @@
                   pioVar%dkind=PIO_real
                   ioDesc => ioDesc_sp_p2dvar(ng)
                 END IF
-                status=nf_fwrite2d(ng, model, pioFile, pioVar,          &
-     &                             0, ioDesc,                           &
+                status=nf_fwrite2d(ng, model, pioFile, idYgrP,          &
+     &                             pioVar, 0, ioDesc,                   &
      &                             LBi, UBi, LBj, UBj, scale,           &
 # ifdef MASKING
      &                             GRID(ng) % pmask,                    &
@@ -4540,12 +4717,14 @@
      &                             SetFillVal = .FALSE.)
                 IF (FoundError(status, PIO_noerr,                       &
      &                         __LINE__, MyFile)) THEN
-                  IF (Master) WRITE (stdout,10) 'y_psi', TRIM(ncname)
+                  IF (Master) WRITE (stdout,10) TRIM(Vname(1,idYgrP)),  &
+     &                                          TRIM(ncname)
                   exit_flag=3
                   ioerror=status
                 END IF
               ELSE
-                IF (Master) WRITE (stdout,20) 'y_psi', TRIM(ncname)
+                IF (Master) WRITE (stdout,20) TRIM(Vname(1,idYgrP)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=nf90_enotvar
               END IF
@@ -4560,7 +4739,8 @@
         IF (exit_flag.eq.NoError) THEN
           scale=1.0_dp
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
-            IF (pio_netcdf_find_var(ng, model, pioFile, 'angle',        &
+            IF (pio_netcdf_find_var(ng, model, pioFile,                 &
+     &                              TRIM(Vname(1,idangR)),              &
      &                              pioVar%vd)) THEN
               pioVar%gtype=r2dvar
               IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4570,8 +4750,8 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_r2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idangR,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #  ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -4579,12 +4759,14 @@
      &                           GRID(ng) % angler,                     &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'angle', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idangR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'angle', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idangR)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
@@ -4611,7 +4793,8 @@
         IF (exit_flag.eq.NoError) THEN
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             scale=1.0_dp
-            IF (pio_netcdf_find_var(ng, model, pioFile, 'mask_rho',     &
+            IF (pio_netcdf_find_var(ng, model, pioFile,                 &
+     &                              TRIM(Vname(1,idmskR)),              &
      &                              pioVar%vd)) THEN
               pioVar%gtype=r2dvar
               IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4621,29 +4804,32 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_r2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idmskR,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
      &                           GRID(ng) % rmask,                      &
      &                           GRID(ng) % rmask,                      &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'mask_rho', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idmskR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'mask_rho', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idmskR)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
           END IF
         END IF
-
+!
         IF (exit_flag.eq.NoError) THEN
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             scale=1.0_dp
-            IF (pio_netcdf_find_var(ng, model, pioFile, 'mask_u',       &
+            IF (pio_netcdf_find_var(ng, model, pioFile,                 &
+     &                              TRIM(Vname(1,idmskU)),              &
      &                              pioVar%vd)) THEN
               pioVar%gtype=u2dvar
               IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4653,29 +4839,32 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_u2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idmskU,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
      &                           GRID(ng) % umask,                      &
      &                           GRID(ng) % umask,                      &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'mask_u', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idmskU)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'mask_u', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idmskU)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
           END IF
         END IF
-
+!
         IF (exit_flag.eq.NoError) THEN
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             scale=1.0_dp
-            IF (pio_netcdf_find_var(ng, model, pioFile, 'mask_v',       &
+            IF (pio_netcdf_find_var(ng, model, pioFile,                 &
+     &                              TRIM(Vname(1,idmskV)),              &
      &                              pioVar%vd)) THEN
               pioVar%gtype=v2dvar
               IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4685,29 +4874,32 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_v2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idmskV,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
      &                           GRID(ng) % vmask,                      &
      &                           GRID(ng) % vmask,                      &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'mask_v', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idmskV)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'mask_v', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idmskV)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
           END IF
         END IF
-
+!
         IF (exit_flag.eq.NoError) THEN
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             scale=1.0_dp
-            IF (pio_netcdf_find_var(ng, model, pioFile, 'mask_psi',     &
+            IF (pio_netcdf_find_var(ng, model, pioFile,                 &
+     &                              TRIM(Vname(1,idmskP)),              &
      &                              pioVar%vd)) THEN
               pioVar%gtype=p2dvar
               IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4717,19 +4909,21 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_p2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idmskP,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
      &                           GRID(ng) % pmask,                      &
      &                           GRID(ng) % pmask,                      &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'mask_psi', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idmskP)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'mask_psi', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idmskP)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
@@ -4746,7 +4940,8 @@
         IF (exit_flag.eq.NoError) THEN
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             scale=1.0_dp
-            IF (pio_netcdf_find_var(ng, model, pioFile, 'scope_rho',    &
+            IF (pio_netcdf_find_var(ng, model, pioFile,                 &
+     &                              TRIM(Vname(1,idscoR)),              &
      &                              pioVar%vd)) THEN
               pioVar%gtype=r2dvar
               IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4756,8 +4951,8 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_r2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idscoR,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #  ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -4765,22 +4960,25 @@
      &                           GRID(ng) % Rscope,                     &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'scope_rho', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idscoR)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'scope_rho', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idscoR)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
           END IF
         END IF
-
+!
         IF (exit_flag.eq.NoError) THEN
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             scale=1.0_dp
-            IF (pio_netcdf_find_var(ng, model, pioFile, 'scope_u',      &
+            IF (pio_netcdf_find_var(ng, model, pioFile,                 &
+     &                              TRIM(Vname(1,idscoU)),              &
      &                              pioVar%vd)) THEN
               pioVar%gtype=u2dvar
               IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4790,8 +4988,8 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_u2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idscoU,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #  ifdef MASKING
      &                           GRID(ng) % umask,                      &
@@ -4799,22 +4997,25 @@
      &                           GRID(ng) % Uscope,                     &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'scope_u', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idscoU)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'scope_u', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idscoU)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
           END IF
         END IF
-
+!
         IF (exit_flag.eq.NoError) THEN
           IF (FileH.ne.ABS(STA(ng)%pioFile%fh)) THEN
             scale=1.0_dp
-            IF (pio_netcdf_find_var(ng, model, pioFile, 'scope_v',      &
+            IF (pio_netcdf_find_var(ng, model, pioFile,                 &
+     &                              TRIM(Vname(1,idscoV)),              &
      &                              pioVar%vd)) THEN
               pioVar%gtype=v2dvar
               IF (PIO_TYPE.eq.PIO_double) THEN
@@ -4824,8 +5025,8 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_v2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idscoV,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #  ifdef MASKING
      &                           GRID(ng) % vmask,                      &
@@ -4833,12 +5034,14 @@
      &                           GRID(ng) % Vscope,                     &
      &                           SetFillVal = .FALSE.)
               IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
-                IF (Master) WRITE (stdout,10) 'scope_v', TRIM(ncname)
+                IF (Master) WRITE (stdout,10) TRIM(Vname(1,idscoV)),    &
+     &                                        TRIM(ncname)
                 exit_flag=3
                 ioerror=status
               END IF
             ELSE
-              IF (Master) WRITE (stdout,20) 'scope_v', TRIM(ncname)
+              IF (Master) WRITE (stdout,20) TRIM(Vname(1,idscoV)),      &
+     &                                      TRIM(ncname)
               exit_flag=3
               ioerror=nf90_enotvar
             END IF
@@ -4863,8 +5066,8 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_r2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idZoBL,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #   ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -4895,8 +5098,8 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_r2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idragL,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #   ifdef MASKING
      &                           GRID(ng) % rmask,                      &
@@ -4927,8 +5130,8 @@
                 pioVar%dkind=PIO_real
                 ioDesc => ioDesc_sp_r2dvar(ng)
               END IF
-              status=nf_fwrite2d(ng, model, pioFile, pioVar,            &
-     &                           0, ioDesc,                             &
+              status=nf_fwrite2d(ng, model, pioFile, idragQ,            &
+     &                           pioVar, 0, ioDesc,                     &
      &                           LBi, UBi, LBj, UBj, scale,             &
 #   ifdef MASKING
      &                           GRID(ng) % rmask,                      &

--- a/ROMS/Utility/wrt_ini.F
+++ b/ROMS/Utility/wrt_ini.F
@@ -4,7 +4,7 @@
 #ifdef FOUR_DVAR
 !
 !git $Id$
-!svn $Id: wrt_ini.F 1151 2023-02-09 03:08:53Z arango $
+!svn $Id: wrt_ini.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -229,7 +229,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idFsur),   &
+      status=nf_fwrite2d(ng, iNLM, INI(ng)%ncid, idFsur,                &
+     &                   INI(ng)%Vid(idFsur),                           &
      &                   INI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -261,7 +262,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u2dvar
-      status=nf_fwrite2d(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idUbar),   &
+      status=nf_fwrite2d(ng, iNLM, INI(ng)%ncid, idUbar,                &
+     &                   INI(ng)%Vid(idUbar),                           &
      &                   INI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -289,7 +291,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v2dvar
-      status=nf_fwrite2d(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idVbar),   &
+      status=nf_fwrite2d(ng, iNLM, INI(ng)%ncid, idVbar,                &
+     &                   INI(ng)%Vid(idVbar),                           &
      &                   INI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
 # ifdef MASKING
@@ -319,7 +322,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idUvel),   &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, idUvel,                &
+     &                   INI(ng)%Vid(idUvel),                           &
      &                   INI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -347,7 +351,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idVvel),   &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, idVvel,                &
+     &                   INI(ng)%Vid(idVvel),                           &
      &                   INI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
 #  ifdef MASKING
@@ -376,7 +381,8 @@
       DO itrc=1,NT(ng)
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, INI(ng)%Tid(itrc),   &
+        status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, idTvar(itrc),        &
+     &                     INI(ng)%Tid(itrc),                           &
      &                     INI(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -413,7 +419,8 @@
       END IF
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idVvis),   &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, idVvis,                &
+     &                   INI(ng)%Vid(idVvis),                           &
      &                   INI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
 #   ifdef MASKING
@@ -447,7 +454,8 @@
       END IF
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idTdif),   &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, idTdif,                &
+     &                   INI(ng)%Vid(idTdif),                           &
      &                   INI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
 #   ifdef MASKING
@@ -482,7 +490,8 @@
       END IF
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idSdif),   &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, idSdif,                &
+     &                   INI(ng)%Vid(idSdif),                           &
      &                   INI(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
 #    ifdef MASKING
@@ -624,7 +633,7 @@
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iNLM, INI(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iNLM, INI(ng)%pioFile, idFsur,             &
      &                   INI(ng)%pioVar(idFsur),                        &
      &                   INI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -663,7 +672,7 @@
         ioDesc => ioDesc_sp_u2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iNLM, INI(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iNLM, INI(ng)%pioFile, idUbar,             &
      &                   INI(ng)%pioVar(idUbar),                        &
      &                   INI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -698,7 +707,7 @@
         ioDesc => ioDesc_sp_v2dvar(ng)
       END IF
 !
-      status=nf_fwrite2d(ng, iNLM, INI(ng)%pioFile,                     &
+      status=nf_fwrite2d(ng, iNLM, INI(ng)%pioFile, idVbar,             &
      &                   INI(ng)%pioVar(idVbar),                        &
      &                   INI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -735,7 +744,7 @@
         ioDesc => ioDesc_sp_u3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile, idUvel,             &
      &                   INI(ng)%pioVar(idUvel),                        &
      &                   INI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -770,7 +779,7 @@
         ioDesc => ioDesc_sp_v3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile, idVvel,             &
      &                   INI(ng)%pioVar(idVvel),                        &
      &                   INI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -854,7 +863,7 @@
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile, idVvis,             &
      &                   INI(ng)%pioVar(idVvis),                        &
      &                   INI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -899,7 +908,7 @@
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile, idTdif,             &
      &                   INI(ng)%pioVar(idTdif),                        &
      &                   INI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -945,7 +954,7 @@
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile, idSdif,             &
      &                   INI(ng)%pioVar(idSdif),                        &
      &                   INI(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1092,6 +1101,16 @@
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
+!  Report.
+!
+      IF (Master) THEN
+#  ifdef NESTING
+        WRITE (stdout,10) outer, inner, Tindex, OutRec, ng
+#  else
+        WRITE (stdout,10) outer, inner, Tindex, OutRec
+#  endif
+      END IF
+!
 !  Set grid type factor to write full (gfactor=1) fields or water
 !  points (gfactor=-1) fields only.
 !
@@ -1120,7 +1139,7 @@
      &                                                 Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1141,7 +1160,7 @@
      &                                                 Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1162,7 +1181,7 @@
      &                                                 Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1185,7 +1204,7 @@
      &                                              Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1206,7 +1225,7 @@
      &                                              Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1229,7 +1248,7 @@
      &                                                Tindex,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
+              WRITE (stdout,20) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
      &                          OutRec
             END IF
             exit_flag=3
@@ -1249,7 +1268,8 @@
 !
       scale=rho0                                    ! m2/s2 to N/m2 (Pa)
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idUsms),   &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, idUsms,                &
+     &                   INI(ng)%Vid(idUsms),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #   ifdef MASKING
@@ -1258,7 +1278,7 @@
      &                   FORCES(ng) % ustr(:,:,:,Tindex))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -1269,7 +1289,8 @@
 !
       scale=rho0                                    ! m2/s2 to N/m2 (Pa)
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idVsms),   &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, idVsms,                &
+     &                   INI(ng)%Vid(idVsms),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #   ifdef MASKING
@@ -1278,7 +1299,7 @@
      &                   FORCES(ng) % vstr(:,:,:,Tindex))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -1300,7 +1321,7 @@
             scale=1.0_dp
           END IF
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, idTsur(itrc),      &
      &                       INI(ng)%Vid(idTsur(itrc)),                 &
      &                       OutRec, gtype,                             &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -1310,7 +1331,7 @@
      &                       FORCES(ng) % tflux(:,:,:,Tindex,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          OutRec
             END IF
             exit_flag=3
@@ -1328,18 +1349,8 @@
 !
       CALL netcdf_sync (ng, iNLM, INI(ng)%name, INI(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-      IF (Master) THEN
-#  ifdef NESTING
-        WRITE (stdout,20) outer, inner, Tindex, OutRec, ng
-#  else
-        WRITE (stdout,20) outer, inner, Tindex, OutRec
-#  endif
-      END IF
 !
-  10  FORMAT (/,' WRT_FRC_NF90 - error while writing variable: ',a,     &
-     &        /,16x,'into initial NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'WRT_FRC_NF90     - wrote forcing  fields',            &
+  10  FORMAT (2x,'WRT_FRC_NF90     - writing forcing  fields',          &
      &        ' (Outer=',i2.2,                                          &
 #  ifdef NESTING
      &        ', Inner=',i3.3,', Index=',i0,', Rec=',i0,', Grid ',      &
@@ -1347,6 +1358,8 @@
 #  else
      &        ', Inner=',i3.3,', Index=',i0,', Rec=',i0,')')
 #  endif
+  20  FORMAT (/,' WRT_FRC_NF90 - error while writing variable: ',a,     &
+     &        /,16x,'into initial NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_frc_nf90
@@ -1389,6 +1402,16 @@
 !-----------------------------------------------------------------------
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+!
+!  Report.
+!
+      IF (Master) THEN
+#   ifdef NESTING
+        WRITE (stdout,10) outer, inner, Tindex, OutRec, ng
+#   else
+        WRITE (stdout,10) outer, inner, Tindex, OutRec
+#   endif
+      END IF
 
 #   ifdef ADJUST_BOUNDARY
 !
@@ -1416,7 +1439,7 @@
      &                                                 Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1444,7 +1467,7 @@
      &                                                 Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1472,7 +1495,7 @@
      &                                                 Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1502,7 +1525,7 @@
      &                                              Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1530,7 +1553,7 @@
      &                                              Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1561,7 +1584,7 @@
      &                                                Tindex,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
+              WRITE (stdout,20) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
      &                          OutRec
             END IF
             exit_flag=3
@@ -1586,7 +1609,7 @@
         ioDesc => ioDesc_sp_u2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile, idUsms,             &
      &                   INI(ng)%pioVar(idUsms), OutRec,                &
      &                   ioDesc,                                        &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
@@ -1596,7 +1619,7 @@
      &                   FORCES(ng) % ustr(:,:,:,Tindex))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -1612,7 +1635,7 @@
         ioDesc => ioDesc_sp_v2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile, idVsms,             &
      &                   INI(ng)%pioVar(idVsms), OutRec,                &
      &                   ioDesc,                                        &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
@@ -1622,7 +1645,7 @@
      &                   FORCES(ng) % vstr(:,:,:,Tindex))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -1649,7 +1672,7 @@
             ioDesc => ioDesc_sp_r2dfrc(ng)
           END IF
 !
-          status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile, idTsur(itrc),   &
      &                       INI(ng)%pioVar(idTsur(itrc)), OutRec,      &
      &                       ioDesc,                                    &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -1659,7 +1682,7 @@
      &                       FORCES(ng) % tflux(:,:,:,Tindex,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          OutRec
             END IF
             exit_flag=3
@@ -1677,18 +1700,8 @@
 !
       CALL pio_netcdf_sync (ng, iNLM, INI(ng)%name, INI(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-      IF (Master) THEN
-#   ifdef NESTING
-        WRITE (stdout,20) outer, inner, Tindex, OutRec, ng
-#   else
-        WRITE (stdout,20) outer, inner, Tindex, OutRec
-#   endif
-      END IF
 !
-  10  FORMAT (/,' WRT_FRC_pio - error while writing variable: ',a,      &
-     &        /,15x,'into initial NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'WRT_FRC_PIO      - wrote forcing  fields',            &
+  10  FORMAT (2x,'WRT_FRC_PIO      - writing forcing  fields',          &
      &        ' (Outer=',i2.2,                                          &
 #   ifdef NESTING
      &        ', Inner=',i3.3,', Index=',i0,', Rec=',i0,', Grid ',      &
@@ -1696,6 +1709,8 @@
 #   else
      &        ', Inner=',i3.3,', Index=',i0,', Rec=',i0,')')
 #   endif
+  20  FORMAT (/,' WRT_FRC_pio - error while writing variable: ',a,      &
+     &        /,15x,'into initial NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_frc_pio
@@ -1795,6 +1810,16 @@
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
+!  Report.
+!
+      IF (Master) THEN
+# ifdef NESTING
+        WRITE (stdout,10) outer, inner, Tindex, OutRec, ng
+# else
+        WRITE (stdout,10) outer, inner, Tindex, OutRec
+# endif
+      END IF
+!
 !  Set grid type factor to write full (gfactor=1) fields or water
 !  points (gfactor=-1) fields only.
 !
@@ -1823,7 +1848,7 @@
      &                                                    Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1844,7 +1869,7 @@
      &                                                    Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1865,7 +1890,7 @@
      &                                                    Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1888,7 +1913,7 @@
      &                                                 Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1909,7 +1934,7 @@
      &                                                 Tindex))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -1932,7 +1957,7 @@
      &                                                   Tindex,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
+              WRITE (stdout,20) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
      &                          OutRec
             END IF
             exit_flag=3
@@ -1952,7 +1977,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idUsms),   &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, idUsms,                &
+     &                   INI(ng)%Vid(idUsms),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #   ifdef MASKING
@@ -1961,7 +1987,7 @@
      &                   FORCES(ng) % ad_ustr(:,:,:,Tindex))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -1972,7 +1998,8 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idVsms),   &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, idVsms,                &
+     &                   INI(ng)%Vid(idVsms),                           &
      &                   OutRec, gtype,                                 &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
 #   ifdef MASKING
@@ -1981,7 +2008,7 @@
      &                   FORCES(ng) % ad_vstr(:,:,:,Tindex))
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -1999,7 +2026,7 @@
         IF (Lstflux(itrc,ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid,                    &
+          status=nf_fwrite3d(ng, iNLM, INI(ng)%ncid, idTsur(itrc),      &
      &                       INI(ng)%Vid(idTsur(itrc)),                 &
      &                       OutRec, gtype,                             &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -2009,7 +2036,7 @@
      &                       FORCES(ng) % ad_tflux(:,:,:,Tindex,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          OutRec
             END IF
             exit_flag=3
@@ -2028,17 +2055,7 @@
       CALL netcdf_sync (ng, iNLM, INI(ng)%name, INI(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-      IF (Master) THEN
-# ifdef NESTING
-        WRITE (stdout,20) outer, inner, Tindex, OutRec, ng
-# else
-        WRITE (stdout,20) outer, inner, Tindex, OutRec
-# endif
-      END IF
-!
-  10  FORMAT (/,' WRT_FRC_AD_NF90 - error while writing variable: ',a,  &
-     &        /,19x,'into initial NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'WRT_FRC_AD_NF90  - wrote forcing  fields',            &
+  10  FORMAT (2x,'WRT_FRC_AD_NF90  - writing forcing  fields',          &
      &        ' (Outer=',i2.2,   &
 #  ifdef NESTING
      &        ', Inner=',i3.3,', Index=',i0,', Rec=',i0,', Grid ',      &
@@ -2046,6 +2063,8 @@
 #  else
      &        ', Inner=',i3.3,', Index=',i0,', Rec=',i0,')')
 #  endif
+  20  FORMAT (/,' WRT_FRC_AD_NF90 - error while writing variable: ',a,  &
+     &        /,19x,'into initial NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_frc_AD_nf90
@@ -2088,6 +2107,16 @@
 !-----------------------------------------------------------------------
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+!
+!  Report
+!
+      IF (Master) THEN
+#  ifdef NESTING
+        WRITE (stdout,10) outer, inner, Tindex, OutRec, ng
+#  else
+        WRITE (stdout,10) outer, inner, Tindex, OutRec
+#  endif
+      END IF
 
 #   ifdef ADJUST_BOUNDARY
 !
@@ -2115,7 +2144,7 @@
      &                                                    Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isFsur))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isFsur))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -2143,7 +2172,7 @@
      &                                                    Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUbar))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUbar))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -2171,7 +2200,7 @@
      &                                                    Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVbar))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVbar))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -2201,7 +2230,7 @@
      &                                                 Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isUvel))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isUvel))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -2229,7 +2258,7 @@
      &                                                 Tindex))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbry(isVvel))), OutRec
+            WRITE (stdout,20) TRIM(Vname(1,idSbry(isVvel))), OutRec
           END IF
           exit_flag=3
           ioerror=status
@@ -2260,7 +2289,7 @@
      &                                                   Tindex,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
+              WRITE (stdout,20) TRIM(Vname(1,idSbry(isTvar(itrc)))),    &
      &                          OutRec
             END IF
             exit_flag=3
@@ -2285,7 +2314,7 @@
         ioDesc => ioDesc_sp_u2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile, idUsms,             &
      &                   INI(ng)%pioVar(idUsms),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
@@ -2295,7 +2324,7 @@
      &                   FORCES(ng) % ad_ustr(:,:,:,Tindex))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUsms)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idUsms)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -2311,7 +2340,7 @@
         ioDesc => ioDesc_sp_v2dfrc(ng)
       END IF
 !
-      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile,                     &
+      status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile, idVsms,             &
      &                   INI(ng)%pioVar(idVsms),                        &
      &                   OutRec, ioDesc,                                &
      &                   LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,       &
@@ -2321,7 +2350,7 @@
      &                   FORCES(ng) % ad_vstr(:,:,:,Tindex))
       IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVsms)), OutRec
+          WRITE (stdout,20) TRIM(Vname(1,idVsms)), OutRec
         END IF
         exit_flag=3
         ioerror=status
@@ -2344,7 +2373,7 @@
             ioDesc => ioDesc_sp_r2dfrc(ng)
           END IF
 !
-          status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile,                 &
+          status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile, idTsur(itrc),   &
      &                       INI(ng)%pioVar(idTsur(itrc)),              &
      &                       OutRec, ioDesc,                            &
      &                       LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,   &
@@ -2354,7 +2383,7 @@
      &                       FORCES(ng) % ad_tflux(:,:,:,Tindex,itrc))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          OutRec
             END IF
             exit_flag=3
@@ -2373,17 +2402,7 @@
       CALL pio_netcdf_sync (ng, iNLM, INI(ng)%name, INI(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-      IF (Master) THEN
-#  ifdef NESTING
-        WRITE (stdout,20) outer, inner, Tindex, OutRec, ng
-#  else
-        WRITE (stdout,20) outer, inner, Tindex, OutRec
-#  endif
-      END IF
-!
-  10  FORMAT (/,' WRT_FRC_AD_PIO - error while writing variable: ',a,   &
-     &        /,19x,'into initial NetCDF file for time record: ',i0)
-  20  FORMAT (2x,'WRT_FRC_AD_PIO   - wrote forcing  fields',            &
+  10  FORMAT (2x,'WRT_FRC_AD_PIO   - writing forcing  fields',          &
      &        ' (Outer=',i2.2,   &
 #   ifdef NESTING
      &        ', Inner=',i3.3,', Index=',i0,', Rec=',i0,', Grid ',      &
@@ -2391,6 +2410,8 @@
 #   else
      &        ', Inner=',i3.3,', Index=',i0,', Rec=',i0,')')
 #   endif
+  20  FORMAT (/,' WRT_FRC_AD_PIO - error while writing variable: ',a,   &
+     &        /,19x,'into initial NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_frc_AD_pio

--- a/ROMS/Utility/wrt_ini.F
+++ b/ROMS/Utility/wrt_ini.F
@@ -4,7 +4,7 @@
 #ifdef FOUR_DVAR
 !
 !git $Id$
-!svn $Id: wrt_ini.F 1189 2023-08-15 21:26:58Z arango $
+!svn $Id: wrt_ini.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -815,7 +815,7 @@
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iNLM, INI(ng)%pioFile, idTvar(itrc),     &
      &                     INI(ng)%pioTrc(itrc),                        &
      &                     INI(ng)%Rindex,                              &
      &                     ioDesc,                                      &

--- a/ROMS/Utility/wrt_quick.F
+++ b/ROMS/Utility/wrt_quick.F
@@ -2,7 +2,7 @@
       MODULE wrt_quick_mod
 !
 !git $Id$
-!svn $Id: wrt_quick.F 1185 2023-08-01 21:42:38Z arango $
+!svn $Id: wrt_quick.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -189,6 +189,22 @@
       Fcount=QCK(ng)%load
       QCK(ng)%Nrec(Fcount)=QCK(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+#ifdef SOLVE3D
+# ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, QCK(ng)%Rindex, ng
+# else
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, QCK(ng)%Rindex
+# endif
+#else
+# ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, QCK(ng)%Rindex, ng
+# else
+      IF (Master) WRITE (stdout,10) KOUT, QCK(ng)%Rindex
+# endif
+#endif
+!
 !  Write out model time (s).
 !
       CALL netcdf_put_fvar (ng, model, QCK(ng)%name,                    &
@@ -204,7 +220,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*p2dvar
-      status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idPwet,               &
      &                   QCK(ng)%Vid(idPwet),                           &
      &                   QCK(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -215,7 +231,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idPwet)), QCK(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idPwet)), QCK(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -226,7 +242,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idRwet,               &
      &                   QCK(ng)%Vid(idRwet),                           &
      &                   QCK(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -237,7 +253,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRwet)), QCK(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRwet)), QCK(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -248,7 +264,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*u2dvar
-      status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idUwet,               &
      &                   QCK(ng)%Vid(idUwet),                           &
      &                   QCK(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -259,7 +275,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUwet)), QCK(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUwet)), QCK(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -270,7 +286,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*v2dvar
-      status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idVwet,               &
      &                   QCK(ng)%Vid(idVwet),                           &
      &                   QCK(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -281,7 +297,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVwet)), QCK(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVwet)), QCK(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -295,7 +311,7 @@
       IF (Qout(idpthR,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idpthR,             &
      &                     QCK(ng)%Vid(idpthR),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -306,7 +322,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthR)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthR)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -327,7 +343,7 @@
             END DO
           END DO
         END DO
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idpthU,             &
      &                     QCK(ng)%Vid(idpthU),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -338,7 +354,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthU)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthU)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -359,7 +375,7 @@
             END DO
           END DO
         END DO
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idpthV,             &
      &                     QCK(ng)%Vid(idpthV),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -370,7 +386,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthV)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthV)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -383,7 +399,7 @@
       IF (Qout(idpthW,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idpthW,             &
      &                     QCK(ng)%Vid(idpthW),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -394,7 +410,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthW)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthW)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -408,7 +424,7 @@
       IF (Qout(idFsur,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idFsur,             &
      &                     QCK(ng)%Vid(idFsur),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -423,7 +439,7 @@
 #endif
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idFsur)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idFsur)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -436,7 +452,7 @@
       IF (Qout(idUbar,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idUbar,             &
      &                     QCK(ng)%Vid(idUbar),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -446,7 +462,7 @@
      &                     OCEAN(ng) % ubar(:,:,KOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbar)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbar)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -459,7 +475,7 @@
       IF (Qout(idVbar,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idVbar,             &
      &                     QCK(ng)%Vid(idVbar),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -469,7 +485,7 @@
      &                     OCEAN(ng) % vbar(:,:,KOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbar)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbar)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -502,7 +518,7 @@
 
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idu2dE,             &
      &                     QCK(ng)%Vid(idu2dE),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -512,14 +528,14 @@
      &                     Ur2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu2dE)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu2dE)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
 
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idv2dN,             &
      &                     QCK(ng)%Vid(idv2dN),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -529,7 +545,7 @@
      &                     Vr2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv2dN)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv2dN)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -546,7 +562,7 @@
       IF (Qout(idUvel,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idUvel,             &
      &                     QCK(ng)%Vid(idUvel),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -556,7 +572,7 @@
      &                     OCEAN(ng) % u(:,:,:,NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUvel)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUvel)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -569,7 +585,7 @@
       IF (Qout(idVvel,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idVvel,             &
      &                     QCK(ng)%Vid(idVvel),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -579,7 +595,7 @@
      &                     OCEAN(ng) % v(:,:,:,NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvel)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvel)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -592,7 +608,7 @@
       IF (Qout(idUsur,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idUsur,             &
      &                     QCK(ng)%Vid(idUsur),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -602,7 +618,7 @@
      &                     OCEAN(ng) % u(:,:,N(ng),NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUsur)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUsur)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -615,7 +631,7 @@
       IF (Qout(idVsur,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idVsur,             &
      &                     QCK(ng)%Vid(idVsur),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -625,7 +641,7 @@
      &                     OCEAN(ng) % v(:,:,N(ng),NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVsur)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVsur)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -660,7 +676,7 @@
         IF ((Qout(idu3dE,ng).and.Qout(idv3dN,ng))) THEN
           scale=1.0_dp
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idu3dE,           &
      &                       QCK(ng)%Vid(idu3dE),                       &
      &                       QCK(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -670,14 +686,14 @@
      &                       Ur3d)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idu3dE)), QCK(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idu3dE)), QCK(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
             RETURN
           END IF
 
-          status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idv3dN,           &
      &                       QCK(ng)%Vid(idv3dN),                       &
      &                       QCK(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -687,7 +703,7 @@
      &                       Vr3d)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idv3dN)), QCK(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idv3dN)), QCK(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -701,7 +717,7 @@
         IF ((Qout(idUsuE,ng).and.Qout(idVsuN,ng))) THEN
           scale=1.0_dp
           gtype=gfactor*r2dvar
-          status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                   &
+          status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idUsuE,           &
      &                       QCK(ng)%Vid(idUsuE),                       &
      &                       QCK(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -711,14 +727,14 @@
      &                       Ur3d(:,:,N(ng)))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idUsuE)), QCK(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idUsuE)), QCK(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
             RETURN
           END IF
 
-          status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                   &
+          status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idVsuN,           &
      &                       QCK(ng)%Vid(idVsuN),                       &
      &                       QCK(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -728,7 +744,7 @@
      &                       Vr3d(:,:,N(ng)))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idVsuN)), QCK(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idVsuN)), QCK(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -753,7 +769,7 @@
      &                    GRID(ng) % pn,                                &
      &                    OCEAN(ng) % W,                                &
      &                    Wr3d)
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idOvel,             &
      &                     QCK(ng)%Vid(idOvel),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -763,7 +779,7 @@
      &                     Wr3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idOvel)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idOvel)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -777,7 +793,7 @@
       IF (Qout(idWvel,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idWvel,             &
      &                     QCK(ng)%Vid(idWvel),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -787,7 +803,7 @@
      &                     OCEAN(ng) % wvel)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idWvel)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idWvel)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -801,7 +817,7 @@
         IF (Qout(idTvar(itrc),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r3dvar
-          status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                   &
+          status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idTvar(itrc),     &
      &                       QCK(ng)%Tid(itrc),                         &
      &                       QCK(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -811,7 +827,7 @@
      &                       OCEAN(ng) % t(:,:,:,NOUT,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),            &
      &                          QCK(ng)%Rindex
             END IF
             exit_flag=3
@@ -827,7 +843,7 @@
         IF (Qout(idsurT(itrc),ng)) THEN
           scale=1.0_dp
           gtype=gfactor*r2dvar
-          status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                   &
+          status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idsurT(itrc),     &
      &                       QCK(ng)%Vid(idsurT(itrc)),                 &
      &                       QCK(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -837,7 +853,7 @@
      &                       OCEAN(ng) % t(:,:,N(ng),NOUT,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idsurT(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idsurT(itrc))),            &
      &                          QCK(ng)%Rindex
             END IF
             exit_flag=3
@@ -852,7 +868,7 @@
       IF (Qout(idDano,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idDano,             &
      &                     QCK(ng)%Vid(idDano),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -862,7 +878,7 @@
      &                     OCEAN(ng) % rho)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idDano)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idDano)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -876,7 +892,7 @@
       IF (Qout(idHsbl,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idHsbl,             &
      &                     QCK(ng)%Vid(idHsbl),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -886,7 +902,7 @@
      &                     MIXING(ng) % hsbl)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHsbl)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHsbl)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -901,7 +917,7 @@
       IF (Qout(idHbbl,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idHbbl,             &
      &                     QCK(ng)%Vid(idHbbl),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -911,7 +927,7 @@
      &                     MIXING(ng) % hbbl)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHbbl)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHbbl)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -925,7 +941,7 @@
       IF (Qout(idVvis,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idVvis,             &
      &                     QCK(ng)%Vid(idVvis),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -936,7 +952,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvis)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvis)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -949,7 +965,7 @@
       IF (Qout(idTdif,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idTdif,             &
      &                     QCK(ng)%Vid(idTdif),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -960,7 +976,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTdif)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTdif)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -974,7 +990,7 @@
       IF (Qout(idSdif,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idSdif,             &
      &                     QCK(ng)%Vid(idSdif),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -985,7 +1001,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSdif)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSdif)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1000,7 +1016,7 @@
       IF (Qout(idMtke,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idMtke,             &
      &                     QCK(ng)%Vid(idMtke),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1011,7 +1027,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idMtke)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idMtke)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1024,7 +1040,7 @@
       IF (Qout(idMtls,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idMtls,             &
      &                     QCK(ng)%Vid(idMtls),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 0, N(ng), scale,         &
@@ -1036,7 +1052,7 @@
 
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idMtls)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idMtls)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1051,7 +1067,7 @@
       IF (Qout(idPair,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idPair,             &
      &                     QCK(ng)%Vid(idPair),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1061,7 +1077,7 @@
      &                     FORCES(ng) % Pair)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idPair)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idPair)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1076,7 +1092,7 @@
       IF (Qout(idTair,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idTair,             &
      &                     QCK(ng)%Vid(idTair),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1086,7 +1102,7 @@
      &                     FORCES(ng) % Tair)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTair)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTair)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1101,7 +1117,7 @@
       IF (Qout(idUair,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idUair,             &
      &                     QCK(ng)%Vid(idUair),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1111,7 +1127,7 @@
      &                     FORCES(ng) % Uwind)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUair)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUair)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1122,7 +1138,7 @@
       IF (Qout(idVair,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idVair,             &
      &                     QCK(ng)%Vid(idVair),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1132,7 +1148,7 @@
      &                     FORCES(ng) % Vwind)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVair)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVair)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1155,7 +1171,7 @@
             scale=1.0_dp
           END IF
           gtype=gfactor*r2dvar
-          status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                   &
+          status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idTsur(itrc),     &
      &                       QCK(ng)%Vid(idTsur(itrc)),                 &
      &                       QCK(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, scale,                 &
@@ -1165,7 +1181,7 @@
      &                       FORCES(ng) % stflx(:,:,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          QCK(ng)%Rindex
             END IF
             exit_flag=3
@@ -1182,7 +1198,7 @@
       IF (Qout(idLhea,ng)) THEN
         scale=rho0*Cp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idLhea,             &
      &                     QCK(ng)%Vid(idLhea),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1192,7 +1208,7 @@
      &                     FORCES(ng) % lhflx)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idLhea)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idLhea)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1205,7 +1221,7 @@
       IF (Qout(idShea,ng)) THEN
         scale=rho0*Cp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idShea,             &
      &                     QCK(ng)%Vid(idShea),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1215,7 +1231,7 @@
      &                     FORCES(ng) % shflx)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idShea)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idShea)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1228,7 +1244,7 @@
       IF (Qout(idLrad,ng)) THEN
         scale=rho0*Cp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idLrad,             &
      &                     QCK(ng)%Vid(idLrad),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1238,7 +1254,7 @@
      &                     FORCES(ng) % lrflx)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idLrad)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idLrad)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1255,7 +1271,7 @@
       IF (Qout(idevap,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idevap,             &
      &                     QCK(ng)%Vid(idevap),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1265,7 +1281,7 @@
      &                     FORCES(ng) % evap)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idevap)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idevap)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1278,7 +1294,7 @@
       IF (Qout(idrain,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idrain,             &
      &                     QCK(ng)%Vid(idrain),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1288,7 +1304,7 @@
      &                     FORCES(ng) % rain)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idrain)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idrain)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1303,7 +1319,7 @@
       IF (Qout(idEmPf,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idEmPf,             &
      &                     QCK(ng)%Vid(idEmPf),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1313,7 +1329,7 @@
      &                     FORCES(ng) % stflux(:,:,isalt))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idEmPf)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idEmPf)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1327,7 +1343,7 @@
       IF (Qout(idSrad,ng)) THEN
         scale=rho0*Cp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idSrad,             &
      &                     QCK(ng)%Vid(idSrad),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1337,7 +1353,7 @@
      &                     FORCES(ng) % srflx)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSrad)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSrad)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1352,7 +1368,7 @@
       IF (Qout(idUsms,ng)) THEN
         scale=rho0                          ! m2/s2 to Pa
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idUsms,             &
      &                     QCK(ng)%Vid(idUsms),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1362,7 +1378,7 @@
      &                     FORCES(ng) % sustr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUsms)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUsms)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1375,7 +1391,7 @@
       IF (Qout(idVsms,ng)) THEN
         scale=rho0
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idVsms,             &
      &                     QCK(ng)%Vid(idVsms),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1385,7 +1401,7 @@
      &                     FORCES(ng) % svstr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVsms)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVsms)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1398,7 +1414,7 @@
       IF (Qout(idUbms,ng)) THEN
         scale=-rho0
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idUbms,             &
      &                     QCK(ng)%Vid(idUbms),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1408,7 +1424,7 @@
      &                     FORCES(ng) % bustr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbms)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbms)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1421,7 +1437,7 @@
       IF (Qout(idVbms,ng)) THEN
         scale=-rho0
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idVbms,             &
      &                     QCK(ng)%Vid(idVbms),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1431,7 +1447,7 @@
      &                     FORCES(ng) % bvstr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbms)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbms)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1495,37 +1511,22 @@
       CALL netcdf_sync (ng, model, QCK(ng)%name, QCK(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
+  10  FORMAT (2x,'WRT_QUICK_NF90   - writing quicksave', t42,           &
 #ifdef SOLVE3D
-# ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, QCK(ng)%Rindex, ng
-# else
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, QCK(ng)%Rindex
-# endif
-#else
-# ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, QCK(ng)%Rindex, ng
-# else
-      IF (Master) WRITE (stdout,20) KOUT, QCK(ng)%Rindex
-# endif
-#endif
-!
-  10  FORMAT (/,' WRT_QUICK_NF90 - error while writing variable: ',a,   &
-     &        /,18x,'into quicksave NetCDF file for time record: ',i0)
-#ifdef SOLVE3D
-  20  FORMAT (2x,'WRT_QUICK_NF90   - wrote quicksave', t40,             &
 # ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
 # else
      &        'fields (Index=',i1,',',i1,') in record = ',i0)
 # endif
 #else
-  20  FORMAT (2x,'WRT_QUICK_NF90   - wrote quicksave', t40,             &
 # ifdef NESTING
      &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
 # else
      &        'fields (Index=',i1,')   in record = ',i0)
 # endif
 #endif
+  20  FORMAT (/,' WRT_QUICK_NF90 - error while writing variable: ',a,   &
+     &        /,18x,'into quicksave NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_quick_nf90
@@ -1582,6 +1583,22 @@
       Fcount=QCK(ng)%load
       QCK(ng)%Nrec(Fcount)=QCK(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+# ifdef SOLVE3D
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, QCK(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, QCK(ng)%Rindex
+#  endif
+# else
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, QCK(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) KOUT, QCK(ng)%Rindex
+#  endif
+# endif
+!
 !  Write out model time (s).
 !
       CALL pio_netcdf_put_fvar (ng, model, QCK(ng)%name,                &
@@ -1601,7 +1618,7 @@
       ELSE
         ioDesc => ioDesc_sp_p2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idPwet,            &
      &                   QCK(ng)%pioVar(idPwet),                        &
      &                   QCK(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1613,7 +1630,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idPwet)), QCK(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idPwet)), QCK(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1628,7 +1645,7 @@
       ELSE
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idRwet,            &
      &                   QCK(ng)%pioVar(idRwet),                        &
      &                   QCK(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1640,7 +1657,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRwet)), QCK(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRwet)), QCK(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1655,7 +1672,7 @@
       ELSE
         ioDesc => ioDesc_sp_u2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idUwet,            &
      &                   QCK(ng)%pioVar(idUwet),                        &
      &                   QCK(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1667,7 +1684,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUwet)), QCK(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUwet)), QCK(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1682,7 +1699,7 @@
       ELSE
         ioDesc => ioDesc_sp_v2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idVwet,            &
      &                   QCK(ng)%pioVar(idVwet),                        &
      &                   QCK(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1694,7 +1711,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVwet)), QCK(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVwet)), QCK(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1712,7 +1729,7 @@
         ELSE
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idpthR,          &
      &                     QCK(ng)%pioVar(idpthR),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1724,7 +1741,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthR)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthR)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1749,7 +1766,7 @@
         ELSE
           ioDesc => ioDesc_sp_u3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idpthU,          &
      &                     QCK(ng)%pioVar(idpthU),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1761,7 +1778,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthU)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthU)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1786,7 +1803,7 @@
         ELSE
           ioDesc => ioDesc_sp_v3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idpthV,          &
      &                     QCK(ng)%pioVar(idpthV),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1798,7 +1815,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthV)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthV)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1815,7 +1832,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idpthW,          &
      &                     QCK(ng)%pioVar(idpthW),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1827,7 +1844,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idpthW)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idpthW)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1845,7 +1862,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idFsur,          &
      &                     QCK(ng)%pioVar(idFsur),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1861,7 +1878,7 @@
 # endif
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idFsur)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idFsur)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1878,7 +1895,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idUbar,          &
      &                     QCK(ng)%pioVar(idUbar),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1889,7 +1906,7 @@
      &                     OCEAN(ng) % ubar(:,:,KOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbar)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbar)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1906,7 +1923,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idVbar,          &
      &                     QCK(ng)%pioVar(idVbar),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1917,7 +1934,7 @@
      &                     OCEAN(ng) % vbar(:,:,KOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbar)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbar)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1954,7 +1971,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idu2dE,          &
      &                     QCK(ng)%pioVar(idu2dE),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1965,7 +1982,7 @@
      &                     Ur2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu2dE)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idu2dE)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1977,7 +1994,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idv2dN,          &
      &                     QCK(ng)%pioVar(idv2dN),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1988,7 +2005,7 @@
      &                     Vr2d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv2dN)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idv2dN)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2009,7 +2026,7 @@
         ELSE
           ioDesc => ioDesc_sp_u3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idUvel,          &
      &                     QCK(ng)%pioVar(idUvel),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2020,7 +2037,7 @@
      &                     OCEAN(ng) % u(:,:,:,NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUvel)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUvel)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2037,7 +2054,7 @@
         ELSE
           ioDesc => ioDesc_sp_v3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idVvel,          &
      &                     QCK(ng)%pioVar(idVvel),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2048,7 +2065,7 @@
      &                     OCEAN(ng) % v(:,:,:,NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvel)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvel)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2065,7 +2082,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idUsur,          &
      &                     QCK(ng)%pioVar(idUsur),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2076,7 +2093,7 @@
      &                     OCEAN(ng) % u(:,:,N(ng),NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUsur)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUsur)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2093,7 +2110,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idVsur,          &
      &                     QCK(ng)%pioVar(idVsur),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2104,7 +2121,7 @@
      &                     OCEAN(ng) % v(:,:,N(ng),NOUT))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVsur)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVsur)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2143,7 +2160,7 @@
           ELSE
             ioDesc => ioDesc_sp_r3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idu3dE,        &
      &                       QCK(ng)%pioVar(idu3dE),                    &
      &                       QCK(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -2154,7 +2171,7 @@
      &                       Ur3d)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idu3dE)), QCK(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idu3dE)), QCK(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -2166,7 +2183,7 @@
           ELSE
             ioDesc => ioDesc_sp_r3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idv3dN,        &
      &                       QCK(ng)%pioVar(idv3dN),                    &
      &                       QCK(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -2177,7 +2194,7 @@
      &                       Vr3d)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idv3dN)), QCK(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idv3dN)), QCK(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -2195,7 +2212,7 @@
           ELSE
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                &
+          status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idUsuE,        &
      &                       QCK(ng)%pioVar(idUsuE),                    &
      &                       QCK(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -2206,7 +2223,7 @@
      &                       Ur3d(:,:,N(ng)))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idUsuE)), QCK(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idUsuE)), QCK(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -2218,7 +2235,7 @@
           ELSE
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                &
+          status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idVsuN,        &
      &                       QCK(ng)%pioVar(idVsuN),                    &
      &                       QCK(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -2229,7 +2246,7 @@
      &                       Vr3d(:,:,N(ng)))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idVsuN)), QCK(ng)%Rindex
+              WRITE (stdout,20) TRIM(Vname(1,idVsuN)), QCK(ng)%Rindex
             END IF
             exit_flag=3
             ioerror=status
@@ -2259,7 +2276,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idOvel,          &
      &                     QCK(ng)%pioVar(idOvel),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2270,7 +2287,7 @@
      &                     Wr3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idOvel)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idOvel)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2288,7 +2305,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idWvel,          &
      &                     QCK(ng)%pioVar(idWvel),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2299,7 +2316,7 @@
      &                     OCEAN(ng) % wvel)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idWvel)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idWvel)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2317,7 +2334,7 @@
           ELSE
             ioDesc => ioDesc_sp_r3dvar(ng)
           END IF
-          status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                &
+          status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idTvar(itrc),  &
      &                       QCK(ng)%pioTrc(itrc),                      &
      &                       QCK(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -2328,7 +2345,7 @@
      &                       OCEAN(ng) % t(:,:,:,NOUT,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),            &
      &                          QCK(ng)%Rindex
             END IF
             exit_flag=3
@@ -2348,7 +2365,7 @@
           ELSE
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                &
+          status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idsurT(itrc),  &
      &                       QCK(ng)%pioVar(idsurT(itrc)),              &
      &                       QCK(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -2359,7 +2376,7 @@
      &                       OCEAN(ng) % t(:,:,N(ng),NOUT,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idsurT(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idsurT(itrc))),            &
      &                          QCK(ng)%Rindex
             END IF
             exit_flag=3
@@ -2378,7 +2395,7 @@
         ELSE
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idDano,          &
      &                     QCK(ng)%pioVar(idDano),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2389,7 +2406,7 @@
      &                     OCEAN(ng) % rho)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idDano)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idDano)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2408,7 +2425,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idHsbl,          &
      &                     QCK(ng)%pioVar(idHsbl),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2419,7 +2436,7 @@
      &                     MIXING(ng) % hsbl)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHsbl)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHsbl)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2438,7 +2455,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idHbbl,          &
      &                     QCK(ng)%pioVar(idHbbl),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2449,7 +2466,7 @@
      &                     MIXING(ng) % hbbl)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idHbbl)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idHbbl)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2467,7 +2484,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idVvis,          &
      &                     QCK(ng)%pioVar(idVvis),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2479,7 +2496,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVvis)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVvis)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2496,7 +2513,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idTdif,          &
      &                     QCK(ng)%pioVar(idTdif),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2508,7 +2525,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTdif)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTdif)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2527,7 +2544,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idSdif,          &
      &                     QCK(ng)%pioVar(idSdif),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2539,7 +2556,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSdif)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSdif)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2558,7 +2575,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idMtke,          &
      &                     QCK(ng)%pioVar(idMtke),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2570,7 +2587,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idMtke)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idMtke)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2587,7 +2604,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idMtls,          &
      &                     QCK(ng)%pioVar(idMtls),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2600,7 +2617,7 @@
 
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idMtls)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idMtls)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2619,7 +2636,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idPair,          &
      &                     QCK(ng)%pioVar(idPair),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2630,7 +2647,7 @@
      &                     FORCES(ng) % Pair)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idPair)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idPair)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2649,7 +2666,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idTair,          &
      &                     QCK(ng)%pioVar(idTair),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2660,7 +2677,7 @@
      &                     FORCES(ng) % Tair)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTair)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTair)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2679,7 +2696,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idUair,          &
      &                     QCK(ng)%pioVar(idUair),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2690,7 +2707,7 @@
      &                     FORCES(ng) % Uwind)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUair)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUair)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2705,7 +2722,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idVair,          &
      &                     QCK(ng)%pioVar(idVair),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2716,7 +2733,7 @@
      &                     FORCES(ng) % Vwind)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVair)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVair)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2743,7 +2760,7 @@
           ELSE
             ioDesc => ioDesc_sp_r2dvar(ng)
           END IF
-          status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                &
+          status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idTsur(itrc),  &
      &                       QCK(ng)%pioVar(idTsur(itrc)),              &
      &                       QCK(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -2754,7 +2771,7 @@
      &                       FORCES(ng) % stflx(:,:,itrc))
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTsur(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),            &
      &                          QCK(ng)%Rindex
             END IF
             exit_flag=3
@@ -2775,7 +2792,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idLhea,          &
      &                     QCK(ng)%pioVar(idLhea),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2786,7 +2803,7 @@
      &                     FORCES(ng) % lhflx)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idLhea)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idLhea)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2803,7 +2820,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idShea,          &
      &                     QCK(ng)%pioVar(idShea),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2814,7 +2831,7 @@
      &                     FORCES(ng) % shflx)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idShea)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idShea)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2831,7 +2848,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idLrad,          &
      &                     QCK(ng)%pioVar(idLrad),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2842,7 +2859,7 @@
      &                     FORCES(ng) % lrflx)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idLrad)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idLrad)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2863,7 +2880,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idevap,          &
      &                     QCK(ng)%pioVar(idevap),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2874,7 +2891,7 @@
      &                     FORCES(ng) % evap)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idevap)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idevap)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2891,7 +2908,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idrain,          &
      &                     QCK(ng)%pioVar(idrain),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2902,7 +2919,7 @@
      &                     FORCES(ng) % rain)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idrain)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idrain)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2921,7 +2938,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idEmPf,          &
      &                     QCK(ng)%pioVar(idEmPf),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2932,7 +2949,7 @@
      &                     FORCES(ng) % stflux(:,:,isalt))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idEmPf)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idEmPf)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2951,7 +2968,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idSrad,          &
      &                     QCK(ng)%pioVar(idSrad),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2962,7 +2979,7 @@
      &                     FORCES(ng) % srflx)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSrad)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSrad)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2981,7 +2998,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idUsms,          &
      &                     QCK(ng)%pioVar(idUsms),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2992,7 +3009,7 @@
      &                     FORCES(ng) % sustr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUsms)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUsms)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3009,7 +3026,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idVsms,          &
      &                     QCK(ng)%pioVar(idVsms),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3020,7 +3037,7 @@
      &                     FORCES(ng) % svstr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVsms)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVsms)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3037,7 +3054,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idUbms,          &
      &                     QCK(ng)%pioVar(idUbms),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3048,7 +3065,7 @@
      &                     FORCES(ng) % bustr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbms)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbms)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3065,7 +3082,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idVbms,          &
      &                     QCK(ng)%pioVar(idVbms),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -3076,7 +3093,7 @@
      &                     FORCES(ng) % bvstr)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbms)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbms)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -3139,38 +3156,23 @@
 !
       CALL pio_netcdf_sync (ng, model, QCK(ng)%name, QCK(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-# ifdef SOLVE3D
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, QCK(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, QCK(ng)%Rindex
-#  endif
-# else
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, QCK(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) KOUT, QCK(ng)%Rindex
-#  endif
-# endif
 !
-  10  FORMAT (/,' WRT_QUICK_PIO - error while writing variable: ',a,    &
-     &        /,17x,'into quicksave NetCDF file for time record: ',i0)
+  10  FORMAT (2x,'WRT_QUICK_PIO    - writing quicksave', t42,           &
 # ifdef SOLVE3D
-  20  FORMAT (2x,'WRT_QUICK_PIO    - wrote quicksave', t40,             &
 #  ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
 #  else
      &        'fields (Index=',i1,',',i1,') in record = ',i0)
 #  endif
 # else
-  20  FORMAT (2x,'WRT_QUICK_PIO    - wrote quicksave', t40,             &
 #  ifdef NESTING
      &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
 #  else
      &        'fields (Index=',i1,')   in record = ',i0)
 #  endif
 # endif
+  20  FORMAT (/,' WRT_QUICK_PIO - error while writing variable: ',a,    &
+     &        /,17x,'into quicksave NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_quick_pio

--- a/ROMS/Utility/wrt_rst.F
+++ b/ROMS/Utility/wrt_rst.F
@@ -2,7 +2,7 @@
       MODULE wrt_rst_mod
 !
 !git $Id$
-!svn $Id: wrt_rst.F 1189 2023-08-15 21:26:58Z arango $
+!svn $Id: wrt_rst.F 1190 2023-08-18 19:51:09Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -647,7 +647,7 @@
         scale=1.0_dp
         gtype=gfactor*r3dvar
 # ifdef PERFECT_RESTART
-        status=nf_fwrite4d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite4d(ng, model, RST(ng)%ncid, idTvar(itrc),       &
      &                     RST(ng)%Tid(itrc),                           &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), 1, 2, scale,   &
@@ -1876,7 +1876,7 @@
         ELSE
           ioDesc => ioDesc_sp_trcvar(ng)
         END IF
-        status=nf_fwrite4d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite4d(ng, model, RST(ng)%pioFile, idTvar(itrc),    &
      &                     RST(ng)%pioTrc(itrc),                        &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &

--- a/ROMS/Utility/wrt_rst.F
+++ b/ROMS/Utility/wrt_rst.F
@@ -2,7 +2,7 @@
       MODULE wrt_rst_mod
 !
 !git $Id$
-!svn $Id: wrt_rst.F 1178 2023-07-11 17:50:57Z arango $
+!svn $Id: wrt_rst.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -153,6 +153,22 @@
       Fcount=RST(ng)%Fcount
       RST(ng)%Nrec(Fcount)=RST(ng)%Nrec(Fcount)+1
 !
+!  Report.
+!
+#ifdef SOLVE3D
+# ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, RST(ng)%Rindex, ng
+# else
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, RST(ng)%Rindex
+# endif
+#else
+# ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, RST(ng)%Rindex, ng
+# else
+      IF (Master) WRITE (stdout,10) KOUT, RST(ng)%Rindex
+# endif
+#endif
+!
 !  If requested, set time index to recycle time records in restart
 !  file.
 !
@@ -214,7 +230,7 @@
       IF (Hout(idbath,ng)) THEN
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, RST(ng)%ncid, idbath,             &
      &                     RST(ng)%Vid(idbath),                         &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -225,7 +241,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idbath)), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idbath)), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -239,7 +255,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*p2dvar
-      status=nf_fwrite2d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, RST(ng)%ncid, idPwet,               &
      &                   RST(ng)%Vid(idPwet),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -250,7 +266,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idPwet)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idPwet)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -261,7 +277,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, RST(ng)%ncid, idRwet,               &
      &                   RST(ng)%Vid(idRwet),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -272,7 +288,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRwet)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRwet)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -283,7 +299,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*u2dvar
-      status=nf_fwrite2d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, RST(ng)%ncid, idUwet,               &
      &                   RST(ng)%Vid(idUwet),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -294,7 +310,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUwet)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUwet)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -305,7 +321,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*v2dvar
-      status=nf_fwrite2d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, RST(ng)%ncid, idVwet,               &
      &                   RST(ng)%Vid(idVwet),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -316,7 +332,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVwet)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVwet)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -329,7 +345,7 @@
       scale=1.0_dp
 #ifdef PERFECT_RESTART
       gtype=gfactor*r3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idFsur,               &
      &                   RST(ng)%Vid(idFsur),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, 3, scale,               &
@@ -344,7 +360,7 @@
 # endif
 #else
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, RST(ng)%ncid, idFsur,               &
      &                   RST(ng)%Vid(idFsur),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -360,7 +376,7 @@
 #endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idFsur)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idFsur)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -372,7 +388,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*r3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idRzet,               &
      &                   RST(ng)%Vid(idRzet),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, 2, scale,               &
@@ -382,7 +398,7 @@
      &                   OCEAN(ng) % rzeta)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRzet)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRzet)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -395,7 +411,7 @@
       scale=1.0_dp
 #ifdef PERFECT_RESTART
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idUbar,               &
      &                   RST(ng)%Vid(idUbar),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, 3, scale,               &
@@ -407,7 +423,7 @@
 
 #else
       gtype=gfactor*u2dvar
-      status=nf_fwrite2d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, RST(ng)%ncid, idUbar,               &
      &                   RST(ng)%Vid(idUbar),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -418,7 +434,7 @@
 #endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUbar)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUbar)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -430,7 +446,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idRu2d,               &
      &                   RST(ng)%Vid(idRu2d),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, 2, scale,               &
@@ -441,7 +457,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRu2d)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRu2d)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -454,7 +470,7 @@
       scale=1.0_dp
 #ifdef PERFECT_RESTART
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idVbar,               &
      &                   RST(ng)%Vid(idVbar),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, 3, scale,               &
@@ -465,7 +481,7 @@
      &                   SetFillVal = .FALSE.)
 #else
       gtype=gfactor*v2dvar
-      status=nf_fwrite2d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, RST(ng)%ncid, idVbar,               &
      &                   RST(ng)%Vid(idVbar),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -476,7 +492,7 @@
 #endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVbar)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVbar)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -489,7 +505,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idRv2d,               &
      &                   RST(ng)%Vid(idRv2d),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, 2, scale,               &
@@ -500,7 +516,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRv2d)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRv2d)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -514,7 +530,7 @@
       scale=1.0_dp
       gtype=gfactor*u3dvar
 # ifdef PERFECT_RESTART
-      status=nf_fwrite4d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite4d(ng, model, RST(ng)%ncid, idUvel,               &
      &                   RST(ng)%Vid(idUvel),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), 1, 2, scale,     &
@@ -524,7 +540,7 @@
      &                   OCEAN(ng) % u,                                 &
      &                   SetFillVal = .FALSE.)
 # else
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idUvel,               &
      &                   RST(ng)%Vid(idUvel),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -535,7 +551,7 @@
 # endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUvel)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUvel)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -548,7 +564,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*u3dvar
-      status=nf_fwrite4d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite4d(ng, model, RST(ng)%ncid, idRu3d,               &
      &                   RST(ng)%Vid(idRu3d),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), 1, 2, scale,     &
@@ -559,7 +575,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRu3d)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRu3d)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -572,7 +588,7 @@
       scale=1.0_dp
       gtype=gfactor*v3dvar
 # ifdef PERFECT_RESTART
-      status=nf_fwrite4d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite4d(ng, model, RST(ng)%ncid, idVvel,               &
      &                   RST(ng)%Vid(idVvel),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), 1, 2, scale,     &
@@ -582,7 +598,7 @@
      &                   OCEAN(ng) % v,                                 &
      &                   SetFillVal = .FALSE.)
 # else
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idVvel,               &
      &                   RST(ng)%Vid(idVvel),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -593,7 +609,7 @@
 # endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVvel)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVvel)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -606,7 +622,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*v3dvar
-      status=nf_fwrite4d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite4d(ng, model, RST(ng)%ncid, idRv3d,               &
      &                   RST(ng)%Vid(idRv3d),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), 1, 2, scale,     &
@@ -617,7 +633,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRv3d)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRv3d)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -640,7 +656,7 @@
 #  endif
      &                     OCEAN(ng) % t(:,:,:,:,itrc))
 # else
-        status=nf_fwrite3d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, RST(ng)%ncid, idTvar(itrc),       &
      &                     RST(ng)%Tid(itrc),                           &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -651,7 +667,7 @@
 # endif
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))),              &
+            WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),              &
      &                        RST(ng)%Rindex
           END IF
           exit_flag=3
@@ -664,7 +680,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*r3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idDano,               &
      &                   RST(ng)%Vid(idDano),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 1, N(ng), scale,           &
@@ -674,7 +690,7 @@
      &                   OCEAN(ng) % rho)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idDano)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idDano)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -687,7 +703,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, RST(ng)%ncid, idHsbl,               &
      &                   RST(ng)%Vid(idHsbl),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -697,7 +713,7 @@
      &                   MIXING(ng) % hsbl)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idHsbl)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idHsbl)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -710,7 +726,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*r2dvar
-      status=nf_fwrite2d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite2d(ng, model, RST(ng)%ncid, idHbbl,               &
      &                   RST(ng)%Vid(idHbbl),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, scale,                     &
@@ -720,7 +736,7 @@
      &                   MIXING(ng) % hbbl)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idHbbl)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idHbbl)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -734,7 +750,7 @@
       DO i=1,NAT
         scale=1.0_dp
         gtype=gfactor*w3dvar
-        status=nf_fwrite3d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, RST(ng)%ncid, idGhat(i),          &
      &                       RST(ng)%Vid(idGhat(i)),                    &
      &                       RST(ng)%Rindex, gtype,                     &
      &                       LBi, UBi, LBj, UBj, 0, N(ng), scale,       &
@@ -744,7 +760,7 @@
      &                       MIXING(ng) % ghats(:,:,:,i))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idGhat(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idGhat(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -759,7 +775,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idVvis,               &
      &                   RST(ng)%Vid(idVvis),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
@@ -770,7 +786,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVvis)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVvis)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -781,7 +797,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idTdif,               &
      &                   RST(ng)%Vid(idTdif),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
@@ -793,7 +809,7 @@
 
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idTdif)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idTdif)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -806,7 +822,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idSdif,               &
      &                   RST(ng)%Vid(idSdif),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
@@ -817,7 +833,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idSdif)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idSdif)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -832,7 +848,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite4d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite4d(ng, model, RST(ng)%ncid, idMtke,               &
      &                   RST(ng)%Vid(idMtke),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), 1, 2, scale,     &
@@ -843,7 +859,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idMtke)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idMtke)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -854,7 +870,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite4d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite4d(ng, model, RST(ng)%ncid, idMtls,               &
      &                   RST(ng)%Vid(idMtls),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), 1, 2, scale,     &
@@ -865,7 +881,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idMtls)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idMtls)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -876,7 +892,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idVmLS,               &
      &                   RST(ng)%Vid(idVmLS),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
@@ -886,7 +902,7 @@
      &                   MIXING(ng) % Lscale)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVmLS)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVmLS)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -897,7 +913,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idVmKK,               &
      &                   RST(ng)%Vid(idVmKK),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
@@ -907,7 +923,7 @@
      &                   MIXING(ng) % Akk)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVmKK)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVmKK)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -919,7 +935,7 @@
 !
       scale=1.0_dp
       gtype=gfactor*w3dvar
-      status=nf_fwrite3d(ng, model, RST(ng)%ncid,                       &
+      status=nf_fwrite3d(ng, model, RST(ng)%ncid, idVmKP,               &
      &                   RST(ng)%Vid(idVmKP),                           &
      &                   RST(ng)%Rindex, gtype,                         &
      &                   LBi, UBi, LBj, UBj, 0, N(ng), scale,           &
@@ -929,7 +945,7 @@
      &                   MIXING(ng) % Akp)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVmKP)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVmKP)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -945,7 +961,7 @@
       DO i=1,NST
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, RST(ng)%ncid, idUbld(i),          &
      &                     RST(ng)%Vid(idUbld(i)),                      &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -955,7 +971,7 @@
      &                     SEDBED(ng) % bedldu(:,:,i))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbld(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbld(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -968,7 +984,7 @@
       DO i=1,NST
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, RST(ng)%ncid, idVbld(i),          &
      &                     RST(ng)%Vid(idVbld(i)),                      &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -978,7 +994,7 @@
      &                     SEDBED(ng) % bedldv(:,:,i))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbld(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbld(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -992,7 +1008,7 @@
       DO i=1,NST
         scale=1.0_dp
         gtype=gfactor*b3dvar
-        status=nf_fwrite3d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, RST(ng)%ncid, idfrac(i),          &
      &                     RST(ng)%Vid(idfrac(i)),                      &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, Nbed, scale,          &
@@ -1003,7 +1019,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idfrac(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idfrac(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1016,7 +1032,7 @@
       DO i=1,NST
         scale=1.0_dp
         gtype=gfactor*b3dvar
-        status=nf_fwrite3d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, RST(ng)%ncid, idBmas(i),          &
      &                     RST(ng)%Vid(idBmas(i)),                      &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, Nbed, scale,          &
@@ -1027,7 +1043,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idBmas(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idBmas(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1044,7 +1060,7 @@
           scale=1.0_dp
         END IF
         gtype=gfactor*b3dvar
-        status=nf_fwrite3d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, RST(ng)%ncid, idSbed(i),          &
      &                     RST(ng)%Vid(idSbed(i)),                      &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, Nbed, scale,          &
@@ -1055,7 +1071,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbed(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSbed(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1073,7 +1089,7 @@
       DO i=1,6
         scale=1.0_dp
         gtype=gfactor*r2dvar
-        status=nf_fwrite2d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, RST(ng)%ncid, idBott(i),          &
      &                     RST(ng)%Vid(idBott(i)),                      &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1083,7 +1099,7 @@
      &                     SEDBED(ng) % bottom(:,:,i))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idBott(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idBott(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1098,7 +1114,7 @@
 !
         scale=1.0_dp
         gtype=gfactor*u2dvar
-        status=nf_fwrite2d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, RST(ng)%ncid, idU2Sd,             &
      &                     RST(ng)%Vid(idU2Sd),                         &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1107,7 +1123,7 @@
 # endif
      &                     OCEAN(ng) % ubar_stokes)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-          IF (Master) WRITE (stdout,10) TRIM(Vname(1,idU2Sd)),          &
+          IF (Master) WRITE (stdout,20) TRIM(Vname(1,idU2Sd)),          &
      &                                  RST(ng)%Rindex
           exit_flag=3
           ioerror=status
@@ -1118,7 +1134,7 @@
 !
         scale=1.0_dp
         gtype=gfactor*v2dvar
-        status=nf_fwrite2d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite2d(ng, model, RST(ng)%ncid, idV2Sd,             &
      &                     RST(ng)%Vid(idV2Sd),                         &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1127,7 +1143,7 @@
 # endif
      &                     OCEAN(ng) % vbar_stokes)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-          IF (Master) WRITE (stdout,10) TRIM(Vname(1,idV2Sd)),          &
+          IF (Master) WRITE (stdout,20) TRIM(Vname(1,idV2Sd)),          &
      &                                  RST(ng)%Rindex
           exit_flag=3
           ioerror=status
@@ -1140,7 +1156,7 @@
 !
         scale=1.0_dp
         gtype=gfactor*u3dvar
-        status=nf_fwrite3d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, RST(ng)%ncid, idU3Sd,             &
      &                     RST(ng)%Vid(idU3Sd),                         &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1149,7 +1165,7 @@
 #  endif
      &                     OCEAN(ng) % u_stokes)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-          IF(Master) WRITE (stdout,10) TRIM(Vname(1,idU3Sd)),           &
+          IF(Master) WRITE (stdout,20) TRIM(Vname(1,idU3Sd)),           &
      &                                 RST(ng)%Rindex
           exit_flag=3
           ioerror=status
@@ -1160,7 +1176,7 @@
 !
         scale=1.0_dp
         gtype=gfactor*v3dvar
-        status=nf_fwrite3d(ng, model, RST(ng)%ncid,                     &
+        status=nf_fwrite3d(ng, model, RST(ng)%ncid, idV3Sd,             &
      &                     RST(ng)%Vid(idV3Sd),                         &
      &                     RST(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1169,7 +1185,7 @@
 #  endif
      &                     OCEAN(ng) % v_stokes)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-          IF (Master) WRITE (stdout,10) TRIM(Vname(1,idV3Sd)),          &
+          IF (Master) WRITE (stdout,20) TRIM(Vname(1,idV3Sd)),          &
      &                                  RST(ng)%Rindex
           exit_flag=3
           ioerror=status
@@ -1195,38 +1211,23 @@
 !
       CALL netcdf_sync (ng, model, RST(ng)%name, RST(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-#ifdef SOLVE3D
-# ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, RST(ng)%Rindex, ng
-# else
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, RST(ng)%Rindex
-# endif
-#else
-# ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, RST(ng)%Rindex, ng
-# else
-      IF (Master) WRITE (stdout,20) KOUT, RST(ng)%Rindex
-# endif
-#endif
 !
-  10  FORMAT (/,' WRT_RST_NF90 - error while writing variable: ',a,     &
-     &        /,16x,'into restart NetCDF file for time record: ',i0)
+  10  FORMAT (2x,'WRT_RST_NF90     - writing re-start', t42,            &
 #ifdef SOLVE3D
-  20  FORMAT (2x,'WRT_RST_NF90     - wrote re-start', t40,              &
 # ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
 # else
      &        'fields (Index=',i1,',',i1,') in record = ',i0)
 # endif
 #else
-  20  FORMAT (2x,'WRT_RST_NF90     - wrote re-start', t40,              &
 # ifdef NESTING
      &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
 # else
      &        'fields (Index=',i1,')   in record = ',i0)
 # endif
 #endif
+  20  FORMAT (/,' WRT_RST_NF90 - error while writing variable: ',a,     &
+     &        /,16x,'into restart NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_rst_nf90
@@ -1272,6 +1273,22 @@
       RST(ng)%Rindex=RST(ng)%Rindex+1
       Fcount=RST(ng)%Fcount
       RST(ng)%Nrec(Fcount)=RST(ng)%Nrec(Fcount)+1
+!
+!  Report.
+!
+# ifdef SOLVE3D
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, RST(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) KOUT, NOUT, RST(ng)%Rindex
+#  endif
+# else
+#  ifdef NESTING
+      IF (Master) WRITE (stdout,10) KOUT, RST(ng)%Rindex, ng
+#  else
+      IF (Master) WRITE (stdout,10) KOUT, RST(ng)%Rindex
+#  endif
+# endif
 !
 !  If requested, set time index to recycle time records in restart
 !  file.
@@ -1338,7 +1355,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idbath,          &
      &                     RST(ng)%pioVar(idbath),                      &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1350,7 +1367,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idbath)), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idbath)), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1368,7 +1385,7 @@
       ELSE
         ioDesc => ioDesc_sp_p2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idPwet,            &
      &                   RST(ng)%pioVar(idPwet),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc(ng),                                    &
@@ -1380,7 +1397,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idPwet)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idPwet)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1395,7 +1412,7 @@
       ELSE
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idRwet,            &
      &                   RST(ng)%pioVar(idRwet),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1407,7 +1424,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRwet)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRwet)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1422,7 +1439,7 @@
       ELSE
         ioDesc => ioDesc_sp_u2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idUwet,            &
      &                   RST(ng)%pioVar(idUwet),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1434,7 +1451,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUwet)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUwet)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1449,7 +1466,7 @@
       ELSE
         ioDesc => ioDesc_sp_v2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idVwet,            &
      &                   RST(ng)%pioVar(idVwet),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1461,7 +1478,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVwet)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVwet)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1478,7 +1495,7 @@
       ELSE
         ioDesc => ioDesc_sp_zeta(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idFsur,            &
      &                   RST(ng)%pioVar(idFsur),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1498,7 +1515,7 @@
       ELSE
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idFsur,            &
      &                   RST(ng)%pioVar(idFsur),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1515,7 +1532,7 @@
 # endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idFsur)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idFsur)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1532,7 +1549,7 @@
       ELSE
         ioDesc => ioDesc_sp_rzeta(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idRzet,            &
      &                   RST(ng)%pioVar(idRzet),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1543,7 +1560,7 @@
      &                   OCEAN(ng) % rzeta)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRzet)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRzet)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1560,7 +1577,7 @@
       ELSE
         ioDesc => ioDesc_sp_ubar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idUbar,            &
      &                   RST(ng)%pioVar(idUbar),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1577,7 +1594,7 @@
       ELSE
         ioDesc => ioDesc_sp_u2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idUbar,            &
      &                   RST(ng)%pioVar(idUbar),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1589,7 +1606,7 @@
 # endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUbar)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUbar)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1606,7 +1623,7 @@
       ELSE
         ioDesc => ioDesc_sp_rubar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idRu2d,            &
      &                   RST(ng)%pioVar(idRu2d),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1618,7 +1635,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRu2d)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRu2d)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1635,7 +1652,7 @@
       ELSE
         ioDesc => ioDesc_sp_vbar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idVbar,            &
      &                   RST(ng)%pioVar(idVbar),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1651,7 +1668,7 @@
       ELSE
         ioDesc => ioDesc_sp_v2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idVbar,            &
      &                   RST(ng)%pioVar(idVbar),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1663,7 +1680,7 @@
 # endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVbar)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVbar)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1680,7 +1697,7 @@
       ELSE
         ioDesc => ioDesc_sp_rvbar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idRv2d,            &
      &                   RST(ng)%pioVar(idRv2d),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1692,7 +1709,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRv2d)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRv2d)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1710,7 +1727,7 @@
       ELSE
         ioDesc => ioDesc_sp_uvel(ng)
       END IF
-      status=nf_fwrite4d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite4d(ng, model, RST(ng)%pioFile, idUvel,            &
      &                   RST(ng)%pioVar(idUvel),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1726,7 +1743,7 @@
       ELSE
         ioDesc => ioDesc_sp_u3dvar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idUvel,            &
      &                   RST(ng)%pioVar(idUvel),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1738,7 +1755,7 @@
 #  endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idUvel)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idUvel)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1755,7 +1772,7 @@
       ELSE
         ioDesc => ioDesc_sp_ruvel(ng)
       END IF
-      status=nf_fwrite4d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite4d(ng, model, RST(ng)%pioFile, idRu3d,            &
      &                   RST(ng)%pioVar(idRu3d),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1767,7 +1784,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRu3d)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRu3d)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1784,7 +1801,7 @@
       ELSE
         ioDesc => ioDesc_sp_vvel(ng)
       END IF
-      status=nf_fwrite4d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite4d(ng, model, RST(ng)%pioFile, idVvel,            &
      &                   RST(ng)%pioVar(idVvel),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1800,7 +1817,7 @@
       ELSE
         ioDesc => ioDesc_sp_v3dvar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idVvel,            &
      &                   RST(ng)%pioVar(idVvel),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1812,7 +1829,7 @@
 #  endif
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVvel)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVvel)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1829,7 +1846,7 @@
       ELSE
         ioDesc => ioDesc_sp_rvvel(ng)
       END IF
-      status=nf_fwrite4d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite4d(ng, model, RST(ng)%pioFile, idRv3d,            &
      &                   RST(ng)%pioVar(idRv3d),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1841,7 +1858,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idRv3d)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idRv3d)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1874,7 +1891,7 @@
         ELSE
           ioDesc => ioDesc_sp_r3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idTvar(itrc),    &
      &                     RST(ng)%pioTrc(itrc),                        &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -1886,7 +1903,7 @@
 #  endif
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idTvar(itrc))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -1902,7 +1919,7 @@
       ELSE
         ioDesc => ioDesc_sp_r3dvar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idDano,            &
      &                   RST(ng)%pioVar(idDano),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1913,7 +1930,7 @@
      &                   OCEAN(ng) % rho)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idDano)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idDano)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1930,7 +1947,7 @@
       ELSE
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idHsbl,            &
      &                   RST(ng)%pioVar(idHsbl),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1941,7 +1958,7 @@
      &                   MIXING(ng) % hsbl)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idHsbl)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idHsbl)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1958,7 +1975,7 @@
       ELSE
         ioDesc => ioDesc_sp_r2dvar(ng)
       END IF
-      status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idHbbl,            &
      &                   RST(ng)%pioVar(idHbbl),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -1969,7 +1986,7 @@
      &                   MIXING(ng) % hbbl)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idHbbl)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idHbbl)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -1987,7 +2004,7 @@
         ELSE
           ioDesc => ioDesc_sp_w3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idGhat(i),       &
      &                       RST(ng)%pioVar(idGhat(i)),                 &
      &                       RST(ng)%Rindex,                            &
      &                       ioDesc,                                    &
@@ -1998,7 +2015,7 @@
      &                       MIXING(ng) % ghats(:,:,:,i))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idGhat(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idGhat(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2017,7 +2034,7 @@
       ELSE
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idVvis,            &
      &                   RST(ng)%pioVar(idVvis),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -2029,7 +2046,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVvis)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVvis)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -2044,7 +2061,7 @@
       ELSE
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idTdif,            &
      &                   RST(ng)%pioVar(idTdif),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -2057,7 +2074,7 @@
 
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idTdif)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idTdif)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -2074,7 +2091,7 @@
       ELSE
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idSdif,            &
      &                   RST(ng)%pioVar(idSdif),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -2086,7 +2103,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idSdif)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idSdif)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -2105,7 +2122,7 @@
       ELSE
         ioDesc => ioDesc_sp_tkevar(ng)
       END IF
-      status=nf_fwrite4d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite4d(ng, model, RST(ng)%pioFile, idMtke,            &
      &                   RST(ng)%pioVar(idMtke),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -2117,7 +2134,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idMtke)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idMtke)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -2132,7 +2149,7 @@
       ELSE
         ioDesc => ioDesc_sp_tkevar(ng)
       END IF
-      status=nf_fwrite4d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite4d(ng, model, RST(ng)%pioFile, idMtls,            &
      &                   RST(ng)%pioVar(idMtls),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -2144,7 +2161,7 @@
      &                   SetFillVal = .FALSE.)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idMtls)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idMtls)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -2159,7 +2176,7 @@
       ELSE
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idVmLS,            &
      &                   RST(ng)%pioVar(idVmLS),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -2170,7 +2187,7 @@
      &                   MIXING(ng) % Lscale)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVmLS)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVmLS)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -2185,7 +2202,7 @@
       ELSE
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idVmKK,            &
      &                   RST(ng)%pioVar(idVmKK),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -2196,7 +2213,7 @@
      &                   MIXING(ng) % Akk)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVmKK)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVmKK)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -2213,7 +2230,7 @@
       ELSE
         ioDesc => ioDesc_sp_w3dvar(ng)
       END IF
-      status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                    &
+      status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idVmKP,            &
      &                   RST(ng)%pioVar(idVmKP),                        &
      &                   RST(ng)%Rindex,                                &
      &                   ioDesc,                                        &
@@ -2224,7 +2241,7 @@
      &                   MIXING(ng) % Akp)
       IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
         IF (Master) THEN
-          WRITE (stdout,10) TRIM(Vname(1,idVmKP)), RST(ng)%Rindex
+          WRITE (stdout,20) TRIM(Vname(1,idVmKP)), RST(ng)%Rindex
         END IF
         exit_flag=3
         ioerror=status
@@ -2244,7 +2261,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idUbld(i),       &
      &                     RST(ng)%pioVar(idUbld(i)),                   &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2255,7 +2272,7 @@
      &                     SEDBED(ng) % bedldu(:,:,i))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idUbld(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idUbld(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2272,7 +2289,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idVbld(i),       &
      &                     RST(ng)%pioVar(idVbld(i)),                   &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2283,7 +2300,7 @@
      &                     SEDBED(ng) % bedldv(:,:,i))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idVbld(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idVbld(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2301,7 +2318,7 @@
         ELSE
           ioDesc => ioDesc_sp_b3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idfrac(i),       &
      &                     RST(ng)%pioVar(idfrac(i)),                   &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2313,7 +2330,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idfrac(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idfrac(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2330,7 +2347,7 @@
         ELSE
           ioDesc => ioDesc_sp_b3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idBmas(i),       &
      &                     RST(ng)%pioVar(idBmas(i)),                   &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2342,7 +2359,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idBmas(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idBmas(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2363,7 +2380,7 @@
         ELSE
           ioDesc => ioDesc_sp_b3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idSbed(i),       &
      &                     RST(ng)%pioVar(idSbed(i)),                   &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2375,7 +2392,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idSbed(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idSbed(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2397,7 +2414,7 @@
         ELSE
           ioDesc => ioDesc_sp_r2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idBott(i),       &
      &                     RST(ng)%pioVar(idBott(i)),                   &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2408,7 +2425,7 @@
      &                     SEDBED(ng) % bottom(:,:,i))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idBott(i))), RST(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idBott(i))), RST(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
@@ -2427,7 +2444,7 @@
         ELSE
           ioDesc => ioDesc_sp_u2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idU2Sd,          &
      &                     RST(ng)%pioVar(idU2Sd),                      &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2437,7 +2454,7 @@
 #  endif
      &                     OCEAN(ng) % ubar_stokes)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-          IF (Master) WRITE (stdout,10) TRIM(Vname(1,idU2Sd)),          &
+          IF (Master) WRITE (stdout,20) TRIM(Vname(1,idU2Sd)),          &
      &                                  RST(ng)%Rindex
           exit_flag=3
           ioerror=status
@@ -2452,7 +2469,7 @@
         ELSE
           ioDesc => ioDesc_sp_v2dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite2d(ng, model, RST(ng)%pioFile, idV2Sd,          &
      &                     RST(ng)%pioVar(idV2Sd),                      &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2462,7 +2479,7 @@
 #  endif
      &                     OCEAN(ng) % vbar_stokes)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-          IF (Master) WRITE (stdout,10) TRIM(Vname(1,idV2Sd)),          &
+          IF (Master) WRITE (stdout,20) TRIM(Vname(1,idV2Sd)),          &
      &                                  RST(ng)%Rindex
           exit_flag=3
           ioerror=status
@@ -2479,7 +2496,7 @@
         ELSE
           ioDesc => ioDesc_sp_u3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idU3Sd,          &
      &                     RST(ng)%pioVar(idU3Sd),                      &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2489,7 +2506,7 @@
 #   endif
      &                     OCEAN(ng) % u_stokes)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-          IF(Master) WRITE (stdout,10) TRIM(Vname(1,idU3Sd)),           &
+          IF(Master) WRITE (stdout,20) TRIM(Vname(1,idU3Sd)),           &
      &                                 RST(ng)%Rindex
           exit_flag=3
           ioerror=status
@@ -2504,7 +2521,7 @@
         ELSE
           ioDesc => ioDesc_sp_v3dvar(ng)
         END IF
-        status=nf_fwrite3d(ng, model, RST(ng)%pioFile,                  &
+        status=nf_fwrite3d(ng, model, RST(ng)%pioFile, idV3Sd,          &
      &                     RST(ng)%pioVar(idV3Sd),                      &
      &                     RST(ng)%Rindex,                              &
      &                     ioDesc,                                      &
@@ -2514,7 +2531,7 @@
 #   endif
      &                     OCEAN(ng) % v_stokes)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-          IF (Master) WRITE (stdout,10) TRIM(Vname(1,idV3Sd)),          &
+          IF (Master) WRITE (stdout,20) TRIM(Vname(1,idV3Sd)),          &
      &                                  RST(ng)%Rindex
           exit_flag=3
           ioerror=status
@@ -2540,38 +2557,23 @@
 !
       CALL pio_netcdf_sync (ng, model, RST(ng)%name, RST(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-# ifdef SOLVE3D
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, RST(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) KOUT, NOUT, RST(ng)%Rindex
-#  endif
-# else
-#  ifdef NESTING
-      IF (Master) WRITE (stdout,20) KOUT, RST(ng)%Rindex, ng
-#  else
-      IF (Master) WRITE (stdout,20) KOUT, RST(ng)%Rindex
-#  endif
-# endif
 !
-  10  FORMAT (/,' WRT_RST_PIO - error while writing variable: ',a,      &
-     &        /,16x,'into restart NetCDF file for time record: ',i0)
+  10  FORMAT (2x,'WRT_RST_PIO      - writing re-start', t42,            &
 # ifdef SOLVE3D
-  20  FORMAT (2x,'WRT_RST_PIO      - wrote re-start', t40,              &
 #  ifdef NESTING
      &        'fields (Index=',i1,',',i1,') in record = ',i0,t92,i2.2)
 #  else
      &        'fields (Index=',i1,',',i1,') in record = ',i0)
 #  endif
 # else
-  20  FORMAT (2x,'WRT_RST_PIO      - wrote re-start', t40,              &
 #  ifdef NESTING
      &        'fields (Index=',i1,')   in record = ',i0,t92,i2.2)
 #  else
      &        'fields (Index=',i1,')   in record = ',i0)
 #  endif
 # endif
+  20  FORMAT (/,' WRT_RST_PIO - error while writing variable: ',a,      &
+     &        /,16x,'into restart NetCDF file for time record: ',i0)
 !
       RETURN
       END SUBROUTINE wrt_rst_pio

--- a/ROMS/Utility/wrt_state.F
+++ b/ROMS/Utility/wrt_state.F
@@ -267,7 +267,8 @@
       scale=1.0_dp
       gtype=gfactor*r2dvar
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite2d(ng, model, ncid, S(ng)%Vid(idFsur),          &
+        status=nf_fwrite2d(ng, model, ncid, idFsur,                     &
+     &                     S(ng)%Vid(idFsur),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 # ifdef MASKING
@@ -284,7 +285,8 @@
      &                     MaxValue = Fmax)
 # endif
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite2d(ng, model, ncid, S(ng)%Vid(idFsur),          &
+        status=nf_fwrite2d(ng, model, ncid, idFsur,                     &
+     &                     S(ng)%Vid(idFsur),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 # ifdef MASKING
@@ -364,7 +366,8 @@
       scale=1.0_dp
       gtype=gfactor*u2dvar
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite2d(ng, model, ncid, S(ng)%Vid(idUbar),          &
+        status=nf_fwrite2d(ng, model, ncid, idUbar,                     &
+     &                     S(ng)%Vid(idUbar),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 # ifdef MASKING
@@ -375,7 +378,8 @@
      &                     MaxValue = Fmax)
 
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite2d(ng, model, ncid, S(ng)%Vid(idUbar),          &
+        status=nf_fwrite2d(ng, model, ncid, idUbar,                     &
+     &                     S(ng)%Vid(idUbar),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 # ifdef MASKING
@@ -448,7 +452,8 @@
       scale=1.0_dp
       gtype=gfactor*v2dvar
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite2d(ng, model, ncid, S(ng)%Vid(idVbar),          &
+        status=nf_fwrite2d(ng, model, ncid, idVbar,                     &
+     &                     S(ng)%Vid(idVbar),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 # ifdef MASKING
@@ -458,7 +463,8 @@
      &                     MinValue = Fmin,                             &
      &                     MaxValue = Fmax)
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite2d(ng, model, ncid, S(ng)%Vid(idVbar),          &
+        status=nf_fwrite2d(ng, model, ncid, idVbar,                     &
+     &                     S(ng)%Vid(idVbar),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, scale,                   &
 # ifdef MASKING
@@ -535,7 +541,8 @@
       scale=1.0_dp
       gtype=gfactor*u3dvar
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite3d(ng, model, ncid, S(ng)%Vid(idUsms),          &
+        status=nf_fwrite3d(ng, model, ncid, idUsms,                     &
+     &                     S(ng)%Vid(idUsms),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,     &
 #  ifdef MASKING
@@ -545,7 +552,8 @@
      &                     MinValue = Fmin,                             &
      &                     MaxValue = Fmax)
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite3d(ng, model, ncid, S(ng)%Vid(idUsms),          &
+        status=nf_fwrite3d(ng, model, ncid, idUsms,                     &
+     &                     S(ng)%Vid(idUsms),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,     &
 #  ifdef MASKING
@@ -575,7 +583,8 @@
       scale=1.0_dp
       gtype=gfactor*v3dvar
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite3d(ng, model, ncid, S(ng)%Vid(idVsms),          &
+        status=nf_fwrite3d(ng, model, ncid, idVsms,                     &
+     &                     S(ng)%Vid(idVsms),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,     &
 #  ifdef MASKING
@@ -586,7 +595,8 @@
      &                     MaxValue = Fmax)
 
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite3d(ng, model, ncid, S(ng)%Vid(idVsms),          &
+        status=nf_fwrite3d(ng, model, ncid, idVsms,                     &
+     &                     S(ng)%Vid(idVsms),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,     &
 #  ifdef MASKING
@@ -618,7 +628,8 @@
       scale=1.0_dp
       gtype=gfactor*u3dvar
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite3d(ng, model, ncid, S(ng)%Vid(idUvel),          &
+        status=nf_fwrite3d(ng, model, ncid, idUvel,                     &
+     &                     S(ng)%Vid(idUvel),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -629,7 +640,8 @@
      &                     MaxValue = Fmax)
 
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite3d(ng, model, ncid, S(ng)%Vid(idUvel),          &
+        status=nf_fwrite3d(ng, model, ncid, idUvel,                     &
+     &                     S(ng)%Vid(idUvel),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -702,7 +714,8 @@
       scale=1.0_dp
       gtype=gfactor*v3dvar
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite3d(ng, model, ncid, S(ng)%Vid(idVvel),          &
+        status=nf_fwrite3d(ng, model, ncid, idVvel,                     &
+     &                     S(ng)%Vid(idVvel),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -712,7 +725,8 @@
      &                     MinValue = Fmin,                             &
      &                     MaxValue = Fmax)
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite3d(ng, model, ncid, S(ng)%Vid(idVvel),          &
+        status=nf_fwrite3d(ng, model, ncid, idVvel,                     &
+     &                     S(ng)%Vid(idVvel),                           &
      &                     OutRec, gtype,                               &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
 #  ifdef MASKING
@@ -786,7 +800,8 @@
         scale=1.0_dp
         gtype=gfactor*r3dvar
         IF (model.eq.iTLM) THEN
-          status=nf_fwrite3d(ng, model, ncid, S(ng)%Tid(itrc),          &
+          status=nf_fwrite3d(ng, model, ncid, idTvar(itrc),             &
+     &                       S(ng)%Tid(itrc),                           &
      &                       OutRec, gtype,                             &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
 #  ifdef MASKING
@@ -796,7 +811,8 @@
      &                       MinValue = Fmin,                           &
      &                       MaxValue = Fmax)
         ELSE IF (model.eq.iADM) THEN
-          status=nf_fwrite3d(ng, model, ncid, S(ng)%Tid(itrc),          &
+          status=nf_fwrite3d(ng, model, ncid, idTvar(itrc),             &
+     &                       S(ng)%Tid(itrc),                           &
      &                       OutRec, gtype,                             &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
 #  ifdef MASKING
@@ -830,27 +846,27 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           IF (model.eq.iTLM) THEN
-            status=nf_fwrite3d_bry (ng, model, S(ng)%name, ncid,        &
-     &                              Vname(1,idSbry(isTvar(itrc))),      &
-     &                              S(ng)%Vid(idSbry(isTvar(itrc))),    &
-     &                              OutRec, r3dvar,                     &
-     &                              LBij, UBij, 1, N(ng), Nbrec(ng),    &
-     &                              scale,                              &
-     &                              BOUNDARY(ng) % tl_t_obc(LBij:,:,:,:,&
-     &                                                Lbout(ng),itrc),  &
-     &                              MinValue = Fmin,                    &
-     &                              MaxValue = Fmax)
+            status=nf_fwrite3d_bry(ng, model, S(ng)%name, ncid,         &
+     &                             Vname(1,idSbry(isTvar(itrc))),       &
+     &                             S(ng)%Vid(idSbry(isTvar(itrc))),     &
+     &                             OutRec, r3dvar,                      &
+     &                             LBij, UBij, 1, N(ng), Nbrec(ng),     &
+     &                             scale,                               &
+     &                             BOUNDARY(ng) % tl_t_obc(LBij:,:,:,:, &
+     &                                               Lbout(ng),itrc),   &
+     &                             MinValue = Fmin,                     &
+     &                             MaxValue = Fmax)
           ELSE IF (model.eq.iADM) THEN
-            status=nf_fwrite3d_bry (ng, model, S(ng)%name, ncid,        &
-     &                              Vname(1,idSbry(isTvar(itrc))),      &
-     &                              S(ng)%Vid(idSbry(isTvar(itrc))),    &
-     &                              OutRec, r3dvar,                     &
-     &                              LBij, UBij, 1, N(ng), Nbrec(ng),    &
-     &                              scale,                              &
-     &                              BOUNDARY(ng) % ad_t_obc(LBij:,:,:,:,&
-     &                                                Lbout(ng),itrc),  &
-     &                              MinValue = Fmin,                    &
-     &                              MaxValue = Fmax)
+            status=nf_fwrite3d_bry(ng, model, S(ng)%name, ncid,         &
+     &                             Vname(1,idSbry(isTvar(itrc))),       &
+     &                             S(ng)%Vid(idSbry(isTvar(itrc))),     &
+     &                             OutRec, r3dvar,                      &
+     &                             LBij, UBij, 1, N(ng), Nbrec(ng),     &
+     &                             scale,                               &
+     &                             BOUNDARY(ng) % ad_t_obc(LBij:,:,:,:, &
+     &                                               Lbout(ng),itrc),   &
+     &                             MinValue = Fmin,                     &
+     &                             MaxValue = Fmax)
           END IF
           IF (status.ne.nf90_noerr) THEN
             IF (Master) THEN
@@ -881,7 +897,7 @@
           scale=1.0_dp                      ! kinematic flux units
           gtype=gfactor*r3dvar
           IF (model.eq.iTLM) THEN
-            status=nf_fwrite3d(ng, iTLM, ncid,                          &
+            status=nf_fwrite3d(ng, iTLM, ncid, idTsur(itrc),            &
      &                         S(ng)%Vid(idTsur(itrc)),                 &
      &                         OutRec, gtype,                           &
      &                         LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale, &
@@ -893,7 +909,7 @@
      &                         MinValue = Fmin,                         &
      &                         MaxValue = Fmax)
           ELSE IF (model.eq.iADM) THEN
-            status=nf_fwrite3d(ng, iTLM, ncid,                          &
+            status=nf_fwrite3d(ng, iTLM, ncid, idTsur(itrc),            &
      &                         S(ng)%Vid(idTsur(itrc)),                 &
      &                         OutRec, gtype,                           &
      &                         LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale, &
@@ -1074,7 +1090,7 @@
       END IF
 !
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite2d(ng, model, pioFile,                          &
+        status=nf_fwrite2d(ng, model, pioFile, idFsur,                  &
      &                     S(ng)%pioVar(idFsur), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1092,7 +1108,7 @@
      &                     MaxValue = Fmax)
 #  endif
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite2d(ng, model, pioFile,                          &
+        status=nf_fwrite2d(ng, model, pioFile, idFsur,                  &
      &                     S(ng)%pioVar(idFsur), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1184,7 +1200,7 @@
       END IF
 !
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite2d(ng, model, pioFile,                          &
+        status=nf_fwrite2d(ng, model, pioFile, idUbar,                  &
      &                     S(ng)%pioVar(idUbar), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1196,7 +1212,7 @@
      &                     MaxValue = Fmax)
 
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite2d(ng, model, pioFile,                          &
+        status=nf_fwrite2d(ng, model, pioFile, idUbar,                  &
      &                     S(ng)%pioVar(idUbar), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1281,7 +1297,7 @@
       END IF
 !
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite2d(ng, model, pioFile,                          &
+        status=nf_fwrite2d(ng, model, pioFile, idVbar,                  &
      &                     S(ng)%pioVar(idVbar), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1292,7 +1308,7 @@
      &                     MinValue = Fmin,                             &
      &                     MaxValue = Fmax)
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite2d(ng, model, pioFile,                          &
+        status=nf_fwrite2d(ng, model, pioFile, idVbar,                  &
      &                     S(ng)%pioVar(idVbar), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, scale,                   &
@@ -1381,7 +1397,7 @@
       END IF
 !
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite3d(ng, model, pioFile,                          &
+        status=nf_fwrite3d(ng, model, pioFile, idUsms,                  &
      &                     S(ng)%pioVar(idUsms), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,     &
@@ -1392,7 +1408,7 @@
      &                     MinValue = Fmin,                             &
      &                     MaxValue = Fmax)
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite3d(ng, model, pioFile,                          &
+        status=nf_fwrite3d(ng, model, pioFile, idUsms,                  &
      &                     S(ng)%pioVar(idUsms), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,     &
@@ -1427,7 +1443,7 @@
       END IF
 !
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite3d(ng, model, pioFile,                          &
+        status=nf_fwrite3d(ng, model, pioFile, idVsms,                  &
      &                     S(ng)%pioVar(idVsms), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,     &
@@ -1439,7 +1455,7 @@
      &                     MaxValue = Fmax)
 
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite3d(ng, model, pioFile,                          &
+        status=nf_fwrite3d(ng, model, pioFile, idVsms,                  &
      &                     S(ng)%pioVar(idVsms), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale,     &
@@ -1477,7 +1493,7 @@
       END IF
 !
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite3d(ng, model, pioFile,                          &
+        status=nf_fwrite3d(ng, model, pioFile, idUvel,                  &
      &                     S(ng)%pioVar(idUvel), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1489,7 +1505,7 @@
      &                     MaxValue = Fmax)
 
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite3d(ng, model, pioFile,                          &
+        status=nf_fwrite3d(ng, model, pioFile, idUvel,                  &
      &                     S(ng)%pioVar(idUvel), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1574,7 +1590,7 @@
       END IF
 !
       IF (model.eq.iTLM) THEN
-        status=nf_fwrite3d(ng, model, pioFile,                          &
+        status=nf_fwrite3d(ng, model, pioFile, idVvel,                  &
      &                     S(ng)%pioVar(idVvel), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1585,7 +1601,7 @@
      &                     MinValue = Fmin,                             &
      &                     MaxValue = Fmax)
       ELSE IF (model.eq.iADM) THEN
-        status=nf_fwrite3d(ng, model, pioFile,                          &
+        status=nf_fwrite3d(ng, model, pioFile, idVvel,                  &
      &                     S(ng)%pioVar(idVvel), OutRec,                &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
@@ -1671,7 +1687,7 @@
         END IF
 !
         IF (model.eq.iTLM) THEN
-          status=nf_fwrite3d(ng, model, pioFile,                        &
+          status=nf_fwrite3d(ng, model, pioFile, idTvar(itrc),          &
      &                       S(ng)%pioTrc(itrc), OutRec,                &
      &                       ioDesc,                                    &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1682,7 +1698,7 @@
      &                       MinValue = Fmin,                           &
      &                       MaxValue = Fmax)
         ELSE IF (model.eq.iADM) THEN
-          status=nf_fwrite3d(ng, model, pioFile,                        &
+          status=nf_fwrite3d(ng, model, pioFile, idTvar(itrc),          &
      &                       S(ng)%pioTrc(itrc), OutRec,                &
      &                       ioDesc,                                    &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
@@ -1780,7 +1796,7 @@
           END IF
 !
           IF (model.eq.iTLM) THEN
-            status=nf_fwrite3d(ng, iTLM, pioFile,                       &
+            status=nf_fwrite3d(ng, iTLM, pioFile, ifield,               &
      &                         S(ng)%pioVar(ifield),                    &
      &                         OutRec, ioDesc,                          &
      &                         LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale, &
@@ -1792,7 +1808,7 @@
      &                         MinValue = Fmin,                         &
      &                         MaxValue = Fmax)
           ELSE IF (model.eq.iADM) THEN
-            status=nf_fwrite3d(ng, iTLM, pioFile,                       &
+            status=nf_fwrite3d(ng, iTLM, pioFile, ifield,               &
      &                         S(ng)%pioVar(ifield),                    &
      &                         OutRec, ioDesc,                          &
      &                         LBi, UBi, LBj, UBj, 1, Nfrec(ng), scale, &

--- a/ROMS/Utility/wrt_tides.F
+++ b/ROMS/Utility/wrt_tides.F
@@ -4,7 +4,7 @@
    (defined SSH_TIDES || defined UV_TIDES)
 !
 !git $Id$
-!svn $Id: wrt_tides.F 1178 2023-07-11 17:50:57Z arango $
+!svn $Id: wrt_tides.F 1189 2023-08-15 21:26:58Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -120,6 +120,10 @@
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
+!  Report.
+!
+      IF (Master) WRITE (stdout,20) ng
+!
 !  Write out number of time-accumulated harmonics.
 !
       CALL netcdf_put_ivar (ng, iNLM, HAR(ng)%name, 'Hcount',           &
@@ -205,7 +209,7 @@
       IF (Aout(idFsuD,ng)) THEN
         scale=1.0_dp
         gtype=r3dvar
-        status=nf_fwrite3d(ng, iNLM, HAR(ng)%ncid,                      &
+        status=nf_fwrite3d(ng, iNLM, HAR(ng)%ncid, idFsuH,              &
      &                     HAR(ng)%Vid(idFsuH), 0, gtype,               &
      &                     LBi, UBi, LBj, UBj, 0, 2*NTC(ng), scale,     &
 # ifdef MASKING
@@ -215,7 +219,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idFsuH)), TRIM(HAR(ng)%name)
+            WRITE (stdout,20) TRIM(Vname(1,idFsuH)), TRIM(HAR(ng)%name)
           END IF
           exit_flag=3
           ioerror=status
@@ -228,7 +232,7 @@
       IF (Aout(idu2dD,ng)) THEN
         scale=1.0_dp
         gtype=u3dvar
-        status=nf_fwrite3d(ng, iNLM, HAR(ng)%ncid,                      &
+        status=nf_fwrite3d(ng, iNLM, HAR(ng)%ncid, idu2dH,              &
      &                     HAR(ng)%Vid(idu2dH), 0, gtype,               &
      &                     LBi, UBi, LBj, UBj, 0, 2*NTC(ng), scale,     &
 # ifdef MASKING
@@ -238,7 +242,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu2dH)), TRIM(HAR(ng)%name)
+            WRITE (stdout,20) TRIM(Vname(1,idu2dH)), TRIM(HAR(ng)%name)
           END IF
           exit_flag=3
           ioerror=status
@@ -251,7 +255,7 @@
       IF (Aout(idv2dD,ng)) THEN
         scale=1.0_dp
         gtype=v3dvar
-        status=nf_fwrite3d(ng, iNLM, HAR(ng)%ncid,                      &
+        status=nf_fwrite3d(ng, iNLM, HAR(ng)%ncid, idv2dH,              &
      &                     HAR(ng)%Vid(idv2dH), 0, gtype,               &
      &                     LBi, UBi, LBj, UBj, 0, 2*NTC(ng), scale,     &
 # ifdef MASKING
@@ -261,7 +265,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv2dH)), TRIM(HAR(ng)%name)
+            WRITE (stdout,20) TRIM(Vname(1,idv2dH)), TRIM(HAR(ng)%name)
           END IF
           exit_flag=3
           ioerror=status
@@ -276,7 +280,7 @@
       IF (Aout(idu3dD,ng)) THEN
         scale=1.0_dp
         gtype=u3dvar
-        status=nf_fwrite4d(ng, iNLM, HAR(ng)%ncid,                      &
+        status=nf_fwrite4d(ng, iNLM, HAR(ng)%ncid, idu3dH,              &
      &                     HAR(ng)%Vid(idu3dH), 0, gtype,               &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), 0, 2*NTC(ng),  &
      &                     scale,                                       &
@@ -287,7 +291,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu3dH)), TRIM(HAR(ng)%name)
+            WRITE (stdout,20) TRIM(Vname(1,idu3dH)), TRIM(HAR(ng)%name)
           END IF
           exit_flag=3
           ioerror=status
@@ -300,7 +304,7 @@
       IF (Aout(idv3dD,ng)) THEN
         scale=1.0_dp
         gtype=v3dvar
-        status=nf_fwrite4d(ng, iNLM, HAR(ng)%ncid,                      &
+        status=nf_fwrite4d(ng, iNLM, HAR(ng)%ncid, idv3dH,              &
      &                     HAR(ng)%Vid(idv3dH), 0, gtype,               &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), 0, 2*NTC(ng),  &
      &                     scale,                                       &
@@ -311,7 +315,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv3dH)), TRIM(HAR(ng)%name)
+            WRITE (stdout,20) TRIM(Vname(1,idv3dH)), TRIM(HAR(ng)%name)
           END IF
           exit_flag=3
           ioerror=status
@@ -325,7 +329,7 @@
         IF (Aout(idTrcD(itrc),ng)) THEN
           scale=1.0_dp
           gtype=r3dvar
-          status=nf_fwrite4d(ng, iNLM, HAR(ng)%ncid,                    &
+          status=nf_fwrite4d(ng, iNLM, HAR(ng)%ncid, idTrcH(itrc),      &
      &                       HAR(ng)%Vid(idTrcH(itrc)), 0, gtype,       &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), 0, 2*NTC(ng),&
      &                       scale,                                     &
@@ -336,7 +340,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTrcH(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTrcH(itrc))),            &
      &                          TRIM(HAR(ng)%name)
             END IF
             exit_flag=3
@@ -355,12 +359,10 @@
       CALL netcdf_sync (ng, iNLM, HAR(ng)%name, HAR(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-      IF (Master) WRITE (stdout,20) ng
-!
-  10  FORMAT (/,' WRT_TIDES_NF90 - error while writing variable: ',a,   &
-     &        /,13x,'into detide harmonics NetCDF file: ',/,13x,a)
-  20  FORMAT (2x,'WRT_TIDES_NF90   - wrote time-accumulated tide ',     &
+  10  FORMAT (2x,'WRT_TIDES_NF90   - writing time-accumulated tide ',   &
      &        'harmonics, Grid ',i2.2)
+  20  FORMAT (/,' WRT_TIDES_NF90 - error while writing variable: ',a,   &
+     &        /,13x,'into detide harmonics NetCDF file: ',/,13x,a)
 !
       RETURN
       END SUBROUTINE wrt_tides_nf90
@@ -396,6 +398,10 @@
 !-----------------------------------------------------------------------
 !
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+!
+!  Report.
+!
+      IF (Master) WRITE (stdout,10) ng
 !
 !  Write out number of time-accumulated harmonics.
 !
@@ -487,7 +493,7 @@
           ioDesc => ioDesc_sp_r2dhar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iNLM, HAR(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iNLM, HAR(ng)%pioFile, idFsuH,           &
      &                     HAR(ng)%pioVar(idFsuH), 0,                   &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 0, 2*NTC(ng), scale,     &
@@ -498,7 +504,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idFsuH)), TRIM(HAR(ng)%name)
+            WRITE (stdout,20) TRIM(Vname(1,idFsuH)), TRIM(HAR(ng)%name)
           END IF
           exit_flag=3
           ioerror=status
@@ -516,7 +522,7 @@
           ioDesc => ioDesc_sp_u2dhar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iNLM, HAR(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iNLM, HAR(ng)%pioFile, idu2dH,           &
      &                     HAR(ng)%pioVar(idu2dH), 0,                   &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 0, 2*NTC(ng), scale,     &
@@ -527,7 +533,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu2dH)), TRIM(HAR(ng)%name)
+            WRITE (stdout,20) TRIM(Vname(1,idu2dH)), TRIM(HAR(ng)%name)
           END IF
           exit_flag=3
           ioerror=status
@@ -545,7 +551,7 @@
           ioDesc => ioDesc_sp_v2dhar(ng)
         END IF
 !
-        status=nf_fwrite3d(ng, iNLM, HAR(ng)%pioFile,                   &
+        status=nf_fwrite3d(ng, iNLM, HAR(ng)%pioFile, idv2dH,           &
      &                     HAR(ng)%pioVar(idv2dH), 0,                   &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 0, 2*NTC(ng), scale,     &
@@ -556,7 +562,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv2dH)), TRIM(HAR(ng)%name)
+            WRITE (stdout,20) TRIM(Vname(1,idv2dH)), TRIM(HAR(ng)%name)
           END IF
           exit_flag=3
           ioerror=status
@@ -576,7 +582,7 @@
           ioDesc => ioDesc_sp_u3dhar(ng)
         END IF
 !
-        status=nf_fwrite4d(ng, iNLM, HAR(ng)%pioFile,                   &
+        status=nf_fwrite4d(ng, iNLM, HAR(ng)%pioFile, idu3dH,           &
      &                     HAR(ng)%pioVar(idu3dH), 0,                   &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), 0, 2*NTC(ng),  &
@@ -588,7 +594,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idu3dH)), TRIM(HAR(ng)%name)
+            WRITE (stdout,20) TRIM(Vname(1,idu3dH)), TRIM(HAR(ng)%name)
           END IF
           exit_flag=3
           ioerror=status
@@ -606,7 +612,7 @@
           ioDesc => ioDesc_sp_v3dhar(ng)
         END IF
 !
-        status=nf_fwrite4d(ng, iNLM, HAR(ng)%pioFile,                   &
+        status=nf_fwrite4d(ng, iNLM, HAR(ng)%pioFile, idv3dH,           &
      &                     HAR(ng)%pioVar(idv3dH), 0,                   &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), 0, 2*NTC(ng),  &
@@ -618,7 +624,7 @@
      &                     SetFillVal = .FALSE.)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,10) TRIM(Vname(1,idv3dH)), TRIM(HAR(ng)%name)
+            WRITE (stdout,20) TRIM(Vname(1,idv3dH)), TRIM(HAR(ng)%name)
           END IF
           exit_flag=3
           ioerror=status
@@ -637,7 +643,7 @@
             ioDesc => ioDesc_sp_r3dhar(ng)
           END IF
 !
-          status=nf_fwrite4d(ng, iNLM, HAR(ng)%pioFile,                 &
+          status=nf_fwrite4d(ng, iNLM, HAR(ng)%pioFile, idTrcH(itrc),   &
      &                       HAR(ng)%pioVar(idTrcH(itrc)), 0,           &
      &                       ioDesc,                                    &
      &                       LBi, UBi, LBj, UBj, 1, N(ng), 0, 2*NTC(ng),&
@@ -649,7 +655,7 @@
      &                       SetFillVal = .FALSE.)
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
-              WRITE (stdout,10) TRIM(Vname(1,idTrcH(itrc))),            &
+              WRITE (stdout,20) TRIM(Vname(1,idTrcH(itrc))),            &
      &                          TRIM(HAR(ng)%name)
             END IF
             exit_flag=3
@@ -668,12 +674,10 @@
       CALL pio_netcdf_sync (ng, iNLM, HAR(ng)%name, HAR(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-      IF (Master) WRITE (stdout,20) ng
-!
-  10  FORMAT (/,' WRT_TIDES_PIO - error while writing variable: ',a,    &
-     &        /,13x,'into detide harmonics NetCDF file: ',/,13x,a)
-  20  FORMAT (2x,'WRT_TIDES_PIO    - wrote time-accumulated tide ',     &
+  10  FORMAT (2x,'WRT_TIDES_PIO    - writing time-accumulated tide ',   &
      &        'harmonics, Grid ',i2.2)
+  20  FORMAT (/,' WRT_TIDES_PIO - error while writing variable: ',a,    &
+     &        /,13x,'into detide harmonics NetCDF file: ',/,13x,a)
 !
       RETURN
       END SUBROUTINE wrt_tides_pio

--- a/ROMS/Version
+++ b/ROMS/Version
@@ -1,4 +1,4 @@
-ROMS/TOMS Framework: Aug 15, 2023
+ROMS/TOMS Framework: Aug 18, 2023
 ===================
 
 Copyright (c) 2002-2023 The ROMS/TOMS Group
@@ -10,6 +10,6 @@ git: $Id$
 
 svn: $HeadURL: https://www.myroms.org/svn/src/trunk/ROMS/Version $
 svn: $LastChangedBy: arango $
-svn: $LastChangedRevision: 1189 $
-svn: $LastChangedDate: 2023-08-15 17:26:58 -0400 (Tue, 15 Aug 2023) $
+svn: $LastChangedRevision: 1190 $
+svn: $LastChangedDate: 2023-08-18 15:51:09 -0400 (Fri, 18 Aug 2023) $
 

--- a/ROMS/Version
+++ b/ROMS/Version
@@ -1,4 +1,4 @@
-ROMS/TOMS Framework: Aug 18, 2023
+ROMS/TOMS Framework:  Aug 18, 2023
 ===================
 
 Copyright (c) 2002-2023 The ROMS/TOMS Group
@@ -10,6 +10,6 @@ git: $Id$
 
 svn: $HeadURL: https://www.myroms.org/svn/src/trunk/ROMS/Version $
 svn: $LastChangedBy: arango $
-svn: $LastChangedRevision: 1190 $
-svn: $LastChangedDate: 2023-08-18 15:51:09 -0400 (Fri, 18 Aug 2023) $
+svn: $LastChangedRevision: 1191 $
+svn: $LastChangedDate: 2023-08-18 17:58:31 -0400 (Fri, 18 Aug 2023) $
 

--- a/ROMS/Version
+++ b/ROMS/Version
@@ -1,4 +1,4 @@
-ROMS/TOMS Framework:  Aug 3, 2023
+ROMS/TOMS Framework: Aug 15, 2023
 ===================
 
 Copyright (c) 2002-2023 The ROMS/TOMS Group
@@ -10,6 +10,6 @@ git: $Id$
 
 svn: $HeadURL: https://www.myroms.org/svn/src/trunk/ROMS/Version $
 svn: $LastChangedBy: arango $
-svn: $LastChangedRevision: 1188 $
-svn: $LastChangedDate: 2023-08-03 15:26:47 -0400 (Thu, 03 Aug 2023) $
+svn: $LastChangedRevision: 1189 $
+svn: $LastChangedDate: 2023-08-15 17:26:58 -0400 (Tue, 15 Aug 2023) $
 

--- a/ROMS/Version
+++ b/ROMS/Version
@@ -1,4 +1,4 @@
-ROMS/TOMS Framework:  Aug 18, 2023
+ROMS/TOMS Framework: Aug 23, 2023
 ===================
 
 Copyright (c) 2002-2023 The ROMS/TOMS Group
@@ -10,6 +10,6 @@ git: $Id$
 
 svn: $HeadURL: https://www.myroms.org/svn/src/trunk/ROMS/Version $
 svn: $LastChangedBy: arango $
-svn: $LastChangedRevision: 1191 $
-svn: $LastChangedDate: 2023-08-18 17:58:31 -0400 (Fri, 18 Aug 2023) $
+svn: $LastChangedRevision: 1192 $
+svn: $LastChangedDate: 2023-08-23 14:33:57 -0400 (Wed, 23 Aug 2023) $
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-# **Regional Ocean Modeling System (ROMS)**
+# Regional Ocean Modeling System (ROMS)
 
 ![ROMS_Picture](https://github.com/myroms/roms/assets/23062912/d72765ed-9d55-4109-84fc-c51b05832adb)
 
-# **License**
+# License
 
 **Copyright (c) 2002-2023 The ROMS/TOMS Group**
 


### PR DESCRIPTION
- The **CMake** build scripts (**cbuild_roms.csh** and **cbuild_roms.sh**) were cleaned and made more compact: 
  - Several macro definitions were moved from the build scripts to the main **CMakeLists.txt** configuration file for simplicity.
  - The ROMS executable is now **copied** to the project directory instead of making a **symbolic** link. It should work even if ROMS were linked to the shared library (**libROMS.{so|dylib}**) because **`CMAKE_BUILD_WITH_INSTALL_RPATH`** is set to **FALSE** so that **`RPATH/RUNPATH`** are set correctly for both the build tree and installed locations of the ROMS executable. 
  - The macro definitions in **`Compilers/roms_compiler_flags.cmake`** and **`Compilers/roms_config.cmake`** were also updated.

- The **`OUTPUT_STATS`** option is introduced to report the statistics of every output variable into standard output to facilitate debugging. For example, we can have the following report: 
 ```
  WRT_HIS_NF90     - writing history     fields (Index=1,1) in record = 33
    - zeta:                       Min = -2.53787051E-01,  Max =  2.21499656E-01,  CheckSum = 8935
    - ubar:                       Min = -1.34311554E-01,  Max =  1.93256921E-01,  CheckSum = 8568
    - DU_avg1:                    Min = -2.07583251E+07,  Max =  3.32353876E+07,  CheckSum = 7365
    - DU_avg2:                    Min = -2.07602196E+07,  Max =  3.32406785E+07,  CheckSum = 7461
    - vbar:                       Min = -2.15736568E-01,  Max =  1.94236573E-01,  CheckSum = 8406
    - DV_avg1:                    Min = -3.37735448E+07,  Max =  1.84199170E+07,  CheckSum = 7265
    - DV_avg2:                    Min = -3.37768757E+07,  Max =  1.84168047E+07,  CheckSum = 7277
    - u:                          Min = -3.54280363E-01,  Max =  5.53737927E-01,  CheckSum = 257209
    - v:                          Min = -5.36308150E-01,  Max =  4.26453121E-01,  CheckSum = 251702
    - omega:                      Min = -1.60468150E-03,  Max =  1.36090242E-03,  CheckSum = 255075
    - w:                          Min = -2.31089520E-03,  Max =  1.50154444E-03,  CheckSum = 271803
    - temp:                       Min =  1.11330213E+00,  Max =  1.83344385E+01,  CheckSum = 241650
    - salt:                       Min =  3.19036203E+01,  Max =  3.46896641E+01,  CheckSum = 211601
    - AKv:                        Min =  2.23812185E-05,  Max =  8.12660236E-01,  CheckSum = 272259
    - AKt:                        Min =  1.00000000E-05,  Max =  9.92734690E-01,  CheckSum = 273723
    - AKs:                        Min =  1.00000000E-05,  Max =  9.92734690E-01,  CheckSum = 273723
    - Pair:                       Min =  1.00743285E+03,  Max =  1.02769252E+03,  CheckSum = 6863
    - Tair:                       Min = -2.08358809E+00,  Max =  1.77220951E+01,  CheckSum = 6496
    - Uwind:                      Min = -1.45947707E+01,  Max =  3.82034782E+00,  CheckSum = 8050
    - Vwind:                      Min = -7.43046612E+00,  Max =  1.32450908E+01,  CheckSum = 6425
    - shflux:                     Min = -1.26168950E-04,  Max =  1.21942551E-05,  CheckSum = 8438
    - ssflux:                     Min = -1.55420481E-05,  Max =  2.02108689E-06,  CheckSum = 8850
    - latent:                     Min = -5.21229738E-05,  Max =  5.96354770E-06,  CheckSum = 9261
    - sensible:                   Min = -4.84698719E-05,  Max =  7.84890317E-06,  CheckSum = 8970
    - lwrad:                      Min = -3.46309283E-05,  Max = -1.61819579E-06,  CheckSum = 9208
    - evaporation:                Min = -9.84070050E-06,  Max =  8.59023387E-05,  CheckSum = 8691
    - rain:                       Min = -7.05555578E-07,  Max =  4.68687525E-04,  CheckSum = 8526
    - EminusP:                    Min = -4.72947771E-07,  Max =  6.06640234E-08,  CheckSum = 8707
    - swrad:                      Min =  0.00000000E+00,  Max =  6.02349409E-05,  CheckSum = 8724
    - sustr:                      Min = -5.49541550E-04,  Max =  3.78055345E-05,  CheckSum = 8639
    - svstr:                      Min = -9.05397457E-05,  Max =  3.54286819E-04,  CheckSum = 8133
```

 - As a consequence, all the calls to **nf_fwrite2d**, **nfwrite3d**, and **nf_fwrite4d** were modified to include the variable metadata index in its **fourth** argument:
  ```
!
!  Write out tracer type variables.
!
      DO itrc=1,NT(ng)
        IF (Hout(idTvar(itrc),ng)) THEN
          scale=1.0_dp
          gtype=gfactor*r3dvar
          status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idTvar(itrc),     &
     &                       HIS(ng)%Tid(itrc),                         &
     &                       HIS(ng)%Rindex, gtype,                     &
     &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
# ifdef MASKING
     &                       GRID(ng) % rmask,                          &
# endif
     &                       OCEAN(ng) % t(:,:,:,NOUT,itrc))
          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
            IF (Master) THEN
              WRITE (stdout,20) TRIM(Vname(1,idTvar(itrc))),            &
     &                          HIS(ng)%Rindex
            END IF
            exit_flag=3
            ioerror=status
            RETURN
          END IF
        END IF
      END DO
```

  Notice the additional fourth argument **idTvar(itrc)** to **nf_fwrite3d**.

- The metadata file **varinfo.yaml** was updated to include ROMS geometry variables used in **def_info.F** and **wrt_info.F**. I should have done this a long time ago. For example, when the file is created, it reports its statistics when **OUTPUT_STATS** is activated:
 
```
 DEF_HIS_NF90     - creating history file,            Grid 01: wc13_fwd_20040103_outer0.nc
    - h:                          Min =  7.80292502E+01,  Max =  5.19952300E+03,  CheckSum = 7704
    - f:                          Min =  7.27220522E-05,  Max =  1.08086034E-04,  CheckSum = 8151
    - pm:                         Min =  3.11708295E-05,  Max =  4.03430084E-05,  CheckSum = 7924
    - pn:                         Min =  2.69947206E-05,  Max =  2.69947206E-05,  CheckSum = 9405
    - lon_rho:                    Min = -1.34000000E+02,  Max = -1.16000000E+02,  CheckSum = 4984
    - lat_rho:                    Min =  3.00000000E+01,  Max =  4.80000000E+01,  CheckSum = 5282
    - lon_u:                      Min = -1.33833333E+02,  Max = -1.16166667E+02,  CheckSum = 4914
    - lat_u:                      Min =  3.00000000E+01,  Max =  4.80000000E+01,  CheckSum = 5004
    - lon_v:                      Min = -1.34000000E+02,  Max = -1.16000000E+02,  CheckSum = 4628
    - lat_v:                      Min =  3.01666667E+01,  Max =  4.78333333E+01,  CheckSum = 5206
    - lon_psi:                    Min = -1.33833333E+02,  Max = -1.15833333E+02,  CheckSum = 4563
    - lat_psi:                    Min =  3.01666667E+01,  Max =  4.78333333E+01,  CheckSum = 4932
    - angle:                      Min =  1.45444412E-03,  Max =  2.16172340E-03,  CheckSum = 7606
    - mask_rho:                   Min =  1.00000000E+00,  Max =  1.00000000E+00,  CheckSum = 2660
    - mask_u:                     Min =  1.00000000E+00,  Max =  1.00000000E+00,  CheckSum = 2520
    - mask_v:                     Min =  1.00000000E+00,  Max =  1.00000000E+00,  CheckSum = 2470
    - mask_psi:                   Min =  1.00000000E+00,  Max =  2.00000000E+00,  CheckSum = 2340
```
