### PR TITLE
Corrected minor typo in wrt_station.F

### DIFF
--- a/ROMS/Include/cppdefs.h
+++ b/ROMS/Include/cppdefs.h
@@ -2,7 +2,7 @@
 ** Include file "cppdefs.h"
 **
 ** git $Id$
-** svn $Id: cppdefs.h 1189 2023-08-15 21:26:58Z arango $
+** svn $Id: cppdefs.h 1209 2023-12-01 02:17:45Z arango $
 ********************************************************** Hernan G. Arango ***
 ** Copyright (c) 2002-2023 The ROMS/TOMS Group                               **
 **   Licensed under a MIT/X style license                                    **
@@ -44,7 +44,7 @@
 ** UV_LOGDRAG              to turn ON or OFF logarithmic bottom friction     **
 ** UV_LDRAG                to turn ON or OFF linear bottom friction          **
 ** UV_QDRAG                to turn ON or OFF quadratic bottom friction       **
-** OMEGA_IMPLICT           to add adaptive implicit vertical advection       **
+** OMEGA_IMPLICIT          to add adaptive implicit vertical advection       **
 ** SPLINES_VVISC           if splines reconstruction of vertical viscosity   **
 **                                                                           **
 ** OPTION for barotropic kernel time-stepping algorithm. Currently, the      **
@@ -427,6 +427,7 @@
 ** POSTERIOR_ERROR_I       if initial posterior analysis error covariance    **
 ** PRIOR_BULK_FLUXES       if imposing prior NLM surface fluxes              **
 ** RECOMPUTE_4DVAR         if recomputing 4DVar in analysis algorithms       **
+** REMOVE_LAPACK_GOTOS     to replace GOTOs in customized LAPACK routines    **
 ** RPCG                    if Restricted B-preconditioned Lanczos solver     **
 ** RPM_RELAXATION          if Picard iterations, Diffusive Relaxation of RPM **
 ** SKIP_NLM                to skip running NLM, reading NLM trajectory       **

--- a/ROMS/Utility/wrt_station.F
+++ b/ROMS/Utility/wrt_station.F
@@ -3,7 +3,7 @@
 #ifdef STATIONS
 !
 !git $Id$
-!svn $Id: wrt_station.F 1185 2023-08-01 21:42:38Z arango $
+!svn $Id: wrt_station.F 1209 2023-12-01 02:17:45Z arango $
 !================================================== Hernan G. Arango ===
 !  Copyright (c) 2002-2023 The ROMS/TOMS Group                         !
 !    Licensed under a MIT/X style license                              !
@@ -689,7 +689,7 @@
      &                        TRIM(Vname(1,idUaiE)), psta,              &
      &                        (/1,STA(ng)%Rindex/), (/Nstation(ng),1/), &
      &                        ncid = STA(ng)%ncid,                      &
-     &                        varid = STA(ng)%Vid(idUairE))
+     &                        varid = STA(ng)%Vid(idUaiE))
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
         CALL extract_sta2d (ng, model, Cgrid, idVaiN, r2dvar,           &
@@ -697,7 +697,7 @@
      &                      scale, Vr2d,                                &
      &                      Nstation(ng), Xpos, Ypos, psta)
         CALL netcdf_put_fvar (ng, model, STA(ng)%name,                  &
-     &                        TRIM(Vname(1,idVairN)), psta,             &
+     &                        TRIM(Vname(1,idVaiN)), psta,              &
      &                        (/1,STA(ng)%Rindex/), (/Nstation(ng),1/), &
      &                        ncid = STA(ng)%ncid,                      &
      &                        varid = STA(ng)%Vid(idVaiN))

--- a/ROMS/Version
+++ b/ROMS/Version
@@ -1,4 +1,4 @@
-ROMS/TOMS Framework: Oct 27, 2023
+ROMS/TOMS Framework: Nov 30, 2023
 ===================
 
 Copyright (c) 2002-2023 The ROMS/TOMS Group
@@ -10,6 +10,6 @@ git: $Id$
 
 svn: $HeadURL: https://www.myroms.org/svn/src/trunk/ROMS/Version $
 svn: $LastChangedBy: arango $
-svn: $LastChangedRevision: 1207 $
-svn: $LastChangedDate: 2023-10-27 17:28:58 -0400 (Fri, 27 Oct 2023) $
+svn: $LastChangedRevision: 1209 $
+svn: $LastChangedDate: 2023-11-30 21:17:45 -0500 (Thu, 30 Nov 2023) $
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,9 +33,10 @@ The State University of New Jersey, New Brunswick, New Jersey, USA. Currently, t
 **git** repository contains the following branches:
 
 - **main**: Tagged versions and the latest stable release version of **ROMS**
-- **develop**: Main developing branch of **ROMS**. It is not recommended for public
- consumption but passes the internal tests. It is intended for **ROMS** superusers
- and beta testers.
+- **develop**: Main developing branch of **ROMS**. It contains the model's
+  latest corrections, updates, and minor evolutions. It is a stable branch
+  that passes selected internal tests. It is the parent to other feature
+  branches describing new options and algorithms.
 - **feature branches**: Research and new development branches recommended to
 superusers and beta testers.
 


### PR DESCRIPTION
- The metadata indices for writing Eastward/Northward wind components into the station's output NetCDF file were misspelled in routine **`wrt_station.F`**. We must use **`idUaiE`** and **`idVaiN`** instead of **`idUairE`** and **`idVairN`**

- Updated documentation in **`cppdefs.h`** preamble. 

