### PR TITLE
Updating ROMS standard input and output management

### DIFF
--- a/Compilers/AIX-xlf.mk
+++ b/Compilers/AIX-xlf.mk
@@ -168,6 +168,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/AIX-xlf.mk
+++ b/Compilers/AIX-xlf.mk
@@ -128,6 +128,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/CYGWIN-df.mk
+++ b/Compilers/CYGWIN-df.mk
@@ -147,6 +147,11 @@ endif
 #
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/CYGWIN-df.mk
+++ b/Compilers/CYGWIN-df.mk
@@ -135,6 +135,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/CYGWIN-g95.mk
+++ b/Compilers/CYGWIN-g95.mk
@@ -144,6 +144,11 @@ endif
 
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/CYGWIN-g95.mk
+++ b/Compilers/CYGWIN-g95.mk
@@ -135,6 +135,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/CYGWIN-gfortran.mk
+++ b/Compilers/CYGWIN-gfortran.mk
@@ -95,7 +95,8 @@ ifdef USE_ROMS
            FFLAGS += -fbacktrace
            FFLAGS += -fcheck=all
 #          FFLAGS += -fsanitize=address -fsanitize=undefined
-           FFLAGS += -finit-real=nan -ffpe-trap=invalid,zero,overflow
+           FFLAGS += -finit-real=nan
+#          FFLAGS += -ffpe-trap=invalid,zero,overflow
  else
            FFLAGS += -O3
            FFLAGS += -ffast-math

--- a/Compilers/CYGWIN-gfortran.mk
+++ b/Compilers/CYGWIN-gfortran.mk
@@ -161,6 +161,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/CYGWIN-gfortran.mk
+++ b/Compilers/CYGWIN-gfortran.mk
@@ -169,6 +169,11 @@ endif
 
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/CYGWIN-ifort.mk
+++ b/Compilers/CYGWIN-ifort.mk
@@ -148,6 +148,11 @@ endif
 #
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/CYGWIN-ifort.mk
+++ b/Compilers/CYGWIN-ifort.mk
@@ -136,6 +136,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Darwin-f90.mk
+++ b/Compilers/Darwin-f90.mk
@@ -164,6 +164,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Darwin-f90.mk
+++ b/Compilers/Darwin-f90.mk
@@ -132,6 +132,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Darwin-gfortran.mk
+++ b/Compilers/Darwin-gfortran.mk
@@ -193,6 +193,14 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+
+ # If nc-config and nf-config is split into different directories, add
+ # appropriate directory for nc-config needed for linking ROMS.
+
+ ifneq ($(netcdf_c_ROOT),)
+        NC_CONFIG ?= nc-config
+             LIBS += $(shell $(NC_CONFIG) --libs)
+ endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Darwin-gfortran.mk
+++ b/Compilers/Darwin-gfortran.mk
@@ -193,14 +193,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
-
- # If nc-config and nf-config is split into different directories, add
- # appropriate directory for nc-config needed for linking ROMS.
-
- ifneq ($(netcdf_c_ROOT),)
         NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
              LIBS += $(shell $(NC_CONFIG) --libs)
- endif
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Darwin-gfortran.mk
+++ b/Compilers/Darwin-gfortran.mk
@@ -161,6 +161,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Darwin-gfortran.mk
+++ b/Compilers/Darwin-gfortran.mk
@@ -94,7 +94,8 @@ ifdef USE_ROMS
            FFLAGS += -fbacktrace
            FFLAGS += -fcheck=all
 #          FFLAGS += -fsanitize=address -fsanitize=undefined
-           FFLAGS += -finit-real=nan -ffpe-trap=invalid,zero,overflow
+           FFLAGS += -finit-real=nan
+#          FFLAGS += -ffpe-trap=invalid,zero,overflow
            FFLAGS += -fmax-stack-var-size=64000000
  else
            FFLAGS += -O3

--- a/Compilers/Darwin-ifort.mk
+++ b/Compilers/Darwin-ifort.mk
@@ -181,14 +181,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
-
- # If nc-config and nf-config is split into different directories, add
- # appropriate directory for nc-config needed for linking ROMS.
-
- ifneq ($(netcdf_c_ROOT),)
         NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
              LIBS += $(shell $(NC_CONFIG) --libs)
- endif
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Darwin-ifort.mk
+++ b/Compilers/Darwin-ifort.mk
@@ -181,6 +181,14 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+
+ # If nc-config and nf-config is split into different directories, add
+ # appropriate directory for nc-config needed for linking ROMS.
+
+ ifneq ($(netcdf_c_ROOT),)
+        NC_CONFIG ?= nc-config
+             LIBS += $(shell $(NC_CONFIG) --libs)
+ endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Darwin-ifort.mk
+++ b/Compilers/Darwin-ifort.mk
@@ -149,6 +149,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Darwin-nag.mk
+++ b/Compilers/Darwin-nag.mk
@@ -195,6 +195,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Darwin-nag.mk
+++ b/Compilers/Darwin-nag.mk
@@ -162,6 +162,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Darwin-pgi.mk
+++ b/Compilers/Darwin-pgi.mk
@@ -140,6 +140,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Darwin-pgi.mk
+++ b/Compilers/Darwin-pgi.mk
@@ -155,6 +155,11 @@ endif
 
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Darwin-xlf.mk
+++ b/Compilers/Darwin-xlf.mk
@@ -168,6 +168,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Darwin-xlf.mk
+++ b/Compilers/Darwin-xlf.mk
@@ -136,6 +136,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/IRIX64-f90.mk
+++ b/Compilers/IRIX64-f90.mk
@@ -163,6 +163,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/IRIX64-f90.mk
+++ b/Compilers/IRIX64-f90.mk
@@ -125,6 +125,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Linux-ftn-cray.mk
+++ b/Compilers/Linux-ftn-cray.mk
@@ -164,6 +164,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-ftn-cray.mk
+++ b/Compilers/Linux-ftn-cray.mk
@@ -131,6 +131,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Linux-ftn-gnu.mk
+++ b/Compilers/Linux-ftn-gnu.mk
@@ -138,6 +138,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Linux-ftn-gnu.mk
+++ b/Compilers/Linux-ftn-gnu.mk
@@ -171,6 +171,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-ftn-intel.mk
+++ b/Compilers/Linux-ftn-intel.mk
@@ -169,6 +169,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-ftn-intel.mk
+++ b/Compilers/Linux-ftn-intel.mk
@@ -137,6 +137,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Linux-ftn.mk
+++ b/Compilers/Linux-ftn.mk
@@ -132,6 +132,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Linux-ftn.mk
+++ b/Compilers/Linux-ftn.mk
@@ -165,6 +165,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-g95.mk
+++ b/Compilers/Linux-g95.mk
@@ -134,6 +134,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Linux-g95.mk
+++ b/Compilers/Linux-g95.mk
@@ -167,14 +167,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
-
- # If nc-config and nf-config is split into different directories, add
- # appropriate directory for nc-config needed for linking ROMS.
-
- ifneq ($(netcdf_c_ROOT),)
         NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
              LIBS += $(shell $(NC_CONFIG) --libs)
- endif
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-g95.mk
+++ b/Compilers/Linux-g95.mk
@@ -167,6 +167,14 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+
+ # If nc-config and nf-config is split into different directories, add
+ # appropriate directory for nc-config needed for linking ROMS.
+
+ ifneq ($(netcdf_c_ROOT),)
+        NC_CONFIG ?= nc-config
+             LIBS += $(shell $(NC_CONFIG) --libs)
+ endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-gfortran.mk
+++ b/Compilers/Linux-gfortran.mk
@@ -194,18 +194,16 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
-
- # If nc-config and nf-config is split into different directories, add
- # appropriate directory for nc-config needed for linking ROMS.
-
- ifneq ($(netcdf_c_ROOT),)
         NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
              LIBS += $(shell $(NC_CONFIG) --libs)
- endif
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)
            INCDIR += $(NETCDF_INCDIR) $(INCDIR)
+
 else
     NETCDF_INCDIR ?= /opt/gfortransoft/serial/netcdf3/include
     NETCDF_LIBDIR ?= /opt/gfortransoft/serial/netcdf3/lib

--- a/Compilers/Linux-gfortran.mk
+++ b/Compilers/Linux-gfortran.mk
@@ -162,6 +162,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Linux-gfortran.mk
+++ b/Compilers/Linux-gfortran.mk
@@ -194,6 +194,14 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+
+ # If nc-config and nf-config is split into different directories, add
+ # appropriate directory for nc-config needed for linking ROMS.
+
+ ifneq ($(netcdf_c_ROOT),)
+        NC_CONFIG ?= nc-config
+             LIBS += $(shell $(NC_CONFIG) --libs)
+ endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-gfortran.mk
+++ b/Compilers/Linux-gfortran.mk
@@ -94,7 +94,8 @@ ifdef USE_ROMS
            FFLAGS += -fbacktrace
            FFLAGS += -fcheck=all
 #          FFLAGS += -fsanitize=address -fsanitize=undefined
-           FFLAGS += -finit-real=nan -ffpe-trap=invalid,zero,overflow
+           FFLAGS += -finit-real=nan
+#          FFLAGS += -ffpe-trap=invalid,zero,overflow
  else
            FFLAGS += -O3
            FFLAGS += -ffast-math
@@ -203,7 +204,6 @@ ifdef USE_NETCDF4
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)
            INCDIR += $(NETCDF_INCDIR) $(INCDIR)
-
 else
     NETCDF_INCDIR ?= /opt/gfortransoft/serial/netcdf3/include
     NETCDF_LIBDIR ?= /opt/gfortransoft/serial/netcdf3/lib

--- a/Compilers/Linux-ifc.mk
+++ b/Compilers/Linux-ifc.mk
@@ -132,6 +132,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Linux-ifc.mk
+++ b/Compilers/Linux-ifc.mk
@@ -165,6 +165,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-ifort.mk
+++ b/Compilers/Linux-ifort.mk
@@ -184,7 +184,8 @@ endif
 ifdef USE_NETCDF4
 
  # If nc-config and nf-config is split into different directories, add
- # appropriate directory for nc-config needed for linking ROMS.
+ # appropriate directory for nc-config needed for linking ROMS. Here,
+ # 'netcdf_c_ROOT' is an environmental variable used in Spack-Stack.
 
  ifneq ($(netcdf_c_ROOT),)
         NC_CONFIG ?= nc-config

--- a/Compilers/Linux-ifort.mk
+++ b/Compilers/Linux-ifort.mk
@@ -253,7 +253,7 @@ ifdef USE_ESMF
       ESMF_MK_DIR ?= $(ESMF_DIR)/lib/lib$(ESMF_BOPT)/$(ESMF_SUBDIR)
            FFLAGS += $(ESMF_F90COMPILEPATHS)
              LIBS += $(ESMF_F90LINKPATHS) $(ESMF_F90ESMFLINKLIBS)
-             LIBS += -liomp5
+             LIBS += -liomp5 -lstdc++
 endif
 
 # Use full path of compiler.

--- a/Compilers/Linux-ifort.mk
+++ b/Compilers/Linux-ifort.mk
@@ -182,6 +182,14 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+
+ # If nc-config and nf-config is split into different directories, add
+ # appropriate directory for nc-config needed for linking ROMS.
+
+ ifneq ($(netcdf_c_ROOT),)
+        NC_CONFIG ?= nc-config
+             LIBS += $(shell $(NC_CONFIG) --libs)
+ endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-ifort.mk
+++ b/Compilers/Linux-ifort.mk
@@ -182,15 +182,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
-
- # If nc-config and nf-config is split into different directories, add
- # appropriate directory for nc-config needed for linking ROMS. Here,
- # 'netcdf_c_ROOT' is an environmental variable used in Spack-Stack.
-
- ifneq ($(netcdf_c_ROOT),)
         NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
              LIBS += $(shell $(NC_CONFIG) --libs)
- endif
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-ifx.mk
+++ b/Compilers/Linux-ifx.mk
@@ -37,7 +37,7 @@
 #
 # First the defaults
 #
-               FC := ifort
+               FC := ifx
            FFLAGS := -fp-model precise
            FFLAGS += -heap-arrays
        FIXEDFLAGS := -nofree
@@ -70,16 +70,20 @@
 ifdef USE_ROMS
  ifdef USE_DEBUG
            FFLAGS += -g
-           FFLAGS += -check all
-           FFLAGS += -check bounds
-           FFLAGS += -traceback
-           FFLAGS += -check uninit
-           FFLAGS += -warn interfaces,nouncalled
-           FFLAGS += -gen-interfaces
+#           FFLAGS += -check all
+#           FFLAGS += -check bounds
+#           FFLAGS += -traceback
+#          Disabled for now because it requires libm.a
+#          https://community.intel.com/t5/Intel-Fortran-Compiler/ifx-IFX-2023-2-0-20230721-linker-problems-with-check-uninit/m-p/1527816
+#          FFLAGS += -check uninit
+#           FFLAGS += -warn interfaces,nouncalled
+#           FFLAGS += -gen-interfaces
  else
-           FFLAGS += -ip -O3
+           FFLAGS += -O3
            FFLAGS += -traceback
-           FFLAGS += -check uninit
+#          Disabled for now because it requires libm.a
+#          https://community.intel.com/t5/Intel-Fortran-Compiler/ifx-IFX-2023-2-0-20230721-linker-problems-with-check-uninit/m-p/1527816
+#          FFLAGS += -check uninit
  endif
  ifdef SHARED
           LDFLAGS += -Wl,-rpath,$(BUILD_DIR)
@@ -185,11 +189,6 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
-        NC_CONFIG ?= nc-config
-   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
-  ifneq ($(TEST_NC_CONFIG),)
-             LIBS += $(shell $(NC_CONFIG) --libs)
-  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-ifx.mk
+++ b/Compilers/Linux-ifx.mk
@@ -252,7 +252,7 @@ ifdef USE_ESMF
       ESMF_MK_DIR ?= $(ESMF_DIR)/lib/lib$(ESMF_BOPT)/$(ESMF_SUBDIR)
            FFLAGS += $(ESMF_F90COMPILEPATHS)
              LIBS += $(ESMF_F90LINKPATHS) $(ESMF_F90ESMFLINKLIBS)
-             LIBS += -liomp5
+             LIBS += -liomp5 -lstdc++
 endif
 
 # Use full path of compiler.

--- a/Compilers/Linux-necsx.mk
+++ b/Compilers/Linux-necsx.mk
@@ -168,6 +168,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-necsx.mk
+++ b/Compilers/Linux-necsx.mk
@@ -135,6 +135,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Linux-path.mk
+++ b/Compilers/Linux-path.mk
@@ -167,6 +167,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/Linux-path.mk
+++ b/Compilers/Linux-path.mk
@@ -131,6 +131,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Linux-pgi.mk
+++ b/Compilers/Linux-pgi.mk
@@ -144,6 +144,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/Linux-pgi.mk
+++ b/Compilers/Linux-pgi.mk
@@ -183,6 +183,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/MINGW-g95.mk
+++ b/Compilers/MINGW-g95.mk
@@ -144,6 +144,11 @@ endif
 
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/MINGW-g95.mk
+++ b/Compilers/MINGW-g95.mk
@@ -135,6 +135,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/MINGW-gfortran.mk
+++ b/Compilers/MINGW-gfortran.mk
@@ -95,7 +95,8 @@ ifdef USE_ROMS
            FFLAGS += -fbacktrace
            FFLAGS += -fcheck=all
 #          FFLAGS += -fsanitize=address -fsanitize=undefined
-           FFLAGS += -finit-real=nan -ffpe-trap=invalid,zero,overflow
+           FFLAGS += -finit-real=nan
+#          FFLAGS += -ffpe-trap=invalid,zero,overflow
  else
            FFLAGS += -O3
            FFLAGS += -ffast-math

--- a/Compilers/MINGW-gfortran.mk
+++ b/Compilers/MINGW-gfortran.mk
@@ -161,6 +161,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/MINGW-gfortran.mk
+++ b/Compilers/MINGW-gfortran.mk
@@ -169,6 +169,11 @@ endif
 
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/OSF1-f90.mk
+++ b/Compilers/OSF1-f90.mk
@@ -163,6 +163,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/OSF1-f90.mk
+++ b/Compilers/OSF1-f90.mk
@@ -125,6 +125,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/SunOS-f95.mk
+++ b/Compilers/SunOS-f95.mk
@@ -168,6 +168,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/SunOS-f95.mk
+++ b/Compilers/SunOS-f95.mk
@@ -132,6 +132,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/SunOS-ftn.mk
+++ b/Compilers/SunOS-ftn.mk
@@ -132,6 +132,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/SunOS-ftn.mk
+++ b/Compilers/SunOS-ftn.mk
@@ -165,6 +165,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/UNICOS-mk-f90.mk
+++ b/Compilers/UNICOS-mk-f90.mk
@@ -125,6 +125,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/UNICOS-mk-f90.mk
+++ b/Compilers/UNICOS-mk-f90.mk
@@ -157,6 +157,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/UNICOS-mp-ftn.mk
+++ b/Compilers/UNICOS-mp-ftn.mk
@@ -132,6 +132,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/UNICOS-mp-ftn.mk
+++ b/Compilers/UNICOS-mp-ftn.mk
@@ -165,6 +165,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/UNICOS-sn-f90.mk
+++ b/Compilers/UNICOS-sn-f90.mk
@@ -164,6 +164,11 @@ ifdef USE_SCORPIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/UNICOS-sn-f90.mk
+++ b/Compilers/UNICOS-sn-f90.mk
@@ -132,6 +132,9 @@ ifdef USE_WRF
              LIBS += $(WRF_LIB_DIR)/librsl_lite.a
              LIBS += $(WRF_LIB_DIR)/module_internal_header_util.o
              LIBS += $(WRF_LIB_DIR)/pack_utils.o
+ifneq ($(NETCDFPAR),)
+             LIBS += $(WRF_LIB_DIR)/libwrfio_nfpar.a
+endif
              LIBS += $(WRF_LIB_DIR)/libwrfio_nf.a
 endif
 

--- a/Compilers/compiler_flags_GNU_Fortran.cmake
+++ b/Compilers/compiler_flags_GNU_Fortran.cmake
@@ -13,9 +13,13 @@
 ###########################################################################
 
 if( MPI )
-  set( CMAKE_Fortran_COMPILER mpif90 )
+  execute_process( COMMAND which mpif90
+                   OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
+                   OUTPUT_STRIP_TRAILING_WHITESPACE ) 
 else()
-  set( CMAKE_Fortran_COMPILER gfortran )
+  execute_process( COMMAND which gfortran
+                   OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
+                   OUTPUT_STRIP_TRAILING_WHITESPACE ) 
 endif()
 
 ###########################################################################

--- a/Compilers/compiler_flags_Intel_Fortran.cmake
+++ b/Compilers/compiler_flags_Intel_Fortran.cmake
@@ -14,12 +14,18 @@
 
 if( MPI )
   if( ${COMM} MATCHES "intel")
-    set( CMAKE_Fortran_COMPILER mpiifort )
+    execute_process( COMMAND which mpiifort
+                     OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
+                     OUTPUT_STRIP_TRAILING_WHITESPACE ) 
   else()
-    set( CMAKE_Fortran_COMPILER mpif90 )
+    execute_process( COMMAND which mpif90
+                     OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
+                     OUTPUT_STRIP_TRAILING_WHITESPACE ) 
   endif()
 else()
-  set( CMAKE_Fortran_COMPILER ifort )
+  execute_process( COMMAND which ifort
+                   OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
+                   OUTPUT_STRIP_TRAILING_WHITESPACE ) 
 endif()
 
 ###########################################################################

--- a/Compilers/my_build_paths.csh
+++ b/Compilers/my_build_paths.csh
@@ -128,6 +128,11 @@ endif
 # to use the serial version of the NetCDF-4/HDF5 to avoid conflicts
 # with the compiler. We cannot activate MPI constructs in serial
 # or shared-memory ROMS code. Hybrid parallelism is not possible.
+#
+# If NetCDF-C and NetCDF-Fortran libraries are in different
+# directories, you must define NETCDFC correctly to the appropriate
+# split path. Otherwise, set NETCDFC to NETCDF because they are
+# located in the same path.
 
 setenv MPI_SOFT ""
 
@@ -164,27 +169,30 @@ switch ($FORT)
     endif
 
     if (! $?SINGULARITY_COMMAND) then
-        if ($?USE_NETCDF4) then
-          if ($?USE_PARALLEL_IO && $?USE_MPI) then
-              setenv ESMF_DIR       ${MPI_SOFT}/esmf_nc4
-              setenv NETCDF         ${MPI_SOFT}/netcdf4
-              setenv NF_CONFIG      ${NETCDF}/bin/nf-config
-              setenv NETCDF_INCDIR  ${NETCDF}/include
-              setenv NETCDF4        1
-          else
-            setenv ESMF_DIR         ${MPI_SOFT}/esmf_nc4
-            setenv NETCDF           /opt/intelsoft/serial/netcdf4
-            setenv NF_CONFIG        ${NETCDF}/bin/nf-config
-            setenv NETCDF_INCDIR    ${NETCDF}/include
-            setenv NETCDF4          1
-          endif
+      if ($?USE_NETCDF4) then
+        if ($?USE_PARALLEL_IO && $?USE_MPI) then
+          setenv ESMF_DIR       ${MPI_SOFT}/esmf_nc4
+          setenv NETCDF         ${MPI_SOFT}/netcdf4
+          setenv NETCDFC        ${MPI_SOFT}/netcdf4c
+          setenv NC_CONFIG      ${NETCDFC}/bin/nc-config
+          setenv NF_CONFIG      ${NETCDF}/bin/nf-config
+          setenv NETCDF_INCDIR  ${NETCDF}/include
+          setenv NETCDF4        1
         else
-          setenv ESMF_DIR           ${MPI_SOFT}/esmf_nc3
-          setenv NETCDF             /opt/intelsoft/serial/netcdf3
-          setenv NETCDF_INCDIR      ${NETCDF}/include
-          setenv NETCDF_LIBDIR      ${NETCDF}/lib
-          setenv NETCDF_classic     1
+          setenv ESMF_DIR       ${MPI_SOFT}/esmf_nc4
+          setenv NETCDF         /opt/intelsoft/serial/netcdf4
+          setenv NETCDFC        ${MPI_SOFT}/netcdf4c
+          setenv NC_CONFIG      ${NETCDFC}/bin/nc-config
+          setenv NF_CONFIG      ${NETCDF}/bin/nf-config
+          setenv NETCDF_INCDIR  ${NETCDF}/include
+          setenv NETCDF4        1
         endif
+      else
+        setenv ESMF_DIR           ${MPI_SOFT}/esmf_nc3
+        setenv NETCDF             /opt/intelsoft/serial/netcdf3
+        setenv NETCDF_INCDIR      ${NETCDF}/include
+        setenv NETCDF_LIBDIR      ${NETCDF}/lib
+        setenv NETCDF_classic     1
       endif
     endif
 
@@ -252,17 +260,21 @@ switch ($FORT)
     if (! $?SINGULARITY_COMMAND) then
       if ($?USE_NETCDF4) then
         if ($?USE_PARALLEL_IO && $?USE_MPI) then
-            setenv ESMF_DIR       ${MPI_SOFT}/esmf_nc4
-            setenv NETCDF         ${MPI_SOFT}/netcdf4
-            setenv NF_CONFIG      ${NETCDF}/bin/nf-config
-            setenv NETCDF_INCDIR  ${NETCDF}/include
-            setenv NETCDF4        1
+          setenv ESMF_DIR       ${MPI_SOFT}/esmf_nc4
+          setenv NETCDF         ${MPI_SOFT}/netcdf4
+          setenv NETCDFC        ${MPI_SOFT}/netcdf4c
+          setenv NC_CONFIG      ${NETCDFC}/bin/nc-config
+          setenv NF_CONFIG      ${NETCDF}/bin/nf-config
+          setenv NETCDF_INCDIR  ${NETCDF}/include
+          setenv NETCDF4        1
         else
-          setenv ESMF_DIR         ${MPI_SOFT}/esmf_nc4
-          setenv NETCDF           /opt/pgisoft/serial/netcdf4
-          setenv NF_CONFIG        ${NETCDF}/bin/nf-config
-          setenv NETCDF_INCDIR    ${NETCDF}/include
-          setenv NETCDF4          1
+          setenv ESMF_DIR       ${MPI_SOFT}/esmf_nc4
+          setenv NETCDF         /opt/pgisoft/serial/netcdf4
+          setenv NETCDFC        ${MPI_SOFT}/netcdf4c
+          setenv NC_CONFIG      ${NETCDFC}/bin/nc-config
+          setenv NF_CONFIG      ${NETCDF}/bin/nf-config
+          setenv NETCDF_INCDIR  ${NETCDF}/include
+          setenv NETCDF4        1
         endif
       else
         setenv ESMF_DIR           ${MPI_SOFT}/esmf_nc3
@@ -335,17 +347,21 @@ switch ($FORT)
     if (! $?SINGULARITY_COMMAND) then
       if ($?USE_NETCDF4) then
         if ($?USE_PARALLEL_IO && $?USE_MPI) then
-            setenv ESMF_DIR       ${MPI_SOFT}/esmf_nc4
-            setenv NETCDF         ${MPI_SOFT}/netcdf4
-            setenv NF_CONFIG      ${NETCDF}/bin/nf-config
-            setenv NETCDF_INCDIR  ${NETCDF}/include
-            setenv NETCDF4        1
+          setenv ESMF_DIR       ${MPI_SOFT}/esmf_nc4
+          setenv NETCDF         ${MPI_SOFT}/netcdf4
+          setenv NETCDFC        ${MPI_SOFT}/netcdf4c
+          setenv NC_CONFIG      ${NETCDFC}/bin/nc-config
+          setenv NF_CONFIG      ${NETCDF}/bin/nf-config
+          setenv NETCDF_INCDIR  ${NETCDF}/include
+          setenv NETCDF4        1
         else
-          setenv ESMF_DIR         ${MPI_SOFT}/esmf_nc4
-          setenv NETCDF           /opt/gfortransoft/serial/netcdf4
-          setenv NF_CONFIG        ${NETCDF}/bin/nf-config
-          setenv NETCDF_INCDIR    ${NETCDF}/include
-          setenv NETCDF4          1
+          setenv ESMF_DIR       ${MPI_SOFT}/esmf_nc4
+          setenv NETCDF         /opt/gfortransoft/serial/netcdf4
+          setenv NETCDFC        ${MPI_SOFT}/netcdf4c
+          setenv NC_CONFIG      ${NETCDFC}/bin/nc-config
+          setenv NF_CONFIG      ${NETCDF}/bin/nf-config
+          setenv NETCDF_INCDIR  ${NETCDF}/include
+          setenv NETCDF4        1
         endif
       else
         setenv ESMF_DIR           ${MPI_SOFT}/esmf_nc3

--- a/Compilers/my_build_paths.sh
+++ b/Compilers/my_build_paths.sh
@@ -124,6 +124,11 @@ fi
 # to use the serial version of the NetCDF-4/HDF5 to avoid conflicts
 # with the compiler. We cannot activate MPI constructs in serial
 # or shared-memory ROMS code. Hybrid parallelism is not possible.
+#
+# If NetCDF-C and NetCDF-Fortran libraries are in different
+# directories, you must define NETCDFC correctly to the appropriate
+# split path. Otherwise, set NETCDFC to NETCDF because they are
+# located in the same path.
 
 export               MPI_SOFT=""
 
@@ -161,16 +166,20 @@ case "$FORT" in
         if [ -n "${USE_PARALLEL_IO:+1}" ] && [ -n "${USE_MPI:+1}" ]; then
           export       ESMF_DIR=${MPI_SOFT}/esmf_nc4
           export         NETCDF=${MPI_SOFT}/netcdf4
+          export        NETCDFC=${MPI_SOFT}/netcdf4c
+          export      NC_CONFIG=${NETCDFC}/bin/nc-config
           export      NF_CONFIG=${NETCDF}/bin/nf-config
           export  NETCDF_INCDIR=${NETCDF}/include
           export        NETCDF4=1
         else
           export       ESMF_DIR=${MPI_SOFT}/esmf_nc4
           export         NETCDF=/opt/intelsoft/serial/netcdf4
+          export        NETCDFC=${MPI_SOFT}/netcdf4c
+          export      NC_CONFIG=${NETCDFC}/bin/nc-config
           export      NF_CONFIG=${NETCDF}/bin/nf-config
           export  NETCDF_INCDIR=${NETCDF}/include
           export        NETCDF4=1
-        fi
+	fi
       else
         export         ESMF_DIR=${MPI_SOFT}/esmf_nc3
         export           NETCDF=/opt/intelsoft/serial/netcdf3
@@ -243,12 +252,16 @@ case "$FORT" in
         if [ -n "${USE_PARALLEL_IO:+1}" ] && [ -n "${USE_MPI:+1}" ]; then
           export       ESMF_DIR=${MPI_SOFT}/esmf_nc4
           export         NETCDF=${MPI_SOFT}/netcdf4
+          export        NETCDFC=${MPI_SOFT}/netcdf4c
+          export      NC_CONFIG=${NETCDFC}/bin/nc-config
           export      NF_CONFIG=${NETCDF}/bin/nf-config
           export  NETCDF_INCDIR=${NETCDF}/include
           export        NETCDF4=1
         else
           export       ESMF_DIR=${MPI_SOFT}/esmf_nc4
           export         NETCDF=/opt/pgisoft/serial/netcdf4
+          export        NETCDFC=${MPI_SOFT}/netcdf4c
+          export      NC_CONFIG=${NETCDFC}/bin/nc-config
           export      NF_CONFIG=${NETCDF}/bin/nf-config
           export  NETCDF_INCDIR=${NETCDF}/include
           export        NETCDF4=1
@@ -323,12 +336,16 @@ case "$FORT" in
         if [ -n "${USE_PARALLEL_IO:+1}" ] && [ -n "${USE_MPI:+1}" ]; then
           export       ESMF_DIR=${MPI_SOFT}/esmf_nc4
           export         NETCDF=${MPI_SOFT}/netcdf4
+          export        NETCDFC=${MPI_SOFT}/netcdf4c
+          export      NC_CONFIG=${NETCDFC}/bin/nc-config
           export      NF_CONFIG=${NETCDF}/bin/nf-config
           export  NETCDF_INCDIR=${NETCDF}/include
           export        NETCDF4=1
         else
           export       ESMF_DIR=${MPI_SOFT}/esmf_nc4
           export         NETCDF=/opt/gfortransoft/serial/netcdf4
+          export        NETCDFC=${MPI_SOFT}/netcdf4c
+          export      NC_CONFIG=${NETCDFC}/bin/nc-config
           export      NF_CONFIG=${NETCDF}/bin/nf-config
           export  NETCDF_INCDIR=${NETCDF}/include
           export        NETCDF4=1

--- a/ESM/build_ufs.csh
+++ b/ESM/build_ufs.csh
@@ -380,16 +380,6 @@ else
   set ltype=""
 endif
 
-if ( $?FORT ) then
-  if ( "${FORT}" == "ifort" ) then
-    set compiler="-DCMAKE_Fortran_COMPILER=ifort"
-  else if ( "${FORT}" == "gfortran" ) then
-    set compiler="-DCMAKE_Fortran_COMPILER=gfortran"
-  else
-    set compiler=""
-  endif
-endif
-
 if ( $?MY_CPP_FLAGS ) then
   set tmp=`echo ${MY_CPP_FLAGS} | sed 's/^ *-D//' | sed 's/ *-D/;/g'`
   set extra_flags="-DMY_CPP_FLAGS=${tmp}"
@@ -495,7 +485,6 @@ if ( $dprint == 0 ) then
                      -DROMS_APP_DIR=${ROMS_APP_DIR} \
                      ${my_hdir} \
                      ${ltype} \
-                     ${compiler} \
                      ${extra_flags} \
                      ${parpack_ldir} \
                      ${arpack_ldir} \

--- a/ESM/build_ufs.csh
+++ b/ESM/build_ufs.csh
@@ -360,13 +360,11 @@ endif
 set ANALYTICAL_DIR = "ANALYTICAL_DIR='${MY_ANALYTICAL_DIR}'"
 set HEADER = `echo ${ROMS_APPLICATION} | tr '[:upper:]' '[:lower:]'`.h
 set HEADER_DIR = "HEADER_DIR='${MY_HEADER_DIR}'"
-set ROOT_DIR = "ROOT_DIR='${MY_ROMS_SRC}'"
 
 set mycppflags = "${MY_CPP_FLAGS}"
 
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
-setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
 cd ${BUILD_DIR}
 

--- a/ESM/build_ufs.sh
+++ b/ESM/build_ufs.sh
@@ -376,16 +376,6 @@ else
   ltype=""
 fi
 
-if [ ! -z "${FORT}" ]; then
-  if [ ${FORT} == "ifort" ]; then
-    compiler="-DCMAKE_Fortran_COMPILER=ifort"
-  elif [ ${FORT} == "gfortran" ]; then
-    compiler="-DCMAKE_Fortran_COMPILER=gfortran"
-  else
-    compiler=""
-  fi
-fi
-
 if [ ! -z "${MY_CPP_FLAGS}" ]; then
   tmp=`echo ${MY_CPP_FLAGS} | sed 's/^ *-D//' | sed 's/ *-D/;/g'`
   extra_flags="-DMY_CPP_FLAGS=${tmp}"
@@ -477,7 +467,6 @@ if [[ $dprint -eq 0 && $clean -eq 1 ]]; then
                    -DROMS_APP_DIR=${ROMS_APP_DIR} \
                    ${my_hdir} \
                    ${ltype} \
-                   ${compiler} \
                    ${extra_flags} \
                    ${parpack_ldir} \
                    ${arpack_ldir} \

--- a/ESM/build_ufs.sh
+++ b/ESM/build_ufs.sh
@@ -356,13 +356,11 @@ fi
 ANALYTICAL_DIR="ANALYTICAL_DIR='${MY_ANALYTICAL_DIR}'"
 HEADER=`echo ${ROMS_APPLICATION} | tr '[:upper:]' '[:lower:]'`.h
 HEADER_DIR="HEADER_DIR='${MY_HEADER_DIR}'"
-ROOT_DIR="ROOT_DIR='${MY_ROMS_SRC}'"
 
 mycppflags="${MY_CPP_FLAGS}"
 
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
-export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
 cd ${BUILD_DIR}
 

--- a/ESM/build_wrf.csh
+++ b/ESM/build_wrf.csh
@@ -206,6 +206,7 @@ if ( $branch == 1 ) then
   echo "Checking out myroms WRF GitHub branch: $branch_name"
   echo ""
   cd wrf
+  git submodule update --init --recursive
   git checkout $branch_name
   setenv WRF_ROOT_DIR ${PWD}
 else

--- a/ESM/build_wrf.sh
+++ b/ESM/build_wrf.sh
@@ -206,6 +206,7 @@ if [ $branch -eq 1 ]; then
   echo "Checking out myroms WRF GitHub branch: $branch_name"
   echo ""
   cd wrf
+  git submodule update --init --recursive
   git checkout $branch_name
   export WRF_ROOT_DIR=${PWD}
 else

--- a/ESM/roms_cmeps.yaml
+++ b/ESM/roms_cmeps.yaml
@@ -223,7 +223,7 @@ export:
 
 import:
 
-  - standard_name:       mean_down_lw_flx
+  - standard_name:       inst_down_lw_flx
     long_name:           surface downward longwave radiation flux
     short_name:          dLWrad                                 # Faxa_lwdn
     data_variables:      [lwrad_down, time]
@@ -253,7 +253,7 @@ import:
     map_type:            mapbilnr
     map_norm:            none
 
-  - standard_name:       mean_net_sw_flx
+  - standard_name:       inst_net_sw_flx
     long_name:           surface net shortwave radiation flux
     short_name:          SWrad                                  # Faxa_swnet
     data_variables:      [swrad_daily, time]
@@ -328,7 +328,7 @@ import:
     map_type:            mapbilnr
     map_norm:            none
 
-  - standard_name:       mean_prec_rate
+  - standard_name:       inst_prec_rate
     long_name:           precipitation rate
     short_name:          rain                                   # Faxa_rain
     data_variables:      [rain, time]

--- a/ESM/wrf_links.csh
+++ b/ESM/wrf_links.csh
@@ -59,6 +59,9 @@ foreach file ( ${WRF_ROOT_DIR}/run/* )
   endif
 end
 
+# The WRF_NOMOVE environment variable is used by DEVELOPERS ONLY
+# when debugging the coupled system infrastructure.
+
 # Remove all symlinks inside the WRF_BUILD_DIR
 
 find ${WRF_BUILD_DIR} -type l -exec /bin/rm -f {} \;
@@ -76,6 +79,10 @@ echo ""
 /bin/mkdir -vp ${WRF_BUILD_DIR}/external/io_int
 /bin/mkdir -vp ${WRF_BUILD_DIR}/external/io_netcdf
 /bin/mkdir -vp ${WRF_BUILD_DIR}/frame
+
+if ( $?NETCDFPAR ) then
+  /bin/mkdir -vp ${WRF_BUILD_DIR}/external/io_netcdfpar
+endif
 
 # We do not copy files out of the inc directory so we create a symlink
 # do that directory.
@@ -104,6 +111,13 @@ echo "cd ${WRF_BUILD_DIR}/external/io_int"
 cd ${WRF_BUILD_DIR}/external/io_int
 ln -sfv ../../libwrfio_int.a                  .
 ln -sfv ../../module_internal_header_util.mod .
+
+# io_nfpar
+if ( $?NETCDFPAR ) then
+  echo "cd ${WRF_BUILD_DIR}/external/io_netcdfpar"
+  cd ${WRF_BUILD_DIR}/external/io_netcdfpar
+  ln -sfv ../../libwrfio_nfpar.a .
+endif
 
 # io_netcdf
 

--- a/ESM/wrf_links.sh
+++ b/ESM/wrf_links.sh
@@ -81,6 +81,10 @@ echo ""
 /bin/mkdir -vp ${WRF_BUILD_DIR}/external/io_netcdf
 /bin/mkdir -vp ${WRF_BUILD_DIR}/frame
 
+if [ -n "${NETCDFPAR:+1}" ]; then
+  /bin/mkdir -vp ${WRF_BUILD_DIR}/external/io_netcdfpar
+fi
+
 # We do not copy files out of the inc directory so we create a symlink
 # do that directory.
 
@@ -108,6 +112,13 @@ echo "cd ${WRF_BUILD_DIR}/external/io_int"
 cd ${WRF_BUILD_DIR}/external/io_int
 ln -sfv ../../libwrfio_int.a                  .
 ln -sfv ../../module_internal_header_util.mod .
+
+# io_nfpar
+if [ -n "${NETCDFPAR:+1}" ]; then
+  echo "cd ${WRF_BUILD_DIR}/external/io_netcdfpar"
+  cd ${WRF_BUILD_DIR}/external/io_netcdfpar
+  ln -sfv ../../libwrfio_nfpar.a .
+fi
 
 # io_netcdf
 

--- a/Master/cmeps_roms.h
+++ b/Master/cmeps_roms.h
@@ -146,7 +146,7 @@
       USE mod_stepping,     ONLY : nstp, knew
       USE mp_exchange_mod,  ONLY : mp_exchange2d
       USE stdinp_mod,       ONLY : getpar_i
-      USE stdout_mod,       ONLY : stdout_unit
+      USE stdout_mod,       ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,      ONLY : FoundError, assign_string, lowercase
       USE yaml_parser_mod,  ONLY : yaml_AssignString,                   &
      &                             yaml_Error,                          &
@@ -1656,7 +1656,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-      stdout=stdout_unit(MyMaster)
+      IF (Set_StdOutUnit) THEN
+        stdout=stdout_unit(MyMaster)
+        Set_StdOutUnit=.FALSE.
+      END IF
 !
 !-----------------------------------------------------------------------
 !  Open standard output unit for ROMS cap information and messages.

--- a/Master/esmf_atm_coamps.h
+++ b/Master/esmf_atm_coamps.h
@@ -140,7 +140,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering ATM_SetServices',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -292,7 +292,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  ATM_SetServices',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -335,7 +335,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_SetInitializeP1',  &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -426,7 +426,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_SetInitializeP1',  &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -502,7 +502,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_SetInitializeP2',  &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -701,7 +701,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_SetInitializeP2',  &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (/,' COAMPS_SetInitializeP2 - unable to find time-',       &
@@ -743,7 +743,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_DataInit',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -795,7 +795,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_DataInit',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -850,7 +850,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_SetClock',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1125,7 +1125,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_SetClock',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
  10   FORMAT (2x,a,2x,a/,2x,a,2x,a,/,2x,a,2x,a,/)
@@ -1166,7 +1166,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_SetRunClock',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1224,7 +1224,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_SetRunClock',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1275,7 +1275,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_CheckImport',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1453,7 +1453,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_CheckImport',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (1x,'COAMPS_CheckImport - ',a,':',t32,'TimeStamp = ',a,    &
@@ -1598,7 +1598,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_SetGridArrays',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1915,9 +1915,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_SetGridArrays',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT ('COAMPS_DistGrid - Grid = ',i2.2,',',3x,'Mesh = ',a,',',  &
      &        3x,'Partition = ',i0,' x ',i0)
@@ -1975,7 +1975,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_SetStates',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2319,7 +2319,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_SetStates',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
 !
@@ -2378,7 +2378,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_ModelAdvance',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2538,13 +2538,13 @@
         IF (ESM_track) THEN
           WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_Run',            &
      &                            ', PET', PETrank
-          CALL my_flush (trac)
+          FLUSH (trac)
         END IF
         CALL COAMPS_Run (ltau_0, StepCount)
         IF (ESM_track) THEN
           WRITE (trac,'(a,a,i0)') '==> Exiting  COAMPS_Run',            &
      &                            ', PET', PETrank
-          CALL my_flush (trac)
+          FLUSH (trac)
         END IF
       END IF
 !
@@ -2569,7 +2569,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_ModelAdvance',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (3x,'ModelAdvance - ESMF, Running COAMPS:',t42,a,          &
@@ -2609,7 +2609,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_SetFinalize',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2618,12 +2618,12 @@
 !-----------------------------------------------------------------------
 !
       CALL COAMPS_Finalize ()
-      CALL my_flush (6)                   ! flush standard output buffer
+      FLUSH (6)                   ! flush standard output buffer
 !
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_SetFinalize',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -2693,7 +2693,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_Import',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -3126,9 +3126,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_Import',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT (/,2x,'COAMPS_Import - unable to find option to import: ', &
      &        a,/,18x,'check ''Import(atmos)'' in input script: ', a)
@@ -3242,7 +3242,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_ProcessImport',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -3584,9 +3584,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_ProcessImport',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT (/,5x,'COAMPS_ProcessImport - ',                           &
      &         'unable to find option to import: ',a,                   &
@@ -3687,7 +3687,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering COAMPS_Export',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -4203,9 +4203,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  COAMPS_Export',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT (/,2x,'COAMPS_Export - unable to find option to export: ', &
      &        a,/,18x,'check ''Export(atmos)'' in input script: ',a)

--- a/Master/esmf_atm_regcm.h
+++ b/Master/esmf_atm_regcm.h
@@ -140,7 +140,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering ATM_SetServices',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -292,7 +292,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_SetServices',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -335,7 +335,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_SetInitializeP1',   &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -426,7 +426,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_SetInitializeP1',   &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -474,7 +474,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_SetInitializeP2',   &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -547,7 +547,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_SetInitializeP2',   &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -592,7 +592,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_DataInit',          &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -687,9 +687,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_DataInit',          &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT (/,' ESMF, Running RegCM: ',a,' --> ',a,' Phase: ',i1)
   20  FORMAT (/,' ESMF, Running RegCM: ',a,' --> ',a,' Phase: ',i1,     &
@@ -744,7 +744,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_SetClock',          &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1003,7 +1003,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_SetClock',          &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1041,7 +1041,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_SetRunClock',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1099,7 +1099,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_SetRunClock',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1150,7 +1150,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_CheckImport',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1328,7 +1328,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_CheckImport',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (1x,'RegCM_CheckImport - ',a,':',t32,'TimeStamp = ',a,     &
@@ -1389,7 +1389,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_SetGridArrays',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1702,7 +1702,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_SetGridArrays',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1751,7 +1751,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_SetStates',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2067,7 +2067,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_SetStates',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
 !
@@ -2121,7 +2121,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_ModelAdvance',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2286,7 +2286,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_ModelAdvance',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (' Running RegCM Component: ',a,' --> ',a,' Phase: ',i1)
@@ -2327,7 +2327,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_SetFinalize',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2336,12 +2336,12 @@
 !-----------------------------------------------------------------------
 !
       CALL RegCM_Finalize ()
-      CALL my_flush (6)                   ! flush standard output buffer
+      FLUSH (6)                   ! flush standard output buffer
 !
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_SetFinalize',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -2404,7 +2404,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_Import',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2750,9 +2750,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_Import',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT (/,2x,'RegCM_Import - unable to find option to import: ',  &
      &        a,/,18x,'check ''Import(atmos)'' in input script: ', a)
@@ -2820,7 +2820,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_Export',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -3394,9 +3394,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_Export',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT (/,2x,'RegCM_Export - unable to find option to export: ',  &
      &        a,/,18x,'check ''Export(atmos)'' in input script: ',a)
@@ -3447,7 +3447,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering RegCM_uvrot',             &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
 !  Rotated Mercator (ROTMER) or Normal Mercator (NORMER) projections.
@@ -3529,7 +3529,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  RegCM_uvrot',             &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN

--- a/Master/esmf_atm_wrf.h
+++ b/Master/esmf_atm_wrf.h
@@ -144,7 +144,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering ATM_SetServices',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -296,7 +296,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  ATM_SetServices',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -339,7 +339,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_SetInitializeP1',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -430,7 +430,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_SetInitializeP1',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -477,7 +477,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_SetInitializeP2',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -560,7 +560,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_SetInitializeP2',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -599,7 +599,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_DataInit',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -645,7 +645,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_DataInit',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -695,7 +695,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_SetClock',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -987,7 +987,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_SetClock',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
  10   FORMAT (/,1x,a,a,/,1x,a,a,/,1x,a)
@@ -1027,7 +1027,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_SetRunClock',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1085,7 +1085,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_SetRunClock',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1136,7 +1136,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_CheckImport',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1314,7 +1314,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_CheckImport',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (1x,'WRF_CheckImport - ',a,':',t32,'TimeStamp = ',a,       &
@@ -1387,7 +1387,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_SetGridArrays',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1814,9 +1814,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_SetGridArrays',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT (3x,'WRF_DistGrid - Grid = ',i2.2,',',3x,'Mesh = ',a,',',  &
      &        3x,'Partition = ',i0,' x ',i0)
@@ -1871,7 +1871,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_SetStates',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2197,7 +2197,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_SetStates',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
 !
@@ -2263,7 +2263,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_ModelAdvance',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2486,13 +2486,13 @@
         IF (ESM_track) THEN
           WRITE (trac,'(a,a,i0)') '==> Entering WRF_Run',               &
      &                            ', PET', PETrank
-          CALL my_flush (trac)
+          FLUSH (trac)
         END IF
         CALL WRF_Run ()
         IF (ESM_track) THEN
           WRITE (trac,'(a,a,i0)') '==> Exiting  WRF_Run',               &
      &                            ', PET', PETrank
-          CALL my_flush (trac)
+          FLUSH (trac)
         END IF
       END IF
 !
@@ -2522,7 +2522,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_ModelAdvance',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (3x,'ModelAdvance - ESMF, Running WRF:',t42,a,             &
@@ -2564,7 +2564,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_SetFinalize',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2577,12 +2577,12 @@
 !
       no_shutdown=.TRUE.
       CALL WRF_Finalize (no_shutdown)
-      CALL my_flush (6)                   ! flush standard output buffer
+      FLUSH (6)                   ! flush standard output buffer
 !
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_SetFinalize',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -2655,7 +2655,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_Import',              &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -3131,9 +3131,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_Import',              &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT (/,5x,'WRF_Import - unable to find option to import: ',    &
      &        a,/,18x,'check ''Import(atmos)'' in input script: ', a)
@@ -3250,7 +3250,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_ProcessImport_scalar',&
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -3599,9 +3599,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_ProcessImport_scalar',&
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT (/,5x,'WRF_ProcessImport - ',                              &
      &         'unable to find option to import: ',a,                   &
@@ -3735,7 +3735,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_ProcessImport_vector',&
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -4218,9 +4218,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_ProcessImport_vector',&
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT (/,5x,'WRF_ProcessImport - ',                              &
      &         'unable to find option to import: ',a,                   &
@@ -4306,7 +4306,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WRF_Export',              &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -5235,9 +5235,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WRF_Export',              &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
 # ifdef WRF_TIMEAVG
   10  FORMAT (/,5x,'WRF_Export - illegal configuration: ',a,            &

--- a/Master/esmf_coupler.h
+++ b/Master/esmf_coupler.h
@@ -127,7 +127,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering Coupler_SetServices for ' &
      &                          // TRIM(Cname), ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
 !-----------------------------------------------------------------------
@@ -192,7 +192,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  Coupler_SetServices for ' &
      &                          // TRIM(Cname), ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -274,7 +274,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering Coupler_ComputeRH for '   &
      &                          // TRIM(Cname), ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
 !  Get current parallel node rank and number of nodes.
@@ -681,7 +681,7 @@
      &          TRIM(GridType (MODELS(iDst)%ImportField(idDst)%gtype)), &
      &          TRIM(IntrpType(MODELS(iSrc)%ExportField(idSrc)%itype)), &
      &          rh1Exist, rh2Exist
-                CALL my_flush (cplout)
+                FLUSH (cplout)
               END IF
 !
 !  Create 1st RouteHandle.
@@ -737,7 +737,7 @@
 !
                 IF ((DebugLevel.gt.0).and.(localPET.eq.0)) THEN
                   WRITE (cplout,40) TRIM(Rname)
-                  CALL my_flush (cplout)
+                  FLUSH (cplout)
                 END IF
               END IF
 !
@@ -863,7 +863,7 @@
 !
                 IF ((DebugLevel.gt.0).and.(localPET.eq.0)) THEN
                   WRITE (cplout,40) TRIM(Rname)
-                  CALL my_flush (cplout)
+                  FLUSH (cplout)
                 END IF
               END IF
 !
@@ -920,7 +920,7 @@
      &          TRIM(GridType (MODELS(iDst)%ImportField(idDst)%gtype)), &
      &          TRIM(IntrpType(MODELS(iSrc)%ExportField(idSrc)%itype)), &
      &          rh1Exist, rh2Exist
-                CALL my_flush (cplout)
+                FLUSH (cplout)
               END IF
 !
 !  Regrid method from source to destination.
@@ -1063,9 +1063,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  Coupler_ComputeRH for '   &
      &                          // TRIM(Cname), ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
  10   FORMAT (4x,'RouteHandle - PET = ',i0,' iSrc = ',i0,' iDst = ',i0, &
      &        ' srcMask = ',i0,' dstMask = ',i0,', cplSet = ',a,', ',a)
@@ -1153,7 +1153,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering Coupler_ExecuteRH for '   &
      &                          // TRIM(Cname), ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
 !  Get current parallel node rank and number of nodes.
@@ -1764,9 +1764,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  Coupler_ExecuteRH for '   &
      &                          // TRIM(Cname), ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
  10   FORMAT (3x,'ESMF Coupler - PET(',i3.3,') - ',a,' = ',e14.5,       &
      &        ' (',a,')')
@@ -1824,7 +1824,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering Coupler_ReleaseRH',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2189,7 +2189,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  Coupler_ReleaseRH',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -2253,7 +2253,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering Coupler_AdjustField',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2472,7 +2472,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  Coupler_AdjustField',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -2527,7 +2527,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering Coupler_AreaIntegral',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2711,9 +2711,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  Coupler_AreaIntegral',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
       RETURN
       END FUNCTION Coupler_AreaIntegral
@@ -2766,7 +2766,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering Coupler_FieldCreate',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
 !-----------------------------------------------------------------------
@@ -2931,7 +2931,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  Coupler_FieldCreate',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -2990,7 +2990,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering Coupler_FindUnmapped',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -3252,7 +3252,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  Coupler_FindUnmapped',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN

--- a/Master/esmf_data.F
+++ b/Master/esmf_data.F
@@ -3116,7 +3116,7 @@
                   Tindex=3-Tindex
                   DataSet(Icomp)%Export(ifld)%Tindex=Tindex
 !
-!  Read in time coordinate and scale it to day units.
+!  Read in time coordinate and scale it to DAY UNITS.
 !
                   CALL netcdf_get_time (ng, imodel, ncname,             &
      &                                  TRIM(T_name),                   &
@@ -3417,7 +3417,8 @@
       CALL time_string (TimeStrSec, I_code)
       CALL time_string (TimeEndSec, F_code)
 !
-!  Set available minimum and maximum time coordinates.
+!  Set available minimum and maximum time coordinates. The input time
+!  is scaled to DAY units.
 !
       DO i=1,Nfiles
         Mfiles=IFS(i)%Nfiles  ! number of multi-files within source file
@@ -3450,7 +3451,8 @@
         END IF
 !
 !  Initialize other structure parameters or issue an error if data does
-!  not include initalization time.
+!  not include initalization time. Notice that the time argument to
+!  routine 'time_string' is in seconds.
 !
         IF (Fcount.gt.0) THEN
           IFS(i)%Fcount=Fcount
@@ -3599,7 +3601,7 @@
       Lcheck=.TRUE.
       Lcycle=.FALSE.
       Lperpetual=.FALSE.
-      Tscale=1.0_dp                        ! days
+      Tscale=1.0_dp                        ! time in days by default
       Tmin= MISSING_dp
       Tmax=-MISSING_dp
       DO i=1,LEN(blank)
@@ -3665,6 +3667,7 @@
             END DO
             IF ((INDEX(TRIM(lowercase(long_name)),'time').ne.0).and.    &
      &          ((INDEX(TRIM(lowercase(units)),'day').ne.0).or.         &
+     &           (INDEX(TRIM(lowercase(units)),'hour').ne.0).or.        &
      &           (INDEX(TRIM(lowercase(units)),'second').ne.0))) THEN
               TvarName=TRIM(var_name(i))
               foundit=.TRUE.
@@ -3704,6 +3707,8 @@
 !  for perpetual time axis: the 'calendar' attribute is 'none' or
 !  the number of records in the time dimension is one (Nrec=1).
 !
+!  Compute time scale (Tscale) to convert DAY units.
+!
       Nrec=var_Dsize(1)              ! time is a 1D array
       DO i=1,nvatt
         IF (TRIM(var_Aname(i)).eq.'units') THEN
@@ -3711,9 +3716,9 @@
           IF (INDEX(TRIM(var_Achar(i)),'day').ne.0) THEN
             Tscale=1.0_dp
           ELSE IF (INDEX(TRIM(var_Achar(i)),'hour').ne.0) THEN
-            Tscale=24.0_dp
+            Tscale=1.0_dp/24.0_dp
           ELSE IF (INDEX(TRIM(var_Achar(i)),'second').ne.0) THEN
-            Tscale=86400.0_dp
+            Tscale=1.0_dp/86400.0_dp
           END IF
         ELSE IF (TRIM(var_Aname(i)).eq.'calendar') THEN
           IF ((Nrec.eq.1).or.                                           &
@@ -4238,8 +4243,10 @@
                   Tunits=TRIM(var_Achar(i))
                   IF (Tunits(1:6).eq.'second') THEN
                     Tscale=1.0_dp/86400.0_dp         ! seconds to days
+                  ELSE IF (Tunits(1:4).eq.'hour') THEN
+                    Tscale=1.0_dp/24.0_dp            ! hours to days
                   ELSE
-                    Tscale=1.0_dp                    ! day units
+                    Tscale=1.0_dp                    ! default day units
                   END IF
                   Export(ifield)%Tunits=TRIM(Tunits)
                   Export(ifield)%Tscale=Tscale

--- a/Master/esmf_data.F
+++ b/Master/esmf_data.F
@@ -159,7 +159,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_SetServices',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -266,7 +266,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_SetServices',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -311,7 +311,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_SetInitializeP1',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -394,7 +394,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_SetInitializeP1',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
  10   FORMAT (1x,'DATA_SetInitializeP1 - unable to find field ''',a,    &
@@ -453,7 +453,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_SetInitializeP2',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -522,14 +522,14 @@
         Lwclock=.TRUE.
         CALL initialize_parallel
 !
-!  The standard output is redirected to an specific file for clarity and
+!  The standard output is redirected to an specific file for clarity.
 !  it unit is redifined.
 !
-        dataout=101                    ! overwite Fortran default unit 6
+!!      dataout=101                    ! overwite Fortran default unit 6
 !
         IF (localPET.eq.0) THEN
-          OPEN (dataout, FILE='log.data', FORM='formatted',             &
-     &          STATUS='replace')
+!!        OPEN (dataout, FILE='log.data', FORM='formatted',             &
+!!   &          STATUS='replace')
           lstr=INDEX(my_fflags, 'free')-2
           IF (lstr.le.0) lstr=LEN_TRIM(my_fflags)
           WRITE (dataout,10) TRIM(ESMF_VERSION_STRING),                 &
@@ -637,7 +637,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_SetInitializeP2',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (80('-'),/,                                                &
@@ -730,7 +730,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_Initialize',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -892,7 +892,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_Initialize',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (/,' DATA_Initialize - cannot find export field: ',a,      &
@@ -941,7 +941,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_DataInit',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -999,7 +999,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_DataInit',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1052,7 +1052,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_SetClock',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1230,7 +1230,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_SetClock',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1281,7 +1281,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_SetGridArrays',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1467,7 +1467,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_SetGridArrays',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1517,7 +1517,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_SetStates',          &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1764,7 +1764,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_SetStates',          &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
  10   FORMAT (1x,'DATA_SetStates - Removing field ''',a,''' from ',a,   &
@@ -1821,7 +1821,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_ModelAdvance',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1981,7 +1981,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_ModelAdvance',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (3x,'ModelAdvance - ESMF, Running DATA:',t42,a,            &
@@ -2032,7 +2032,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_SetFinalize',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2059,12 +2059,10 @@
         END IF
       END DO
 !
-      CALL my_flush (dataout)             ! flush standard output buffer
-!
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_SetFinalize',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -2154,7 +2152,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_Export',             &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 # ifdef TIME_INTERP
@@ -2726,11 +2724,11 @@
 !
 !  Flux DATA component standard out unit.
 !
-      CALL my_flush (dataout)
+      FLUSH (dataout)
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_Export',             &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (i4.4,'-',i2.2,'-',i2.2,1x,i2.2,':',i2.2,':',a)
@@ -2804,7 +2802,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_TimeInterp',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2912,7 +2910,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_TimeInterp',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (/,' DATA_TimeInterp - current coupling time',             &
@@ -3012,7 +3010,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_ncread',             &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
       SourceFile=MyFile
@@ -3306,7 +3304,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_ncread',             &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (/,' DATA_ncread - error while reading variable: ',a,2x,   &
@@ -3395,7 +3393,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_multifile',          &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
       SourceFile=MyFile
@@ -3504,7 +3502,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_multifile',          &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
  10   FORMAT (/,' DATA_MULTIFILE - Error while processing ', a,         &
@@ -3593,7 +3591,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_checkfile',          &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       SourceFile=MyFile
 !
@@ -3763,7 +3761,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_checkfile',          &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
  10   FORMAT (' DATA_checkfile   - inquiring range of time records in', &
@@ -3870,7 +3868,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_inquiry',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
       SourceFile=MyFile
@@ -4531,7 +4529,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_inquiry',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
    5  FORMAT (' DATA_inquiry     - inquiring NetCDF variable ''',a,     &
@@ -4668,7 +4666,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering DATA_ncvarcoords',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
       SourceFile=MyFile
@@ -4952,7 +4950,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  DATA_ncvarcoords',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
  10   FORMAT (' DATA_ncvarcoords - setting spatial coordinates for',    &

--- a/Master/esmf_driver.h
+++ b/Master/esmf_driver.h
@@ -239,7 +239,7 @@
 !
 !  Flush and lose coupling standard out unit.
 !
-      CALL my_flush (cplout)
+      FLUSH (cplout)
       CLOSE (cplout)
 !
       STOP

--- a/Master/esmf_esm.F
+++ b/Master/esmf_esm.F
@@ -115,7 +115,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering ESM_SetServices',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -205,7 +205,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  ESM_SetServices',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       END SUBROUTINE ESM_SetServices
@@ -244,7 +244,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering ESM_SetModelServices',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -432,7 +432,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  ESM_SetModelServices',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -477,7 +477,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering ESM_SetRunSequence',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -596,7 +596,7 @@
      &                         file=MyFile)) THEN
           RETURN
         END IF
-        CALL my_flush (6)                   ! flush standard output unit
+        FLUSH (6)                   ! flush standard output unit
       END IF
 !
 !  Destroy free format object. All internal memory is deallocated.
@@ -613,7 +613,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  ESM_SetRunSequence',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
  10   FORMAT (/,' ESM_SetRunSequence - Error while ingesting',          &

--- a/Master/esmf_ice_cice.h
+++ b/Master/esmf_ice_cice.h
@@ -125,7 +125,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering ICE_SetServices',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 
@@ -236,7 +236,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  ICE_SetServices',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -279,7 +279,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering CICE_SetInitializeP1',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -376,7 +376,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  CICE_SetInitializeP1',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -420,7 +420,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering CICE_SetInitializeP2',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -492,7 +492,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  CICE_SetInitializeP2',    &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -528,7 +528,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering CICE_DataInit',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -573,7 +573,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  CICE_DataInit',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -625,7 +625,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering CICE_SetClock',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -907,7 +907,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  CICE_SetClock',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -977,7 +977,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering CICE_SetGridArrays',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1299,7 +1299,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  CICE_SetGridArrays',      &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1351,7 +1351,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering CICE_SetStates',          &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1660,7 +1660,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  CICE_SetStates',          &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1713,7 +1713,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering CICE_ModelAdvance',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1861,7 +1861,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  CICE_ModelAdvance',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT (3x,'ModelAdvance - ESMF, Running CICE:',t42,a,            &
@@ -1901,7 +1901,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering CICE_SetFinalize',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1910,12 +1910,12 @@
 !-----------------------------------------------------------------------
 !
       CALL CICE_Finalize
-      CALL my_flush (6)                   ! flush standard output buffer
+      FLUSH (6)                   ! flush standard output buffer
 !
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  CICE_SetFinalize',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1983,7 +1983,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering CICE_Import',             &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2832,9 +2832,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  CICE_Import',             &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT (/,3x,' CICE_Import - unable to find option to import: ',  &
      &        a,t68,a,/,18x,'check ''Import(roms)'' in input script: ', &
@@ -2906,7 +2906,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering CICE_Export',             &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -3544,9 +3544,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  CICE_Export',             &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      CALL my_flush (cplout)
+      FLUSH (cplout)
 !
   10  FORMAT (/,3x,' CICE_Export - unable to find option to export: ',  &
      &        a,/,18x,'check ''Export(cice)'' in input script: ',a)

--- a/Master/esmf_roms.h
+++ b/Master/esmf_roms.h
@@ -2732,9 +2732,6 @@
 !-----------------------------------------------------------------------
 !
       CALL ROMS_finalize
-      FLUSH (stdout)                      ! flush standard output buffer
-      FLUSH (cplout)                      ! flush coupling output buffer
-      CLOSE (cplout)                      ! close coupling log file
 !
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  ROMS_SetFinalize',        &

--- a/Master/esmf_roms.h
+++ b/Master/esmf_roms.h
@@ -127,7 +127,6 @@
      &                             rho0, sec2day, tdays, time_ref
       USE mod_stepping,     ONLY : nstp, knew
       USE mp_exchange_mod,  ONLY : mp_exchange2d
-      USE stdinp_mod,       ONLY : getpar_i
       USE strings_mod,      ONLY : FoundError, assign_string
 !
 !-----------------------------------------------------------------------

--- a/Master/esmf_wav_wam.h
+++ b/Master/esmf_wav_wam.h
@@ -129,7 +129,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAV_SetServices',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -254,7 +254,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WAV_SetServices',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -297,7 +297,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAM_SetInitializeP1',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -394,7 +394,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WAM_SetInitializeP1',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -437,7 +437,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAM_SetInitializeP2',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -509,7 +509,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WAM_SetInitializeP2',     &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -545,7 +545,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAM_DataInit',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -584,7 +584,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WAM_DataInit',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -638,7 +638,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAM_SetClock',
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -920,7 +920,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WAM_SetClock',            &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -965,7 +965,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAM_CheckImport',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1112,7 +1112,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WAM_CheckImport',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1166,7 +1166,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAM_SetGridArrays',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1393,7 +1393,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WAM_SetGridArrays',       &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1441,7 +1441,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAM_SetStates',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1755,7 +1755,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WAM_SetStates',           &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -1802,7 +1802,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAM_ModelAdvance',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -1952,9 +1952,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WAM_ModelAdvance',        &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      CALL my_flush (cplout)
+      FLUSH (cplout)
 !
   10  FORMAT (/,' ESMF, Running WAM: ',a,' --> ',a,' Phase: ',i1)
   20  FORMAT (/,' ESMF, Running WAV: ',a,' --> ',a,' Phase: ',i1,       &
@@ -1994,7 +1994,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAM_SetFinalize',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2003,12 +2003,12 @@
 !-----------------------------------------------------------------------
 !
       CALL WAM_Finalize ()
-      CALL my_flush (6)                   ! flush standard output buffer
+      FLUSH (6)                   ! flush standard output buffer
 !
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WAM_SetFinalize',         &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN
@@ -2062,7 +2062,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAM_Import',              &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2247,9 +2247,9 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WAM_Import',              &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
   10  FORMAT (' PET(',I3,') - tile(',i2,') - ', a20, ' : ', 4i8)
   20  FORMAT (a,'_',a,'_',i4.4,3('-',i2.2),'.nc')
@@ -2301,7 +2301,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAM_Export',              &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2517,7 +2517,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exitinh  WAM_Export',              &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
   10  FORMAT ('wam_',i2.2,'_export_',a,'_',i4.4,3('-',i2.2),'.nc')
@@ -2567,7 +2567,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '==> Entering WAM_Unpack',              &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
       rc=ESMF_SUCCESS
 !
@@ -2688,7 +2688,7 @@
       IF (ESM_track) THEN
         WRITE (trac,'(a,a,i0)') '<== Exiting  WAM_Unpack',              &
      &                          ', PET', PETrank
-        CALL my_flush (trac)
+        FLUSH (trac)
       END IF
 !
       RETURN

--- a/Master/mod_esmf_esm.F
+++ b/Master/mod_esmf_esm.F
@@ -761,6 +761,9 @@
       IF (.not.allocated(ClockInfo)) THEN
         allocate ( ClockInfo(0:Nmodels) )
       END IF
+      DO i=0,Nmodels
+        ClockInfo(i)%Restarted=.FALSE.
+      END IF
 !
 !  Allocate MPI communicator handle for each ESM component.
 !

--- a/Master/mod_esmf_esm.F
+++ b/Master/mod_esmf_esm.F
@@ -1391,7 +1391,7 @@
 !
       USE mod_parallel,   ONLY : OCN_COMM_WORLD, MyRank
       USE mod_parallel,   ONLY : allocate_parallel, initialize_parallel
-      USE mod_iounits,    ONLY : Iname, SourceFile
+      USE mod_iounits,    ONLY : Iname, SourceFile, stdout
       USE mod_scalars,    ONLY : NoError, Rclock, exit_flag
       USE mod_strings,    ONLY : my_cpu, my_fc, my_fflags, my_fort,     &
      &                           my_os, Rdir
@@ -1404,6 +1404,7 @@
 # ifdef DISTRIBUTE
       USE distribute_mod, ONLY : mp_bcasts
 # endif
+      USE stdout_mod,     ONLY : stdout_unit  
       USE strings_mod,    ONLY : lowercase
 !
       implicit none
@@ -1499,6 +1500,7 @@
      &                       file=MyFile)) THEN
         RETURN
       END IF
+      MyMaster=localPET.eq.0
 !
 !  Assign driver communicatior handle to ROMS temporarily. It is needed
 !  since here are using ROMS generic NetCDF and distributed-memory
@@ -1511,11 +1513,21 @@
 !
       PETrank=localPET
 !
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+      stdout=stdout_unit(MyMaster)
+!
 !  Open standard output unit for ESM coupler information and messages.
 !  It is advisable to have such infomation separated from other standard
 !  output from the coupled models.
 !
-      IF (localPET.eq.0) THEN
+      IF (MyMaster) THEN
         OPEN (cplout, FILE=TRIM(CouplerLog), FORM='formatted',          &
      &        STATUS='replace')
       END IF

--- a/Master/mod_esmf_esm.F
+++ b/Master/mod_esmf_esm.F
@@ -1404,7 +1404,7 @@
 # ifdef DISTRIBUTE
       USE distribute_mod, ONLY : mp_bcasts
 # endif
-      USE stdout_mod,     ONLY : stdout_unit  
+      USE stdout_mod,     ONLY : Set_StdOutUnit, stdout_unit  
       USE strings_mod,    ONLY : lowercase
 !
       implicit none
@@ -1521,7 +1521,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-      stdout=stdout_unit(MyMaster)
+      IF (Set_StdOutUnit) THEN
+        stdout=stdout_unit(MyMaster)
+        Set_StdOutUnit=.FALSE.
+      END IF
 !
 !  Open standard output unit for ESM coupler information and messages.
 !  It is advisable to have such infomation separated from other standard

--- a/Master/mod_esmf_esm.F
+++ b/Master/mod_esmf_esm.F
@@ -763,7 +763,7 @@
       END IF
       DO i=0,Nmodels
         ClockInfo(i)%Restarted=.FALSE.
-      END IF
+      END DO
 !
 !  Allocate MPI communicator handle for each ESM component.
 !

--- a/Master/mod_esmf_esm.F
+++ b/Master/mod_esmf_esm.F
@@ -527,7 +527,7 @@
 !
       integer :: DebugLevel = 0
 !
-!  Execution tracing flag:
+!  Execution tracng flag:
 !
 !    [0] no tracing
 !    [1] reports sequence of coupling subroutine calls
@@ -1067,7 +1067,7 @@
           END IF
         END IF
       END DO
-      IF (DebugLevel.gt.0) CALL my_flush (cplout)
+      IF (DebugLevel.gt.0) FLUSH (cplout)
 !
 !  Store the clock advance counter.
 !
@@ -1418,7 +1418,7 @@
 !  Local variable declarations.
 !
       logical :: doit, first
-      logical :: Lwrite
+      logical :: Lwrite, MasterPET
       logical :: Lvalue(1)
       logical, allocatable :: LvalueA(:), LvalueI(:)
       logical, allocatable :: LvalueR(:), LvalueW(:)
@@ -1500,7 +1500,7 @@
      &                       file=MyFile)) THEN
         RETURN
       END IF
-      MyMaster=localPET.eq.0
+      MasterPET=localPET.eq.0
 !
 !  Assign driver communicatior handle to ROMS temporarily. It is needed
 !  since here are using ROMS generic NetCDF and distributed-memory
@@ -1522,7 +1522,7 @@
 !  the case, it opens such formatted file for writing.
 !
       IF (Set_StdOutUnit) THEN
-        stdout=stdout_unit(MyMaster)
+        stdout=stdout_unit(MasterPET)
         Set_StdOutUnit=.FALSE.
       END IF
 !
@@ -1530,10 +1530,10 @@
 !  It is advisable to have such infomation separated from other standard
 !  output from the coupled models.
 !
-      IF (MyMaster) THEN
+!     IF (MasterPET) THEN
         OPEN (cplout, FILE=TRIM(CouplerLog), FORM='formatted',          &
      &        STATUS='replace')
-      END IF
+!     END IF
 !
 !-----------------------------------------------------------------------
 !  Determine coupling standard input filename.  In distributed-memory,
@@ -1542,7 +1542,7 @@
 !  is specified in this coupling script.
 !-----------------------------------------------------------------------
 !
-      Lwrite=localPET .eq. 0
+      Lwrite=MasterPET
       inp=100
       out=cplout
 !
@@ -3805,7 +3805,7 @@
 !
 !  Flush standard output buffer.
 !
-      CALL my_flush (out)
+      FLUSH (out)
 !
   70  FORMAT (80('-'),/,                                                &
      &        ' Earth System Models Coupling: ESMF/NUOPC Library,',     &

--- a/ROMS/Adjoint/ad_diag.F
+++ b/ROMS/Adjoint/ad_diag.F
@@ -319,7 +319,7 @@
 # else
  20         FORMAT (i10,1x,a,4(1pe14.6))
 # endif
-            CALL my_flush (stdout)
+            FLUSH (stdout)
           END IF
 !
 !  If blowing-up, set exit_flag to stop computations.

--- a/ROMS/Adjoint/ad_nesting.F
+++ b/ROMS/Adjoint/ad_nesting.F
@@ -898,7 +898,7 @@
      &                20x,'(dg)',4x,'(rg)',18x,'2D',6x,'3D',9x,'(rg)',  &
      &                8x,'told',8x,'(ng)',8x,'tnew',/)
  20           FORMAT (4(1x,i3),2(1x,i7),2(2x,i4),2(4x,i4),1x,4(2x,i10))
-              CALL my_flush (102)
+              FLUSH (102)
             END IF
           END IF
 # endif
@@ -4160,7 +4160,7 @@
      &            7x,'Wold',7x,'Wnew',/,18x,'(dg)',3x,'(ng)',           &
      &            19x,'(dg)',7x,'told',7x,'(ng)',7x,'tnew',/)
  30       FORMAT (3i5,2i7,2i6,4(2x,i9),2f11.4)
-          CALL my_flush (202)
+          FLUSH (202)
         END IF
       END IF
 # endif
@@ -7696,7 +7696,7 @@
             IF (Master) THEN
               WRITE (302,10) 'Western Boundary Mass Fluxes: ',          &
      &                       cr, dg, rg, iif(rg), iic(rg), INT(time(rg))
-              CALL my_flush (302)
+              FLUSH (302)
             END IF
           END IF
 !
@@ -7740,7 +7740,7 @@
               END IF
               WRITE (302,30) Jbc, REFINED(cr)%DU_avg2(1,m,tnew),        &
      &                       WestSum, MFratio
-              CALL my_flush (302)
+              FLUSH (302)
 # endif
             END IF
           END DO
@@ -7759,7 +7759,7 @@
             IF (Master) THEN
               WRITE (302,10) 'Eastern Boundary Mass Fluxes: ',          &
      &                       cr, dg, rg, iif(rg), iic(rg), INT(time(rg))
-              CALL my_flush (302)
+              FLUSH (302)
             END IF
           END IF
 !
@@ -7803,7 +7803,7 @@
               END IF
               WRITE (302,30) Jbc, REFINED(cr)%DU_avg2(1,m,tnew),        &
      &                       EastSum, MFratio
-              CALL my_flush (302)
+              FLUSH (302)
 # endif
             END IF
           END DO
@@ -7822,7 +7822,7 @@
             IF (Master) THEN
               WRITE (302,20) 'Southern Boundary Mass Fluxes: ',         &
      &                       cr, dg, rg, iif(rg), iic(rg), INT(time(rg))
-              CALL my_flush (302)
+              FLUSH (302)
             END IF
           END IF
 !
@@ -7867,7 +7867,7 @@
               END IF
               WRITE (302,30) Ibc, REFINED(cr)%DV_avg2(1,m,tnew),        &
      &                       SouthSum, MFratio
-              CALL my_flush (302)
+              FLUSH (302)
 # endif
             END IF
           END DO
@@ -7886,7 +7886,7 @@
             IF (Master) THEN
               WRITE (302,20) 'Northern Boundary Mass Fluxes: ',         &
      &                       cr, dg, rg, iif(rg), iic(rg), INT(time(rg))
-              CALL my_flush (302)
+              FLUSH (302)
             END IF
           END IF
 !
@@ -7979,7 +7979,7 @@
 
 # ifdef NESTING_DEBUG_NOT
 !
-      CALL my_flush (302)
+      FLUSH (302)
 !
   10  FORMAT (/,1x,a,/,/,4x,'cr = ',i2.2,4x,'dg = ',i2.2,4x,'rg = ',    &
      &        i2.2,4x,'iif(rg) = ',i3.3,4x,'iic(rg) = ',i10.10,4x,      &

--- a/ROMS/Drivers/ad_roms.h
+++ b/ROMS/Drivers/ad_roms.h
@@ -37,7 +37,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -117,7 +117,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/ad_roms.h
+++ b/ROMS/Drivers/ad_roms.h
@@ -37,6 +37,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -107,6 +108,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/adsen_roms.h
+++ b/ROMS/Drivers/adsen_roms.h
@@ -59,6 +59,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -131,6 +132,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/adsen_roms.h
+++ b/ROMS/Drivers/adsen_roms.h
@@ -59,7 +59,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -141,7 +141,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/afte_roms.h
+++ b/ROMS/Drivers/afte_roms.h
@@ -66,6 +66,7 @@
 #endif
       USE packing_mod,       ONLY : c_norm2
       USE packing_mod,       ONLY : r_norm2
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -140,6 +141,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/afte_roms.h
+++ b/ROMS/Drivers/afte_roms.h
@@ -66,7 +66,7 @@
 #endif
       USE packing_mod,       ONLY : c_norm2
       USE packing_mod,       ONLY : r_norm2
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -150,7 +150,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/array_modes.h
+++ b/ROMS/Drivers/array_modes.h
@@ -96,7 +96,7 @@
 # endif
 #endif
       USE normalization_mod, ONLY : normalization
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_impulse_mod,   ONLY : wrt_impulse
@@ -183,7 +183,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/array_modes.h
+++ b/ROMS/Drivers/array_modes.h
@@ -96,6 +96,7 @@
 # endif
 #endif
       USE normalization_mod, ONLY : normalization
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_impulse_mod,   ONLY : wrt_impulse
@@ -173,6 +174,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/correlation.h
+++ b/ROMS/Drivers/correlation.h
@@ -70,7 +70,7 @@
       USE ini_adjust_mod,     ONLY : load_TLtoAD
       USE inp_par_mod,        ONLY : inp_par
       USE normalization_mod,  ONLY : normalization
-      USE stdout_mod,         ONLY : stdout_unit
+      USE stdout_mod,         ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,        ONLY : FoundError
 #ifdef BALANCE_OPERATOR
       USE tl_balance_mod,     ONLY : tl_balance
@@ -160,7 +160,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/correlation.h
+++ b/ROMS/Drivers/correlation.h
@@ -70,6 +70,7 @@
       USE ini_adjust_mod,     ONLY : load_TLtoAD
       USE inp_par_mod,        ONLY : inp_par
       USE normalization_mod,  ONLY : normalization
+      USE stdout_mod,         ONLY : stdout_unit
       USE strings_mod,        ONLY : FoundError
 #ifdef BALANCE_OPERATOR
       USE tl_balance_mod,     ONLY : tl_balance
@@ -150,6 +151,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/fsv_roms.h
+++ b/ROMS/Drivers/fsv_roms.h
@@ -69,6 +69,7 @@
 # endif
 #endif
       USE packing_mod,       ONLY : r_norm2
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -143,6 +144,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/fsv_roms.h
+++ b/ROMS/Drivers/fsv_roms.h
@@ -69,7 +69,7 @@
 # endif
 #endif
       USE packing_mod,       ONLY : r_norm2
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -153,7 +153,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/fte_roms.h
+++ b/ROMS/Drivers/fte_roms.h
@@ -64,7 +64,7 @@
 #endif
       USE packing_mod,       ONLY : c_norm2
       USE packing_mod,       ONLY : r_norm2
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -148,7 +148,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/fte_roms.h
+++ b/ROMS/Drivers/fte_roms.h
@@ -64,6 +64,7 @@
 #endif
       USE packing_mod,       ONLY : c_norm2
       USE packing_mod,       ONLY : r_norm2
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -138,6 +139,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/hessian_op_roms.h
+++ b/ROMS/Drivers/hessian_op_roms.h
@@ -66,6 +66,7 @@
 # endif
 #endif
       USE packing_mod,       ONLY : r_norm2
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -140,6 +141,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/hessian_op_roms.h
+++ b/ROMS/Drivers/hessian_op_roms.h
@@ -66,7 +66,7 @@
 # endif
 #endif
       USE packing_mod,       ONLY : r_norm2
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -150,7 +150,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/hessian_so_roms.h
+++ b/ROMS/Drivers/hessian_so_roms.h
@@ -60,6 +60,7 @@
 # endif
 #endif
       USE packing_mod,       ONLY : r_norm2
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -134,6 +135,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/hessian_so_roms.h
+++ b/ROMS/Drivers/hessian_so_roms.h
@@ -60,7 +60,7 @@
 # endif
 #endif
       USE packing_mod,       ONLY : r_norm2
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -144,7 +144,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/i4dvar_roms.h
+++ b/ROMS/Drivers/i4dvar_roms.h
@@ -63,7 +63,7 @@
 # endif
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_dai_mod,       ONLY : wrt_dai
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -144,7 +144,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/i4dvar_roms.h
+++ b/ROMS/Drivers/i4dvar_roms.h
@@ -63,6 +63,7 @@
 # endif
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_dai_mod,       ONLY : wrt_dai
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -134,6 +135,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/jedi_roms.h
+++ b/ROMS/Drivers/jedi_roms.h
@@ -60,7 +60,7 @@
 #endif
       USE stiffness_mod,     ONLY : stiffness
       USE strings_mod,       ONLY : FoundError
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
 #ifdef TANGENT
       USE tl_set_depth_mod,  ONLY : tl_bath
 #endif
@@ -152,7 +152,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/jedi_roms.h
+++ b/ROMS/Drivers/jedi_roms.h
@@ -60,6 +60,7 @@
 #endif
       USE stiffness_mod,     ONLY : stiffness
       USE strings_mod,       ONLY : FoundError
+      USE stdout_mod,        ONLY : stdout_unit
 #ifdef TANGENT
       USE tl_set_depth_mod,  ONLY : tl_bath
 #endif
@@ -142,6 +143,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/nl_roms.h
+++ b/ROMS/Drivers/nl_roms.h
@@ -46,6 +46,7 @@
 #ifdef VERIFICATION
       USE stats_modobs_mod,  ONLY : stats_modobs
 #endif
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -117,6 +118,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/nl_roms.h
+++ b/ROMS/Drivers/nl_roms.h
@@ -46,7 +46,7 @@
 #ifdef VERIFICATION
       USE stats_modobs_mod,  ONLY : stats_modobs
 #endif
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -127,7 +127,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/obs_sen_i4dvar_analysis.h
+++ b/ROMS/Drivers/obs_sen_i4dvar_analysis.h
@@ -165,7 +165,7 @@
 # endif
 #endif
       USE stats_modobs_mod,   ONLY : stats_modobs
-      USE stdout_mod,         ONLY : stdout_unit
+      USE stdout_mod,         ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,        ONLY : FoundError
 #ifdef BALANCE_OPERATOR
       USE tl_balance_mod,     ONLY : tl_balance
@@ -254,7 +254,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/obs_sen_i4dvar_analysis.h
+++ b/ROMS/Drivers/obs_sen_i4dvar_analysis.h
@@ -165,6 +165,7 @@
 # endif
 #endif
       USE stats_modobs_mod,   ONLY : stats_modobs
+      USE stdout_mod,         ONLY : stdout_unit
       USE strings_mod,        ONLY : FoundError
 #ifdef BALANCE_OPERATOR
       USE tl_balance_mod,     ONLY : tl_balance
@@ -244,6 +245,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/obs_sen_r4dvar_analysis.h
+++ b/ROMS/Drivers/obs_sen_r4dvar_analysis.h
@@ -92,7 +92,7 @@
 #endif
       USE normalization_mod, ONLY : normalization
       USE stats_modobs_mod,  ONLY : stats_modobs
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_ini_mod,       ONLY : wrt_ini
@@ -178,7 +178,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/obs_sen_r4dvar_analysis.h
+++ b/ROMS/Drivers/obs_sen_r4dvar_analysis.h
@@ -92,6 +92,7 @@
 #endif
       USE normalization_mod, ONLY : normalization
       USE stats_modobs_mod,  ONLY : stats_modobs
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_ini_mod,       ONLY : wrt_ini
@@ -168,6 +169,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/obs_sen_rbl4dvar_analysis.h
+++ b/ROMS/Drivers/obs_sen_rbl4dvar_analysis.h
@@ -98,6 +98,7 @@
       USE rpcg_lanczos_mod,  ONLY : rpcg_lanczos
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_ini_mod,       ONLY : wrt_ini
@@ -174,6 +175,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/obs_sen_rbl4dvar_analysis.h
+++ b/ROMS/Drivers/obs_sen_rbl4dvar_analysis.h
@@ -98,7 +98,7 @@
       USE rpcg_lanczos_mod,  ONLY : rpcg_lanczos
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_ini_mod,       ONLY : wrt_ini
@@ -184,7 +184,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/obs_sen_rbl4dvar_forecast.h
+++ b/ROMS/Drivers/obs_sen_rbl4dvar_forecast.h
@@ -100,6 +100,7 @@
       USE rpcg_lanczos_mod,  ONLY : rpcg_lanczos
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_ini_mod,       ONLY : wrt_ini
@@ -177,6 +178,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/obs_sen_rbl4dvar_forecast.h
+++ b/ROMS/Drivers/obs_sen_rbl4dvar_forecast.h
@@ -100,7 +100,7 @@
       USE rpcg_lanczos_mod,  ONLY : rpcg_lanczos
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_ini_mod,       ONLY : wrt_ini
@@ -187,7 +187,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/op_roms.h
+++ b/ROMS/Drivers/op_roms.h
@@ -61,7 +61,7 @@
 # endif
 #endif
       USE packing_mod,       ONLY : r_norm2
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -145,7 +145,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/op_roms.h
+++ b/ROMS/Drivers/op_roms.h
@@ -61,6 +61,7 @@
 # endif
 #endif
       USE packing_mod,       ONLY : r_norm2
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -135,6 +136,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/optobs_roms.h
+++ b/ROMS/Drivers/optobs_roms.h
@@ -62,7 +62,7 @@
 # endif
 #endif
       USE normalization_mod, ONLY : normalization
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -147,7 +147,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/optobs_roms.h
+++ b/ROMS/Drivers/optobs_roms.h
@@ -62,6 +62,7 @@
 # endif
 #endif
       USE normalization_mod, ONLY : normalization
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -137,6 +138,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/pert_roms.h
+++ b/ROMS/Drivers/pert_roms.h
@@ -76,7 +76,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -156,7 +156,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/pert_roms.h
+++ b/ROMS/Drivers/pert_roms.h
@@ -76,6 +76,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -146,6 +147,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/picard_roms.h
+++ b/ROMS/Drivers/picard_roms.h
@@ -49,6 +49,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -119,6 +120,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/picard_roms.h
+++ b/ROMS/Drivers/picard_roms.h
@@ -49,7 +49,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -129,7 +129,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/r4dvar_roms.h
+++ b/ROMS/Drivers/r4dvar_roms.h
@@ -69,7 +69,7 @@
 # endif
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_dai_mod,       ONLY : wrt_dai
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -150,8 +150,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
-
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/r4dvar_roms.h
+++ b/ROMS/Drivers/r4dvar_roms.h
@@ -69,6 +69,7 @@
 # endif
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_dai_mod,       ONLY : wrt_dai
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -140,6 +141,17 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
+
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/rbl4dvar_roms.h
+++ b/ROMS/Drivers/rbl4dvar_roms.h
@@ -69,7 +69,7 @@
 # endif
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_dai_mod,       ONLY : wrt_dai
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -150,7 +150,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/rbl4dvar_roms.h
+++ b/ROMS/Drivers/rbl4dvar_roms.h
@@ -69,6 +69,7 @@
 # endif
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_dai_mod,       ONLY : wrt_dai
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -140,6 +141,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/rp_roms.h
+++ b/ROMS/Drivers/rp_roms.h
@@ -37,7 +37,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -117,7 +117,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/rp_roms.h
+++ b/ROMS/Drivers/rp_roms.h
@@ -37,6 +37,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -107,6 +108,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/so_roms.h
+++ b/ROMS/Drivers/so_roms.h
@@ -55,7 +55,7 @@
 # endif
 #endif
       USE packing_mod,       ONLY : r_norm2
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -139,7 +139,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/so_roms.h
+++ b/ROMS/Drivers/so_roms.h
@@ -55,6 +55,7 @@
 # endif
 #endif
       USE packing_mod,       ONLY : r_norm2
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -129,6 +130,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/so_semi_roms.h
+++ b/ROMS/Drivers/so_semi_roms.h
@@ -65,6 +65,7 @@
 #endif
       USE packing_mod,       ONLY : ad_unpack
       USE packing_mod,       ONLY : r_norm2
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -139,6 +140,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/so_semi_roms.h
+++ b/ROMS/Drivers/so_semi_roms.h
@@ -65,7 +65,7 @@
 #endif
       USE packing_mod,       ONLY : ad_unpack
       USE packing_mod,       ONLY : r_norm2
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
 #ifdef CHECKPOINTING
       USE wrt_gst_mod,       ONLY : wrt_gst
@@ -149,7 +149,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/split_i4dvar_roms.h
+++ b/ROMS/Drivers/split_i4dvar_roms.h
@@ -85,7 +85,7 @@
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
       USE stdinp_mod,        ONLY : getpar_i, getpar_s
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE wrt_dai_mod,       ONLY : wrt_dai
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -168,7 +168,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Get 4D-Var phase from APARNAM input script file.
 !

--- a/ROMS/Drivers/split_i4dvar_roms.h
+++ b/ROMS/Drivers/split_i4dvar_roms.h
@@ -85,6 +85,7 @@
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
       USE stdinp_mod,        ONLY : getpar_i, getpar_s
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE wrt_dai_mod,       ONLY : wrt_dai
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -158,6 +159,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Get 4D-Var phase from APARNAM input script file.
 !

--- a/ROMS/Drivers/split_i4dvar_roms.h
+++ b/ROMS/Drivers/split_i4dvar_roms.h
@@ -175,14 +175,14 @@
 !
 !  Get 4D-Var phase from APARNAM input script file.
 !
-        CALL getpar_s (MyRank, aparnam, 'APARNAM')
+        CALL getpar_s (Master, aparnam, 'APARNAM')
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-        CALL getpar_s (MyRank, Phase4DVAR, 'Phase4DVAR',                &
+        CALL getpar_s (Master, Phase4DVAR, 'Phase4DVAR',                &
      &                 InpName = aparnam)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-        CALL getpar_i (MyRank, my_outer, 'OuterLoop',                   &
+        CALL getpar_i (Master, my_outer, 'OuterLoop',                   &
      &                 InpName = aparnam)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !

--- a/ROMS/Drivers/split_r4dvar_roms.h
+++ b/ROMS/Drivers/split_r4dvar_roms.h
@@ -179,10 +179,10 @@
 !
 !  Get 4D-Var phase from APARNAM input script file.
 !
-        CALL getpar_s (MyRank, aparnam, 'APARNAM')
+        CALL getpar_s (Master, aparnam, 'APARNAM')
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-        CALL getpar_s (MyRank, Phase4DVAR, 'Phase4DVAR', aparnam)
+        CALL getpar_s (Master, Phase4DVAR, 'Phase4DVAR', aparnam)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
 !  Determine ROMS standard output append switch. It is only relevant if

--- a/ROMS/Drivers/split_r4dvar_roms.h
+++ b/ROMS/Drivers/split_r4dvar_roms.h
@@ -91,6 +91,7 @@
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
       USE stdinp_mod,        ONLY : getpar_s
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE wrt_dai_mod,       ONLY : wrt_dai
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -162,6 +163,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Get 4D-Var phase from APARNAM input script file.
 !

--- a/ROMS/Drivers/split_r4dvar_roms.h
+++ b/ROMS/Drivers/split_r4dvar_roms.h
@@ -91,7 +91,7 @@
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
       USE stdinp_mod,        ONLY : getpar_s
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE wrt_dai_mod,       ONLY : wrt_dai
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -172,7 +172,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Get 4D-Var phase from APARNAM input script file.
 !

--- a/ROMS/Drivers/split_rbl4dvar_roms.h
+++ b/ROMS/Drivers/split_rbl4dvar_roms.h
@@ -91,7 +91,7 @@
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
       USE stdinp_mod,        ONLY : getpar_i, getpar_s
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE wrt_dai_mod,       ONLY : wrt_dai
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -175,7 +175,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Get 4D-Var phase from APARNAM input script file.
 !

--- a/ROMS/Drivers/split_rbl4dvar_roms.h
+++ b/ROMS/Drivers/split_rbl4dvar_roms.h
@@ -91,6 +91,7 @@
 #endif
       USE stats_modobs_mod,  ONLY : stats_modobs
       USE stdinp_mod,        ONLY : getpar_i, getpar_s
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE wrt_dai_mod,       ONLY : wrt_dai
       USE wrt_rst_mod,       ONLY : wrt_rst
@@ -165,6 +166,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Get 4D-Var phase from APARNAM input script file.
 !

--- a/ROMS/Drivers/split_rbl4dvar_roms.h
+++ b/ROMS/Drivers/split_rbl4dvar_roms.h
@@ -182,13 +182,13 @@
 !
 !  Get 4D-Var phase from APARNAM input script file.
 !
-        CALL getpar_s (MyRank, aparnam, 'APARNAM')
+        CALL getpar_s (Master, aparnam, 'APARNAM')
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-        CALL getpar_i (MyRank, OuterLoop, 'OuterLoop', aparnam)
+        CALL getpar_i (Master, OuterLoop, 'OuterLoop', aparnam)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-        CALL getpar_s (MyRank, Phase4DVAR, 'Phase4DVAR', aparnam)
+        CALL getpar_s (Master, Phase4DVAR, 'Phase4DVAR', aparnam)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
 !  Determine ROMS standard output append switch. It is only relevant if

--- a/ROMS/Drivers/symmetry.h
+++ b/ROMS/Drivers/symmetry.h
@@ -45,7 +45,7 @@
       USE get_state_mod,     ONLY : get_state
       USE inp_par_mod,       ONLY : inp_par
       USE normalization_mod, ONLY : normalization
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_impulse_mod,   ONLY : wrt_impulse
@@ -128,7 +128,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/symmetry.h
+++ b/ROMS/Drivers/symmetry.h
@@ -45,6 +45,7 @@
       USE get_state_mod,     ONLY : get_state
       USE inp_par_mod,       ONLY : inp_par
       USE normalization_mod, ONLY : normalization
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_impulse_mod,   ONLY : wrt_impulse
@@ -118,6 +119,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/tl_r4dvar_roms.h
+++ b/ROMS/Drivers/tl_r4dvar_roms.h
@@ -86,6 +86,7 @@
 # endif
 #endif
       USE normalization_mod, ONLY : normalization
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_impulse_mod,   ONLY : wrt_impulse
@@ -163,6 +164,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/tl_r4dvar_roms.h
+++ b/ROMS/Drivers/tl_r4dvar_roms.h
@@ -86,7 +86,7 @@
 # endif
 #endif
       USE normalization_mod, ONLY : normalization
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_impulse_mod,   ONLY : wrt_impulse
@@ -173,7 +173,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/tl_rbl4dvar_roms.h
+++ b/ROMS/Drivers/tl_rbl4dvar_roms.h
@@ -89,6 +89,7 @@
 # endif
 #endif
       USE normalization_mod, ONLY : normalization
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_impulse_mod,   ONLY : wrt_impulse
@@ -166,6 +167,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/tl_rbl4dvar_roms.h
+++ b/ROMS/Drivers/tl_rbl4dvar_roms.h
@@ -89,7 +89,7 @@
 # endif
 #endif
       USE normalization_mod, ONLY : normalization
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError, uppercase
       USE tl_def_ini_mod,    ONLY : tl_def_ini
       USE wrt_impulse_mod,   ONLY : wrt_impulse
@@ -176,7 +176,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/tl_roms.h
+++ b/ROMS/Drivers/tl_roms.h
@@ -37,7 +37,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -117,7 +117,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/tl_roms.h
+++ b/ROMS/Drivers/tl_roms.h
@@ -37,6 +37,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -107,6 +108,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/tlcheck_roms.h
+++ b/ROMS/Drivers/tlcheck_roms.h
@@ -45,6 +45,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
+      USE stdout_mod,        ONLY : stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -112,6 +113,16 @@
 !  independent from standard input parameters.
 !
         CALL initialize_parallel
+!
+!  Set the ROMS standard output unit to write verbose execution info.
+!  Notice that the default standard out unit in Fortran is 6.
+!
+!  In some applications like coupling or disjointed mpi-communications,
+!  it is advantageous to write standard output to a specific filename
+!  instead of the default Fortran standard output unit 6. If that is
+!  the case, it opens such formatted file for writing.
+!
+        stdout=stdout_unit(Master)
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Drivers/tlcheck_roms.h
+++ b/ROMS/Drivers/tlcheck_roms.h
@@ -45,7 +45,7 @@
       USE mct_coupler_mod,   ONLY : initialize_ocn2wav_coupling
 # endif
 #endif
-      USE stdout_mod,        ONLY : stdout_unit
+      USE stdout_mod,        ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,       ONLY : FoundError
       USE wrt_rst_mod,       ONLY : wrt_rst
 !
@@ -122,7 +122,10 @@
 !  instead of the default Fortran standard output unit 6. If that is
 !  the case, it opens such formatted file for writing.
 !
-        stdout=stdout_unit(Master)
+        IF (Set_StdOutUnit) THEN
+          stdout=stdout_unit(Master)
+          Set_StdOutUnit=.FALSE.
+        END IF
 !
 !  Read in model tunable parameters from standard input. Allocate and
 !  initialize variables in several modules after the number of nested

--- a/ROMS/Modules/mod_iounits.F
+++ b/ROMS/Modules/mod_iounits.F
@@ -191,7 +191,7 @@
 !  I/O units.
 !
       integer :: stdinp = 5                 ! standard input
-      integer :: stdout = 6                 ! standard output
+      integer :: stdout                     ! standard output, usually 6
       integer :: usrout = 10                ! generic user unit
 !
 !  I/O files management, derived type structures.

--- a/ROMS/Modules/mod_netcdf.F
+++ b/ROMS/Modules/mod_netcdf.F
@@ -5515,7 +5515,7 @@
       integer, dimension(2) :: ibuffer
 #endif
       real(dp) :: Afactor, Aoffset, my_Rdate(2), seconds
-      real(dp) :: dnum_old, dnum_new
+      real(dp) :: dnum_old, dnum_new, scale
 
       real(dp), dimension(1) :: my_A
       real(r8), dimension(2) :: AttValue
@@ -5664,6 +5664,27 @@
                     dnum_new=Rdate(2)+A
                     CALL datestr (dnum_new, .FALSE., dstr_new)
                   END IF
+                CASE ('hour', 'hours')        ! convert to seconds
+                  IF (Ldebug) THEN
+                    scale=3600.0_dp           ! hours to seconds
+                    IF (JulianOffset) THEN
+                      dnum_old=A*scale
+                    ELSE
+                      dnum_old=my_Rdate(2)+A*scale
+                    END IF
+                    CALL datestr (dnum_old, .FALSE., dstr_old)
+                  END IF
+                  scale=24.0_dp               ! time reference to hours
+                  IF (JulianOffset) THEN
+                    A=A-Rdate(1)*scale        ! 'add_offset' added above
+                  ELSE
+                    A=(my_Rdate(1)*scale+A)-Rdate(1)*scale
+                  END IF
+                  IF (Ldebug) THEN
+                    scale=3600.0_dp           ! convert to seconds
+                    dnum_new=Rdate(2)+A*scale
+                    CALL datestr (dnum_new, .FALSE., dstr_new)
+                  END IF
                 CASE ('day', 'days')
                   IF (Ldebug) THEN
                     IF (JulianOffset) THEN
@@ -5799,7 +5820,7 @@
 #endif
 !
       real(dp) :: Afactor, Aoffset, my_Rdate(2), seconds
-      real(dp) :: dnum_old, dnum_new
+      real(dp) :: dnum_old, dnum_new, scale
 
       real(r8), dimension(2) :: AttValue
 !
@@ -5960,6 +5981,31 @@
                   END IF
                   IF (Ldebug) THEN
                     dnum_new=Rdate(2)+A(1)
+                    CALL datestr (dnum_new, .FALSE., dstr_new)
+                  END IF
+                CASE ('hour', 'hours')
+                  scale=3600.0_dp             ! convert to seconds
+                  IF (Ldebug) THEN
+                    IF (JulianOffset) THEN
+                      dnum_old=A(1)*scale
+                    ELSE
+                      dnum_old=my_Rdate(2)+A(1)*scale
+                    END IF
+                    CALL datestr (dnum_old, .FALSE., dstr_old)
+                  END IF
+                  scale=24.0_dp               ! time reference to hours
+                  IF (JulianOffset) THEN
+                    DO i=1,Asize(1)
+                      A(i)=A(i)-Rdate(1)*scale ! add_offset added above
+                    END DO
+                  ELSE
+                    DO i=1,Asize(1)
+                      A(i)=(my_Rdate(1)*scale+A(i))-Rdate(1)*scale
+                    END DO
+                  END IF
+                  IF (Ldebug) THEN
+                    scale=3600.0_dp           ! convert to seconds
+                    dnum_new=Rdate(2)+A(1)*scale
                     CALL datestr (dnum_new, .FALSE., dstr_new)
                   END IF
                 CASE ('day', 'days')

--- a/ROMS/Modules/mod_netcdf.F
+++ b/ROMS/Modules/mod_netcdf.F
@@ -8600,7 +8600,7 @@
             WRITE (DBout,'(a,1x," <= ",i8,2(2x,a))')                    &
      &            KernelString(model)//' F90: CLOSE', ncid,             &
      &            TRIM(my_ncname), TRIM(SourceFile)
-            CALL my_flush (DBout)
+            FLUSH (DBout)
           END IF
           ncid=-1
         END IF
@@ -8727,7 +8727,7 @@
             WRITE (DBout,'(a," ** ",i8,2(2x,a))')                       &
      &            KernelString(model)//' F90: CREATE', ncid,            &
      &            TRIM(ncname), TRIM(SourceFile)
-          CALL my_flush (DBout)
+          FLUSH (DBout)
         END IF
 !
 !  Set NOFILL mode to enhance performance.
@@ -8968,7 +8968,7 @@
            WRITE (DBout,'(a,2x," => ",i8,2(2x,a))')                     &
      &           KernelString(model)//' F90: OPEN', ncid,               &
      &           TRIM(ncname), TRIM(SourceFile)
-          CALL my_flush (DBout)
+          FLUSH (DBout)
         END IF
 # ifdef DISTRIBUTE
         ibuffer(1)=exit_flag

--- a/ROMS/Modules/mod_pio_netcdf.F
+++ b/ROMS/Modules/mod_pio_netcdf.F
@@ -8284,7 +8284,7 @@
             IF (Master) WRITE (DBout,'(a,1x," <= ",i8,2(2x,a))')        &
      &                        KernelString(model)//' PIO: CLOSE',       &
      &                        FileH, TRIM(my_ncname), TRIM(SourceFile)
-            CALL my_flush (DBout)
+            FLUSH (DBout)
           END IF
           CALL pio_closefile (pioFile)
 !
@@ -8388,7 +8388,7 @@
         IF (Master) WRITE (DBout,'(a," ** ",i8,2(2x,a))')               &
      &                    KernelString(model)//' PIO: CREATE',          &
      &                    pioFile%fh, TRIM(ncname), TRIM(SourceFile)
-        CALL my_flush (DBout)
+        FLUSH (DBout)
       END IF
 !
   10  FORMAT (/,' PIO_NETCDF_CREATE - unable to create output NetCDF ', &
@@ -8517,7 +8517,7 @@
         IF (Master) WRITE (DBout,'(a,2x," => ",i8,2(2x,a))')            &
      &                    KernelString(model)//' PIO: OPEN',            &
      &                    pioFile%fh, TRIM(ncname), TRIM(SourceFile)
-        CALL my_flush (DBout)
+        FLUSH (DBout)
       END IF
 !
   10  FORMAT (/,' PIO_NETCDF_OPEN - unable to open existing NetCDF ',   &

--- a/ROMS/Modules/mod_pio_netcdf.F
+++ b/ROMS/Modules/mod_pio_netcdf.F
@@ -5487,7 +5487,7 @@
       integer :: year, month, day, hour, minutes
 !
       real(dp) :: Afactor, Aoffset, my_Rdate(2), seconds
-      real(dp) :: dnum_old, dnum_new
+      real(dp) :: dnum_old, dnum_new, scale
 
       real(dp), dimension(1) :: my_A
       real(r8), dimension(2) :: AttValue
@@ -5623,6 +5623,27 @@
                     dnum_new=Rdate(2)+A
                     CALL datestr (dnum_new, .FALSE., dstr_new)
                   END IF
+                CASE ('hour', 'hours')        ! convert to seconds
+                  IF (Ldebug) THEN
+                    scale=3600.0_dp           ! hours to seconds
+                    IF (JulianOffset) THEN
+                      dnum_old=A*scale
+                    ELSE
+                      dnum_old=my_Rdate(2)+A*scale
+                    END IF
+                    CALL datestr (dnum_old, .FALSE., dstr_old)
+                  END IF
+                  scale=24.0_dp               ! time reference to hours
+                  IF (JulianOffset) THEN
+                    A=A-Rdate(1)*scale        ! 'add_offset' added above
+                  ELSE
+                    A=(my_Rdate(1)*scale+A)-Rdate(1)*scale
+                  END IF
+                  IF (Ldebug) THEN
+                    scale=3600.0_dp           ! convert to seconds
+                    dnum_new=Rdate(2)+A*scale
+                    CALL datestr (dnum_new, .FALSE., dstr_new)
+                  END IF
                 CASE ('day', 'days')
                   IF (Ldebug) THEN
                     IF (JulianOffset) THEN
@@ -5752,7 +5773,7 @@
       integer, dimension(1) :: Asize
 !
       real(dp) :: Afactor, Aoffset, my_Rdate(2), seconds
-      real(dp) :: dnum_old, dnum_new
+      real(dp) :: dnum_old, dnum_new, scale
 
       real(r8), dimension(2) :: AttValue
 !
@@ -5900,6 +5921,31 @@
                   END IF
                   IF (Ldebug) THEN
                     dnum_new=Rdate(2)+A(1)
+                    CALL datestr (dnum_new, .FALSE., dstr_new)
+                  END IF
+                CASE ('hour', 'hours')
+                  scale=3600.0_dp             ! convert to seconds
+                  IF (Ldebug) THEN
+                    IF (JulianOffset) THEN
+                      dnum_old=A(1)*scale
+                    ELSE
+                      dnum_old=my_Rdate(2)+A(1)*scale
+                    END IF
+                    CALL datestr (dnum_old, .FALSE., dstr_old)
+                  END IF
+                  scale=24.0_dp               ! time reference to hours
+                  IF (JulianOffset) THEN
+                    DO i=1,Asize(1)
+                      A(i)=A(i)-Rdate(1)*scale ! add_offset added above
+                    END DO
+                  ELSE
+                    DO i=1,Asize(1)
+                      A(i)=(my_Rdate(1)*scale+A(i))-Rdate(1)*scale
+                    END DO
+                  END IF
+                  IF (Ldebug) THEN
+                    scale=3600.0_dp           ! convert to seconds
+                    dnum_new=Rdate(2)+A(1)*scale
                     CALL datestr (dnum_new, .FALSE., dstr_new)
                   END IF
                 CASE ('day', 'days')

--- a/ROMS/Nonlinear/diag.F
+++ b/ROMS/Nonlinear/diag.F
@@ -494,7 +494,7 @@
      &                          max_Cu, max_Cv, max_C,                  &
      &                          maxspeed(ng)
 #endif
-            CALL my_flush (stdout)
+            FLUSH (stdout)
 #ifdef NESTING
  30         FORMAT (i10,1x,a,4(1pe14.6),2x,i2.2)
 #else

--- a/ROMS/Nonlinear/nesting.F
+++ b/ROMS/Nonlinear/nesting.F
@@ -768,7 +768,7 @@
             IF (Master) THEN
               WRITE (300,10) 'Western Boundary Mass Fluxes: ',          &
      &                       cr, dg, rg, iif(rg), iic(rg), INT(time(rg))
-              CALL my_flush (300)
+              FLUSH (300)
             END IF
           END IF
 !
@@ -799,7 +799,7 @@
               END IF
               WRITE (300,30) Jbc, REFINED(cr)%U2d_flux(1,m,tnew),        &
      &                       WestSum, MFratio
-              CALL my_flush (300)
+              FLUSH (300)
             END IF
           END DO
 !
@@ -816,7 +816,7 @@
             IF (Master) THEN
               WRITE (300,10) 'Eastern Boundary Mass Fluxes: ',          &
      &                       cr, dg, rg, iif(rg), iic(rg), INT(time(rg))
-              CALL my_flush (300)
+              FLUSH (300)
             END IF
           END IF
 !
@@ -847,7 +847,7 @@
               END IF
               WRITE (300,30) Jbc, REFINED(cr)%U2d_flux(1,m,tnew),        &
      &                       EastSum, MFratio
-              CALL my_flush (300)
+              FLUSH (300)
             END IF
           END DO
 !
@@ -864,7 +864,7 @@
             IF (Master) THEN
               WRITE (300,20) 'Southern Boundary Mass Fluxes: ',         &
      &                       cr, dg, rg, iif(rg), iic(rg), INT(time(rg))
-              CALL my_flush (300)
+              FLUSH (300)
             END IF
           END IF
 !
@@ -896,7 +896,7 @@
               END IF
               WRITE (300,30) Ibc, REFINED(cr)%V2d_flux(1,m,tnew),        &
      &                       SouthSum, MFratio
-              CALL my_flush (300)
+              FLUSH (300)
             END IF
           END DO
 !
@@ -913,7 +913,7 @@
             IF (Master) THEN
               WRITE (300,20) 'Northern Boundary Mass Fluxes: ',         &
      &                       cr, dg, rg, iif(rg), iic(rg), INT(time(rg))
-              CALL my_flush (300)
+              FLUSH (300)
             END IF
           END IF
 !
@@ -964,7 +964,7 @@
         END IF
       END DO
 !
-      CALL my_flush (300)
+      FLUSH (300)
 !
   10  FORMAT (/,1x,a,/,/,4x,'cr = ',i2.2,4x,'dg = ',i2.2,4x,'rg = ',    &
      &        i2.2,4x,'iif(rg) = ',i3.3,4x,'iic(rg) = ',i7.7,4x,        &
@@ -2486,7 +2486,7 @@
      &                3x,'(rg)',18x,'2D',5x,'3D',4x,'told',3x,'tnew',   &
      &                3x,'(ng)',/)
  20           FORMAT (4i4,9i7)
-              CALL my_flush (100)
+              FLUSH (100)
             END IF
           END IF
 # endif
@@ -6289,7 +6289,7 @@
      &            7x,'Wnew',/,17x,'(dg)',1x,'(ng)',13x,'(ng)',3x,       &
      &            'told',3x,'tnew',/)
  30       FORMAT (7i5,3i7,2f11.4)
-          CALL my_flush (200)
+          FLUSH (200)
         END IF
       END IF
 # endif

--- a/ROMS/Nonlinear/obc_volcons.F
+++ b/ROMS/Nonlinear/obc_volcons.F
@@ -220,7 +220,7 @@
           WRITE (150,10) MyRank, iic(ng), iif(ng), bc_area, rbuffer(1), &
                          bc_flux, rbuffer(2), rbuffer(2)/rbuffer(1)
   10      FORMAT (i3,1x,i3.3,1x,i3.3,5(1x,1pe23.15))
-          CALL my_flush (150)
+          FLUSH (150)
 # endif
           bc_area=rbuffer(1)
           bc_flux=rbuffer(2)

--- a/ROMS/Representer/rp_diag.F
+++ b/ROMS/Representer/rp_diag.F
@@ -303,7 +303,7 @@
 # else
  20         FORMAT (i10,1x,a,4(1pe14.6))
 # endif
-            CALL my_flush (stdout)
+            FLUSH (stdout)
           END IF
 !
 !  If blowing-up, set exit_flag to stop computations.

--- a/ROMS/Tangent/tl_diag.F
+++ b/ROMS/Tangent/tl_diag.F
@@ -320,7 +320,7 @@
 # else
  20         FORMAT (i10,1x,a,4(1pe14.6))
 # endif
-            CALL my_flush (stdout)
+            FLUSH (stdout)
           END IF
 !
 !  If blowing-up, set exit_flag to stop computations.

--- a/ROMS/Tangent/tl_nesting.F
+++ b/ROMS/Tangent/tl_nesting.F
@@ -857,7 +857,7 @@
      &                20x,'(dg)',4x,'(rg)',18x,'2D',6x,'3D',9x,'(rg)',  &
      &                8x,'told',8x,'(ng)',8x,'tnew',/)
  20           FORMAT (4(1x,i3),2(1x,i7),2(2x,i4),2(4x,i4),1x,4(2x,i10))
-              CALL my_flush (101)
+              FLUSH (101)
             END IF
           END IF
 # endif
@@ -3327,7 +3327,7 @@
      &            7x,'Wold',7x,'Wnew',/,18x,'(dg)',3x,'(ng)',           &
      &            19x,'(dg)',7x,'told',7x,'(ng)',7x,'tnew',/)
  30       FORMAT (3i5,2i7,2i6,4(2x,i9),2f11.4)
-          CALL my_flush (201)
+          FLUSH (201)
         END IF
       END IF
 # endif
@@ -4659,7 +4659,7 @@
             IF (Master) THEN
               WRITE (301,10) 'Western Boundary Mass Fluxes: ',          &
      &                       cr, dg, rg, iif(rg), iic(rg), INT(time(rg))
-              CALL my_flush (301)
+              FLUSH (301)
             END IF
           END IF
 !
@@ -4697,7 +4697,7 @@
               END IF
               WRITE (301,30) Jbc, REFINED(cr)%DU_avg2(1,m,tnew),        &
      &                       WestSum, MFratio
-              CALL my_flush (301)
+              FLUSH (301)
 # endif
             END IF
           END DO
@@ -4716,7 +4716,7 @@
             IF (Master) THEN
               WRITE (301,10) 'Eastern Boundary Mass Fluxes: ',          &
      &                       cr, dg, rg, iif(rg), iic(rg), INT(time(rg))
-              CALL my_flush (301)
+              FLUSH (301)
             END IF
           END IF
 !
@@ -4754,7 +4754,7 @@
               END IF
               WRITE (301,30) Jbc, REFINED(cr)%DU_avg2(1,m,tnew),        &
      &                       EastSum, MFratio
-              CALL my_flush (301)
+              FLUSH (301)
 # endif
             END IF
           END DO
@@ -4773,7 +4773,7 @@
             IF (Master) THEN
               WRITE (301,20) 'Southern Boundary Mass Fluxes: ',         &
      &                       cr, dg, rg, iif(rg), iic(rg), INT(time(rg))
-              CALL my_flush (301)
+              FLUSH (301)
             END IF
           END IF
 !
@@ -4812,7 +4812,7 @@
               END IF
               WRITE (301,30) Ibc, REFINED(cr)%DV_avg2(1,m,tnew),        &
      &                       SouthSum, MFratio
-              CALL my_flush (301)
+              FLUSH (301)
 # endif
             END IF
           END DO
@@ -4831,7 +4831,7 @@
             IF (Master) THEN
               WRITE (301,20) 'Northern Boundary Mass Fluxes: ',         &
      &                       cr, dg, rg, iif(rg), iic(rg), INT(time(rg))
-              CALL my_flush (301)
+              FLUSH (301)
             END IF
           END IF
 !
@@ -4900,7 +4900,7 @@
 
 # ifdef NESTING_DEBUG
 !
-      CALL my_flush (301)
+      FLUSH (301)
 !
   10  FORMAT (/,1x,a,/,/,4x,'cr = ',i2.2,4x,'dg = ',i2.2,4x,'rg = ',    &
      &        i2.2,4x,'iif(rg) = ',i3.3,4x,'iic(rg) = ',i10.10,4x,      &

--- a/ROMS/Utility/CMakeLists.txt
+++ b/ROMS/Utility/CMakeLists.txt
@@ -155,6 +155,7 @@ list( APPEND _files
       ROMS/Utility/stats.F
       ROMS/Utility/stats_modobs.F
       ROMS/Utility/stdinp_mod.F
+      ROMS/Utility/stdout_mod.F
       ROMS/Utility/stiffness.F
       ROMS/Utility/strings.F
       ROMS/Utility/sum_grad.F

--- a/ROMS/Utility/close_io.F
+++ b/ROMS/Utility/close_io.F
@@ -441,7 +441,7 @@
 !  Close ROMS standard outpu file.
 !-----------------------------------------------------------------------
 !
-      CALL my_flush (stdout)
+      FLUSH (stdout)
       CLOSE (stdout)
 #endif
 !

--- a/ROMS/Utility/def_his.F
+++ b/ROMS/Utility/def_his.F
@@ -2696,8 +2696,8 @@
             RETURN
           END IF
 # endif
-#endif
         END DO
+#endif
 
 #if (defined BBL_MODEL || defined WAVES_OUTPUT) && defined SOLVE3D
 !
@@ -5757,8 +5757,8 @@
             RETURN
           END IF
 #  endif
-# endif
         END DO
+# endif
 
 # if (defined BBL_MODEL || defined WAVES_OUTPUT) && defined SOLVE3D
 !

--- a/ROMS/Utility/distribute.F
+++ b/ROMS/Utility/distribute.F
@@ -7357,7 +7357,7 @@
       nc=nc+1
       IF (Master) THEN
         WRITE (10,'(a,i3.3,a,a)') 'file ', nc, ': ', TRIM(name)
-        CALL my_flush (10)
+        FLUSH (10)
       END IF
 !
 !  Write out field including ghost-points.
@@ -7391,7 +7391,7 @@
       WRITE (unit,*) ILB, IUB, JLB, JUB, KLB, KUB,                      &
      &               Ioff, Joff, Imin, Imax, Jmin, Jmax,                &
      &               A(ILB:IUB,JLB:JUB,KLB:KUB)
-      CALL my_flush (unit)
+      FLUSH (unit)
 !
 !  Write out non-overlapping field.
 !
@@ -7426,7 +7426,7 @@
       WRITE (unit,*) Imin, Imax, Jmin, Jmax, KLB, KUB,                  &
      &               Ioff, Joff, Imin, Imax, Jmin, Jmax,                &
      &               A(Imin:Imax,Jmin:Jmax,KLB:KUB)
-      CALL my_flush (unit)
+      FLUSH (unit)
 
       RETURN
       END SUBROUTINE mp_dump

--- a/ROMS/Utility/inp_par.F
+++ b/ROMS/Utility/inp_par.F
@@ -40,6 +40,7 @@
 #ifdef NESTING
       USE set_contact_mod, ONLY : set_contact
 #endif
+      USE stdinp_mod,      ONLY : stdinp_unit
       USE strings_mod,     ONLY : FoundError
 #ifdef SOLVE3D
       USE tadv_mod,        ONLY : tadv_report
@@ -53,7 +54,7 @@
 !
 !  Local variable declarations.
 !
-      logical :: Lwrite
+      logical :: GotFile, Lwrite
 !
       integer :: Itile, Jtile, Nghost, Ntiles, tile
       integer :: Imin, Imax, Jmin, Jmax
@@ -62,15 +63,12 @@
       integer :: MaxHaloLenI, MaxHaloLenJ
 #endif
       integer :: ibry, inp, out, i, ic, ifield, itrc, j, ng, npts
-      integer :: io_err, sequence, varid
+      integer :: sequence, varid
 !
       real(r8) :: cff
       real(r8), parameter :: epsilon = 1.0E-8_r8
       real(r8), parameter :: spv = 0.0_r8
 !
-      character (len=10 ) :: stdout_file
-      character (len=256) :: io_errmsg
-
       character (len=*), parameter :: MyFile =                          &
      &  __FILE__
 !
@@ -79,57 +77,30 @@
 !-----------------------------------------------------------------------
 !  Read in and report input model parameters.
 !-----------------------------------------------------------------------
-
-#ifdef ROMS_STDOUT
 !
-!  Change default Fortran standard out unit, so ROMS run information is
-!  directed to a file. This is advantageous in coupling applications to
-!  ROMS information separated from other models. It overwite Fortran
-!  default unit 6.
+#ifdef DISTRIBUTE
 !
-# if defined DISTRIBUTE && defined DISJOINTED
-       stdout=60+ForkColor
-       WRITE (stdout_file,'(a,i2.2,a)') 'log', ForkColor+1, '.roms'
-# else
-       stdout=60
-       stdout_file='log.roms'
-# endif
+!  Get in ROMS standard input script filename (Iname) and and open it
+!  as a regular formatted file in distributed-memory configurations.
 !
-!  Open ROMS standard output file.
-!
-       IF (Master) THEN
-         IF (Lappend) THEN
-           OPEN (stdout, FILE=TRIM(stdout_file), FORM='formatted',      &
-     &           STATUS='old', POSITION='append', ACTION='write',       &
-     &           IOSTAT=io_err, IOMSG=io_errmsg)
-         ELSE
-           OPEN (stdout, FILE=TRIM(stdout_file), FORM='formatted',      &
-     &           STATUS='replace', IOSTAT=io_err, IOMSG=io_errmsg)
-         END IF
-       END IF
-# ifdef DISTRIBUTE
-       CALL mp_bcasti (1, model, io_err)
-# endif
-       IF (io_err.ne.0) THEN
-         IF (Master) WRITE (stdout,10) TRIM(stdout_file),               &
-     &                                 TRIM(io_errmsg)
-         exit_flag=5
- 10      FORMAT (/,' INP_PAR - Cannot open standard output file: ',a,   &
-     &           /,11x,'ERROR: ',a)
-         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-       END IF
-#endif
-!
-!  Set input units.
-!
-#if defined DISTRIBUTE || defined MODEL_COUPLING
-      Lwrite=Master
-      inp=1
+      inp=stdinp_unit(Master, GotFile)
       out=stdout
-#else
       Lwrite=Master
+!
+      IF (.not.GotFile) THEN
+        IF (Master) WRITE (out,10)
+ 10     FORMAT (/,' INP_PAR - Unable to ROMS standard input file, ',   &
+                'Iname')
+        exit_flag=2
+      END IF
+      IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#else
+!
+!  Set standard inpur and output units.
+!
       inp=stdinp
       out=stdout
+      Lwrite=Master
 #endif
 #if defined SPLIT_4DVAR && SUPPRESS_REPORT
 !
@@ -158,51 +129,8 @@
  20   FORMAT (80('-'),/,                                                &
               ' Model Input Parameters:  ROMS/TOMS version ',a,/,       &
      &        26x,a,/,80('-'))
-
-#if defined MODEL_COUPLING || defined JEDI
 !
-!  In multiple model coupling, the ocean input physical parameter
-!  script needs to be opened and processed as a regular file.
-!  Its file name is specified in the coupling standard input script.
-!
-      OPEN (inp, FILE=TRIM(Iname), FORM='formatted', STATUS='old',      &
-     &      IOSTAT=io_err, IOMSG=io_errmsg)
-      IF (io_err.ne.0) THEN
-        IF (Master) WRITE (stdout,30) TRIM(io_errmsg)
-        exit_flag=5
-        RETURN
- 30     FORMAT (/,' INP_PAR - Unable to open ROMS/TOMS input script ',  &
-     &              'file.',/,11x,'ERROR: ',a)
-      END IF
-#else
-# ifdef DISTRIBUTE
-!
-!  In distributed-memory configurations, the input physical parameters
-!  script is opened as a regular file.  It is read and processed by all
-!  parallel nodes.  This is to avoid a very complex broadcasting of the
-!  input parameters to all nodes.
-!
-!!    CALL my_getarg (1, Iname)
-      IF (Master) CALL my_getarg (1, Iname)
-      CALL mp_bcasts (1, model, Iname)
-      OPEN (inp, FILE=TRIM(Iname), FORM='formatted', STATUS='old',      &
-     &      IOSTAT=io_err, IOMSG=io_errmsg)
-      IF (io_err.ne.0) THEN
-        IF (Master) WRITE (stdout,30) TRIM(io_errmsg)
-        exit_flag=5
-        RETURN
- 30     FORMAT (/,' INP_PAR - Unable to open ROMS/TOMS input script ',  &
-     &              'file.',/,11x,'ERROR: ',a,/,                        &
-     &          /,11x,'In distributed-memory applications, the input',  &
-     &          /,11x,'script file is processed in parallel. The Unix', &
-     &          /,11x,'routine GETARG is used to get script file name.',&
-     &          /,11x,'For example, in MPI applications make sure that',&
-     &          /,11x,'command line is something like:',/,              &
-     &          /,11x,'mpirun -np 4 romsM roms.in',/,/,11x,'and not',/, &
-     &          /,11x,'mpirun -np 4 romsM < roms.in',/)
-      END IF
-# endif
-#endif
+!  Process ROMS standard input Iname script.
 !
       CALL read_PhyPar (model, inp, out, Lwrite)
 #ifdef DISTRIBUTE
@@ -213,8 +141,7 @@
 #if defined SPLIT_4DVAR && SUPPRESS_REPORT
 !
 !  If appending into standard output file, supress the reporting of
-!  information.  Turn of "LwrtInfo" switch.
-!  appending into standard output.
+!  information. Turn of "LwrtInfo" switch.
 !
       IF (Lappend) THEN
         DO ng=1,Ngrids

--- a/ROMS/Utility/inp_par.F
+++ b/ROMS/Utility/inp_par.F
@@ -1202,7 +1202,7 @@
 !
       IF (Master.and.Lwrite) THEN
         CALL checkdefs
-        CALL my_flush (out)
+        FLUSH (out)
       END IF
 #ifdef DISTRIBUTE
       CALL mp_bcasti (1, model, exit_flag)

--- a/ROMS/Utility/mp_routines.F
+++ b/ROMS/Utility/mp_routines.F
@@ -11,7 +11,6 @@
 !  This package contains multi-processing routines used during         !
 !  parallel applications:                                              !
 !                                                                      !
-!     my_flush         Flushes the contents of a unit buffer.          !
 !     my_getarg        Returns the argument from command-line.         !
 !     my_getpid        Returns process ID of the calling process.      !
 !     my_numthreads    Returns number of threads that would            !
@@ -22,31 +21,6 @@
 !                        an arbitrary time in the past.                !
 !                                                                      !
 !=======================================================================
-!
-!-----------------------------------------------------------------------
-      SUBROUTINE my_flush (unit)
-!-----------------------------------------------------------------------
-!
-      USE mod_kinds
-!
-      implicit none
-!
-!  Imported variable declarations.
-!
-      integer, intent(in) :: unit
-!
-!  Flush the buffere of requested standard output or Fortran file unit.
-!
-#if defined CYGWIN
-#elif defined AIX
-!!    CALL flush_ (unit)               ! AIX Operating system routine
-#else
-!!    CALL flush (unit)                ! Operating system routine
-#endif
-      FLUSH (unit)                     ! Fortran 2003 standard
-!
-      RETURN
-      END SUBROUTINE my_flush
 
 #ifdef DISTRIBUTE
 !

--- a/ROMS/Utility/normalization.F
+++ b/ROMS/Utility/normalization.F
@@ -627,7 +627,7 @@
             IF (Master) THEN
               WRITE (stdout,20) TRIM(Text),                             &
      &                          '2D normalization factors at RHO-points'
-              CALL my_flush (stdout)
+              FLUSH (stdout)
             END IF
             DO j=JstrT,JendT
               DO i=IstrT,IendT
@@ -783,7 +783,7 @@
             IF (Master) THEN
               WRITE (stdout,20) TRIM(Text),                             &
      &                          '2D normalization factors at   U-points'
-              CALL my_flush (stdout)
+              FLUSH (stdout)
             END IF
             DO j=JstrT,JendT
               DO i=IstrP,IendT
@@ -940,7 +940,7 @@
             IF (Master) THEN
               WRITE (stdout,20) TRIM(Text),                             &
      &                          '2D normalization factors at   V-points'
-              CALL my_flush (stdout)
+              FLUSH (stdout)
             END IF
             DO j=JstrP,JendT
               DO i=IstrT,IendT
@@ -1098,7 +1098,7 @@
             IF (Master) THEN
               WRITE (stdout,20) TRIM(Text),                             &
      &                          '3D normalization factors at   U-points'
-              CALL my_flush (stdout)
+              FLUSH (stdout)
             END IF
             DO j=JstrT,JendT
               DO i=IstrP,IendT
@@ -1278,7 +1278,7 @@
             IF (Master) THEN
               WRITE (stdout,20) TRIM(Text),                             &
      &                          '3D normalization factors at   V-points'
-              CALL my_flush (stdout)
+              FLUSH (stdout)
             END IF
             DO j=JstrP,JendT
               DO i=IstrT,IendT
@@ -1452,7 +1452,7 @@
             IF (Lsame) THEN
               WRITE (stdout,20) TRIM(Text),                             &
      &                          '3D normalization factors at RHO-points'
-              CALL my_flush (stdout)
+              FLUSH (stdout)
             END IF
           END IF
 !
@@ -1717,7 +1717,7 @@
         IF (Master.and.ANY(CnormB(isFsur,:))) THEN
           WRITE (stdout,20) TRIM(Text),                                 &
      &                      '2D normalization factors at RHO-points'
-          CALL my_flush (stdout)
+          FLUSH (stdout)
         END IF
 
         DO ibry=1,4
@@ -1873,7 +1873,7 @@
         IF (Master.and.ANY(CnormB(isUbar,:))) THEN
           WRITE (stdout,20) TRIM(Text),                                 &
      &                      '2D normalization factors at   U-points'
-          CALL my_flush (stdout)
+          FLUSH (stdout)
         END IF
 
         DO ibry=1,4
@@ -2033,7 +2033,7 @@
         IF (Master.and.ANY(CnormB(isVbar,:))) THEN
           WRITE (stdout,20) TRIM(Text),                                 &
      &                      '2D normalization factors at   V-points'
-          CALL my_flush (stdout)
+          FLUSH (stdout)
         END IF
 
         DO ibry=1,4
@@ -2195,7 +2195,7 @@
         IF (Master.and.ANY(CnormB(isUvel,:))) THEN
           WRITE (stdout,20) TRIM(Text),                                 &
      &                      '3D normalization factors at   U-points'
-          CALL my_flush (stdout)
+          FLUSH (stdout)
         END IF
 
         DO ibry=1,4
@@ -2388,7 +2388,7 @@
         IF (Master.and.ANY(CnormB(isVvel,:))) THEN
           WRITE (stdout,20) TRIM(Text),                                 &
      &                      '3D normalization factors at   V-points'
-          CALL my_flush (stdout)
+          FLUSH (stdout)
         END IF
 
         DO ibry=1,4
@@ -2587,7 +2587,7 @@
           IF (Lsame) THEN
             WRITE (stdout,20) TRIM(Text),                               &
      &                        '3D normalization factors at RHO-points'
-            CALL my_flush (stdout)
+            FLUSH (stdout)
           END IF
         END IF
 
@@ -2855,7 +2855,7 @@
           IF (Master) THEN
             WRITE (stdout,20) TRIM(Text),                               &
      &                     '2D normalization factors at U-stress points'
-            CALL my_flush (stdout)
+            FLUSH (stdout)
           END IF
           DO j=JstrT,JendT
             DO i=IstrP,IendT
@@ -3011,7 +3011,7 @@
           IF (Master) THEN
             WRITE (stdout,20) TRIM(Text),                               &
      &                     '2D normalization factors at V-stress points'
-            CALL my_flush (stdout)
+            FLUSH (stdout)
           END IF
           DO j=JstrP,JendT
             DO i=IstrT,IendT
@@ -3165,7 +3165,7 @@
           IF (Lsame) THEN
             WRITE (stdout,20) TRIM(Text),                               &
                               '2D normalization factors at RHO-points'
-            CALL my_flush (stdout)
+            FLUSH (stdout)
           END IF
         END IF
 !
@@ -3714,7 +3714,7 @@
             IF (Master) THEN
               WRITE (stdout,20) TRIM(Text),                             &
      &                          '2D normalization factors at RHO-points'
-              CALL my_flush (stdout)
+              FLUSH (stdout)
             END IF
             DO j=JstrT,JendT
               DO i=IstrT,IendT
@@ -3819,7 +3819,7 @@
             IF (Master) THEN
               WRITE (stdout,20) TRIM(Text),                             &
      &                          '2D normalization factors at   U-points'
-              CALL my_flush (stdout)
+              FLUSH (stdout)
             END IF
             DO j=JstrT,JendT
               DO i=IstrP,IendT
@@ -3924,7 +3924,7 @@
             IF (Master) THEN
               WRITE (stdout,20) TRIM(Text),                             &
      &                          '2D normalization factors at   V-points'
-              CALL my_flush (stdout)
+              FLUSH (stdout)
             END IF
             DO j=JstrP,JendT
               DO i=IstrT,IendT
@@ -4031,7 +4031,7 @@
             IF (Master) THEN
               WRITE (stdout,20) TRIM(Text),                             &
      &                          '3D normalization factors at   U-points'
-              CALL my_flush (stdout)
+              FLUSH (stdout)
             END IF
             DO j=JstrT,JendT
               DO i=IstrP,IendT
@@ -4157,7 +4157,7 @@
             IF (Master) THEN
               WRITE (stdout,20) TRIM(Text),                             &
      &                          '3D normalization factors at   V-points'
-              CALL my_flush (stdout)
+              FLUSH (stdout)
             END IF
             DO j=JstrP,JendT
               DO i=IstrT,IendT
@@ -4288,7 +4288,7 @@
             IF (Lsame) THEN
               WRITE (stdout,20) TRIM(Text),                             &
      &                          '3D normalization factors at RHO-points'
-              CALL my_flush (stdout)
+              FLUSH (stdout)
             END IF
           END IF
 !
@@ -4520,7 +4520,7 @@
         IF (Master.and.ANY(CnormB(isFsur,:))) THEN
           WRITE (stdout,20) TRIM(Text),                                 &
      &                      '2D normalization factors at RHO-points'
-          CALL my_flush (stdout)
+          FLUSH (stdout)
         END IF
 
         DO ibry=1,4
@@ -4667,7 +4667,7 @@
         IF (Master.and.ANY(CnormB(isUbar,:))) THEN
           WRITE (stdout,20) TRIM(Text),                                 &
      &                      '2D normalization factors at   U-points'
-          CALL my_flush (stdout)
+          FLUSH (stdout)
         END IF
 
         DO ibry=1,4
@@ -4813,7 +4813,7 @@
         IF (Master.and.ANY(CnormB(isVbar,:))) THEN
           WRITE (stdout,20) TRIM(Text),                                 &
      &                      '2D normalization factors at   V-points'
-          CALL my_flush (stdout)
+          FLUSH (stdout)
         END IF
 
         DO ibry=1,4
@@ -4961,7 +4961,7 @@
         IF (Master.and.ANY(CnormB(isUvel,:))) THEN
           WRITE (stdout,20) TRIM(Text),                                 &
      &                      '3D normalization factors at   U-points'
-          CALL my_flush (stdout)
+          FLUSH (stdout)
         END IF
 
         DO ibry=1,4
@@ -5138,7 +5138,7 @@
         IF (Master.and.ANY(CnormB(isVvel,:))) THEN
           WRITE (stdout,20) TRIM(Text),                                 &
      &                      '3D normalization factors at   V-points'
-          CALL my_flush (stdout)
+          FLUSH (stdout)
         END IF
 
         DO ibry=1,4
@@ -5321,7 +5321,7 @@
           IF (Lsame) THEN
             WRITE (stdout,20) TRIM(Text),                               &
      &                        '3D normalization factors at RHO-points'
-            CALL my_flush (stdout)
+            FLUSH (stdout)
           END IF
         END IF
 
@@ -5568,7 +5568,7 @@
           IF (Master) THEN
             WRITE (stdout,20) TRIM(Text),                               &
      &                        '2D normalization factors at U-points'
-            CALL my_flush (stdout)
+            FLUSH (stdout)
           END IF
           DO j=JstrT,JendT
             DO i=IstrP,IendT
@@ -5673,7 +5673,7 @@
           IF (Master) THEN
             WRITE (stdout,20) TRIM(Text),                               &
      &                        '2D normalization factors at V-points'
-            CALL my_flush (stdout)
+            FLUSH (stdout)
           END IF
           DO j=JstrP,JendT
             DO i=IstrT,IendT
@@ -5787,7 +5787,7 @@
           IF (Lsame) THEN
             WRITE (stdout,20) TRIM(Text),                               &
      &                        '2D normalization factors at RHO-points'
-            CALL my_flush (stdout)
+            FLUSH (stdout)
           END IF
         END IF
 !
@@ -6039,7 +6039,7 @@
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
       IF (Master) WRITE (stdout,20) TRIM(Vname(1,ifield)), tindex
-      CALL my_flush (stdout)
+      FLUSH (stdout)
 !
   10  FORMAT (/,' WRT_NORM2D_NF90 - error while writing variable: ',a,  &
      &        /,19x 'into normalization NetCDF file for time record: ', &
@@ -6132,7 +6132,7 @@
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
       IF (Master) WRITE (stdout,20) TRIM(Vname(1,ifield)), tindex
-      CALL my_flush (stdout)
+      FLUSH (stdout)
 !
   10  FORMAT (/,' WRT_NORM2D_PIO - error while writing variable: ',a,   &
      &        /,18x 'into normalization NetCDF file for time record: ', &
@@ -6230,7 +6230,7 @@
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
       IF (Master) WRITE (stdout,20) TRIM(Vname(1,ifield)), tindex
-      CALL my_flush (stdout)
+      FLUSH (stdout)
 !
   10  FORMAT (/,' WRT_NORM3D_NF90 - error while writing variable: ',a,  &
      &        /,19x,'into normalization NetCDF file for time record: ', &
@@ -6323,7 +6323,7 @@
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
       IF (Master) WRITE (stdout,20) TRIM(Vname(1,ifield)), tindex
-      CALL my_flush (stdout)
+      FLUSH (stdout)
 !
   10  FORMAT (/,' WRT_NORM3D_PIO - error while writing variable: ',a,   &
      &        /,18x,'into normalization NetCDF file for time record: ', &

--- a/ROMS/Utility/read_phypar.F
+++ b/ROMS/Utility/read_phypar.F
@@ -4829,8 +4829,7 @@
 !
 #endif
       IF (Master.and.Lwrite) THEN
-        lstr=INDEX(my_fflags, 'free')-2
-        IF (lstr.le.0) lstr=LEN_TRIM(my_fflags)
+        lstr=LEN_TRIM(my_fflags)
         WRITE (out,60) TRIM(title), TRIM(my_os), TRIM(my_cpu),          &
      &                 TRIM(my_fort), TRIM(my_fc), my_fflags(1:lstr),   &
 #ifdef DISTRIBUTE

--- a/ROMS/Utility/stats.F
+++ b/ROMS/Utility/stats.F
@@ -239,7 +239,7 @@
      &            'S%rms    = ', S%rms
   10    FORMAT (10x,5(5x,a,i0),/,                                       &
      &          6(15x,a,1p,e15.8,0p,5x,a,1p,e15.8,0p,/))
-        CALL my_flush (stdout)
+        FLUSH (stdout)
       END IF
       tile_count=tile_count+1
       IF (tile_count.eq.NSUB) THEN
@@ -489,7 +489,7 @@
      &            'S%rms    = ', S%rms
   10    FORMAT (10x,5(5x,a,i0),/,                                       &
      &          6(15x,a,1p,e15.8,0p,5x,a,1p,e15.8,0p,/))
-        CALL my_flush (stdout)
+        FLUSH (stdout)
       END IF
       thread_count=thread_count+1
       IF (thread_count.eq.NSUB) THEN
@@ -745,7 +745,7 @@
      &            'S%rms    = ', S%rms
   10    FORMAT (10x,5(5x,a,i0),/,                                       &
      &          6(15x,a,1p,e15.8,0p,5x,a,1p,e15.8,0p,/))
-        CALL my_flush (stdout)
+        FLUSH (stdout)
       END IF
       thread_count=thread_count+1
       IF (thread_count.eq.NSUB) THEN

--- a/ROMS/Utility/stdinp_mod.F
+++ b/ROMS/Utility/stdinp_mod.F
@@ -118,6 +118,7 @@
 # endif
 !
       InpUnit=1
+      io_err=0
 # if !(defined MODEL_COUPLING || defined JEDI)
       IF (MyMaster) CALL my_getarg (1, Iname)
       CALL mp_bcasts (1, 1, Iname)
@@ -199,6 +200,7 @@
 !
 !  Get standard input unit.
 !
+      io_err=0
       IF (PRESENT(InpName)) THEN
         InpUnit=1
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
@@ -299,6 +301,7 @@
 !
 !  Get standard input unit.
 !
+      io_err=0
       IF (PRESENT(InpName)) THEN
         InpUnit=1
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
@@ -396,6 +399,7 @@
 !
 !  Get standard input unit.
 !
+      io_err=0
       IF (PRESENT(InpName)) THEN
         InpUnit=1
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
@@ -496,6 +500,7 @@
 !
 !  Get standard input unit.
 !
+      io_err=0
       IF (PRESENT(InpName)) THEN
         InpUnit=1
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
@@ -596,6 +601,7 @@
 !
 !  Get standard input unit.
 !
+      io_err=0
       IF (PRESENT(InpName)) THEN
         InpUnit=1
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
@@ -697,6 +703,7 @@
 !
 !  Get standard input unit.
 !
+      io_err=0
       IF (PRESENT(InpName)) THEN
         InpUnit=1
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
@@ -794,6 +801,7 @@
 !
 !  Get standard input unit.
 !
+      io_err=0
       IF (PRESENT(InpName)) THEN
         InpUnit=1
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &

--- a/ROMS/Utility/stdinp_mod.F
+++ b/ROMS/Utility/stdinp_mod.F
@@ -29,6 +29,17 @@
       USE mod_kinds
       USE inp_decode_mod
 !
+      USE mod_iounits,    ONLY : Iname, SourceFile, stdinp, stdout
+      USE mod_scalars,    ONLY : exit_flag
+      USE strings_mod,    ONLY : FoundError
+
+#ifdef DISTRIBUTE
+!
+      USE distribute_mod, ONLY : mp_bcasts
+#endif
+
+
+!
       INTERFACE getpar_i
         MODULE PROCEDURE getpar_0d_i
         MODULE PROCEDURE getpar_1d_i
@@ -50,7 +61,7 @@
 !
       CONTAINS
 !
-      FUNCTION stdinp_unit (localPET, GotFile) RESULT (InpUnit)
+      FUNCTION stdinp_unit (MyMaster, GotFile) RESULT (InpUnit)
 !
 !***********************************************************************
 !                                                                      !
@@ -60,7 +71,7 @@
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
-!     localPET   Local Persistent Execution Thread (integer)           !
+!     MyMaster    Switch indicating Master process (logical)           !
 !                                                                      !
 !  On Output:                                                          !
 !                                                                      !
@@ -68,18 +79,10 @@
 !                                                                      !
 !***********************************************************************
 !
-      USE mod_iounits,  ONLY : Iname, SourceFile, stdinp, stdout
-      USE mod_scalars,  ONLY : exit_flag
-
-#ifdef DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasts
-#endif
-!
 !  Imported variable declarations.
 !
+      logical, intent(in)  :: MyMaster
       logical, intent(out) :: GotFile
-      integer, intent(in)  :: localPET
 !
 !  Local variable declararions
 !
@@ -95,32 +98,40 @@
 !  Determine ROMS standard input unit.
 !-----------------------------------------------------------------------
 #ifdef DISTRIBUTE
-!
-!  In distributed-memory configurations, the input physical parameters
-!  script is opened as a regular file.  It is read and processed by all
-!  parallel nodes.  This is to avoid very complex broadcasting of the
-!  input parameters to all nodes.
+!  The ROMS standard input 'roms.in' script filename (Iname) is read
+!  from the execution command and opened as a regular formatted file in
+!  distributed-memory configurations using the 'my_getarg' function.
+!  Then, it is read and processed by all parallel nodes to avoid complex
+!  broadcasting of the ROMS input parameters to all nodes.
 # ifdef MODEL_COUPLING
-!  However, in ESM coupling, the submission argument is 'coupling.in'
-!  and the Iname was read and processed in the coupling configuration
-!  elsewhere.
+!  During native ROMS ESM coupling, the execution command uses the
+!  input script 'coupling.in', and the Iname filename is assigned
+!  elsewhere during the coupling configuration.
+# endif
+# ifdef JEDI
+!  In the ROMSJEDI interface, the Iname filename is processed from the
+!  input configuration YAML file.
 # endif
 !
       InpUnit=1
-# ifndef MODEL_COUPLING
-      IF (localPET.eq.0) CALL my_getarg (1, Iname)
+# if !(defined MODEL_COUPLING || defined JEDI)
+      IF (MyMaster) CALL my_getarg (1, Iname)
       CALL mp_bcasts (1, 1, Iname)
 # endif
       OPEN (InpUnit, FILE=TRIM(Iname), FORM='formatted', STATUS='old',  &
      &      IOSTAT=io_err, IOMSG=io_errmsg)
       IF (io_err.ne.0) THEN
-        IF (localPET.eq.0) WRITE (stdout,10) TRIM(io_errmsg)
+        IF (MyMaster) WRITE (stdout,10) TRIM(io_errmsg)
         exit_flag=2
         RETURN
       ELSE
         GotFile=.TRUE.
       END IF
 #else
+!
+! The ROMS stardard input file is read from Fortran default standard
+! input unit.
+!
       InpUnit=stdinp
       GotFile=.FALSE.
 #endif
@@ -138,7 +149,7 @@
 !
       END FUNCTION stdinp_unit
 !
-      SUBROUTINE getpar_0d_i (localPET, Value, KeyWord, InpName)
+      SUBROUTINE getpar_0d_i (MyMaster, Value, KeyWord, InpName)
 !
 !***********************************************************************
 !                                                                      !
@@ -146,7 +157,7 @@
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
-!     localPET   Local Persistent Execution Thread (integer)           !
+!     MyMaster    Switch indicating Master process (logical)           !
 !     KeyWord    Keyword associated with input parameter (string)      !
 !     InpName    Standard input filename (string; OPTIONAL)            !
 !                                                                      !
@@ -156,14 +167,10 @@
 !                                                                      !
 !***********************************************************************
 !
-      USE mod_iounits, ONLY : stdout
-      USE mod_scalars, ONLY : exit_flag
-!
-      USE strings_mod, ONLY : FoundError
-!
 !  Imported variable declarations.
 !
-      integer, intent(in)  :: localPET
+      logical, intent(in)  :: MyMaster
+!
       integer, intent(out) :: Value
 !
       character (len=*), intent(in) :: KeyWord
@@ -193,8 +200,8 @@
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
      &        STATUS='old', IOSTAT=io_err, IOMSG=io_errmsg)
         IF (io_err.ne.0) THEN
-          IF (localPET.eq.0) WRITE (stdout,10) TRIM(InpName),           &
-     &                                         TRIM(io_errmsg)
+          IF (MyMaster) WRITE (stdout,10) TRIM(InpName),                &
+     &                                    TRIM(io_errmsg)
   10      FORMAT (/,' GETPAR_0D_I - Unable to open input script: ',a,   &
      &            /,15x,'ERROR: ',a)
           exit_flag=2
@@ -203,7 +210,7 @@
           GotFile=.TRUE.
         END IF
       ELSE
-        InpUnit=stdinp_unit(localPET, GotFile)
+        InpUnit=stdinp_unit(MyMaster, GotFile)
       END IF
 !
 !  Process requested parameter.
@@ -220,14 +227,14 @@
           END IF
         END IF
       END DO
-  20  IF (localPET.eq.0) THEN
+  20  IF (MyMaster) THEN
         WRITE (stdout,30) line
   30    FORMAT (/,' GETPAR_0D_I - Error while processing line: ',/,a)
       END IF
       exit_flag=4
   40  CONTINUE
       IF (.not.foundit) THEN
-        IF (localPET.eq.0) THEN
+        IF (MyMaster) THEN
           WRITE (stdout,50) TRIM(KeyWord)
   50    FORMAT (/,' GETPAR_0D_I - unable to find KeyWord: ',a,          &
      &          /,15x,'in ROMS standard input file.')
@@ -241,7 +248,7 @@
       RETURN
       END SUBROUTINE getpar_0d_i
 !
-      SUBROUTINE getpar_1d_i (localPET, Ndim, Value, KeyWord, InpName)
+      SUBROUTINE getpar_1d_i (MyMaster, Ndim, Value, KeyWord, InpName)
 !
 !***********************************************************************
 !                                                                      !
@@ -249,7 +256,7 @@
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
-!     localPET   Local Persistent Execution Thread (integer)           !
+!     MyMaster   Switch indicating Master process (logical)            !
 !     Ndim       Size integer variable dimension                       !
 !     KeyWord    Keyword associated with input parameter (string)      !
 !     InpName    Standard input filename (string; OPTIONAL)            !
@@ -260,14 +267,10 @@
 !                                                                      !
 !***********************************************************************
 !
-      USE mod_iounits, ONLY : stdout
-      USE mod_scalars, ONLY : exit_flag
-!
-      USE strings_mod, ONLY : FoundError
-!
 !  Imported variable declarations.
 !
-      integer, intent(in)  :: localPET
+      logical, intent(in)  :: MyMaster
+!
       integer, intent(in)  :: Ndim
       integer, intent(out) :: Value(:)
 !
@@ -297,8 +300,8 @@
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
      &        STATUS='old', IOSTAT=io_err, IOMSG=io_errmsg)
         IF (io_err.ne.0) THEN
-          IF (localPET.eq.0) WRITE (stdout,10) TRIM(InpName),           &
-     &                                         TRIM(io_errmsg)
+          IF (MyMaster) WRITE (stdout,10) TRIM(InpName),                &
+     &                                    TRIM(io_errmsg)
   10      FORMAT (/,' GETPAR_1D_I - Unable to open input script: ',a,   &
      &            /,15x,'ERROR: ',a)
           exit_flag=5
@@ -307,7 +310,7 @@
           GotFile=.TRUE.
         END IF
       ELSE
-        InpUnit=stdinp_unit(localPET, GotFile)
+        InpUnit=stdinp_unit(MyMaster, GotFile)
       END IF
 !
 !  Process requested parameter.
@@ -323,14 +326,14 @@
           END IF
         END IF
       END DO
-  20  IF (localPET.eq.0) THEN
+  20  IF (MyMaster) THEN
         WRITE (stdout,30) line
   30    FORMAT (/,' GETPAR_1D_I - Error while processing line: ',/,a)
       END IF
       exit_flag=4
   40  CONTINUE
       IF (.not.foundit) THEN
-        IF (localPET.eq.0) THEN
+        IF (MyMaster) THEN
           WRITE (stdout,50) TRIM(KeyWord)
   50    FORMAT (/,' GETPAR_1D_I - unable to find KeyWord: ',a,          &
      &          /,15x,'in ROMS standard input file.')
@@ -344,7 +347,7 @@
       RETURN
       END SUBROUTINE getpar_1d_i
 !
-      SUBROUTINE getpar_0d_l (localPET, Value, KeyWord, InpName)
+      SUBROUTINE getpar_0d_l (MyMaster, Value, KeyWord, InpName)
 !
 !***********************************************************************
 !                                                                      !
@@ -352,7 +355,7 @@
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
-!     localPET   Local Persistent Execution Thread (integer)           !
+!     MyMaster   Switch indicating Master process (logical)            !
 !     KeyWord    Keyword associated with input parameter (string)      !
 !     InpName    Standard input filename (string; OPTIONAL)            !
 !                                                                      !
@@ -362,14 +365,9 @@
 !                                                                      !
 !***********************************************************************
 !
-      USE mod_iounits, ONLY : stdout
-      USE mod_scalars, ONLY : exit_flag
-!
-      USE strings_mod, ONLY : FoundError
-!
 !  Imported variable declarations.
 !
-      integer, intent(in)  :: localPET
+      logical, intent(in)  :: MyMaster
       logical, intent(out) :: Value
 !
       character (len=*), intent(in) :: KeyWord
@@ -399,8 +397,8 @@
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
      &        STATUS='old', IOSTAT=io_err, IOMSG=io_errmsg)
         IF (io_err.ne.0) THEN
-          IF (localPET.eq.0) WRITE (stdout,10) TRIM(InpName),           &
-     &                                         TRIM(io_errmsg)
+          IF (MyMaster) WRITE (stdout,10) TRIM(InpName),                &
+     &                                    TRIM(io_errmsg)
   10      FORMAT (/,' GETPAR_0D_L - Unable to open input script: ',a,   &
      &            /,15x,'ERROR: ',a)
           exit_flag=5
@@ -409,7 +407,7 @@
           GotFile=.TRUE.
         END IF
       ELSE
-        InpUnit=stdinp_unit(localPET, GotFile)
+        InpUnit=stdinp_unit(MyMaster, GotFile)
       END IF
 !
 !  Process requested parameter.
@@ -426,14 +424,14 @@
           END IF
         END IF
       END DO
-  20  IF (localPET.eq.0) THEN
+  20  IF (MyMaster) THEN
         WRITE (stdout,30) line
   30    FORMAT (/,' GETPAR_0D_L - Error while processing line: ',/,a)
       END IF
       exit_flag=4
   40  CONTINUE
       IF (.not.foundit) THEN
-        IF (localPET.eq.0) THEN
+        IF (MyMaster) THEN
           WRITE (stdout,50) TRIM(KeyWord)
   50    FORMAT (/,' GETPAR_0D_L - unable to find KeyWord: ',a,          &
      &          /,15x,'in ROMS standard input file.')
@@ -447,7 +445,7 @@
       RETURN
       END SUBROUTINE getpar_0d_l
 !
-      SUBROUTINE getpar_1d_l (localPET, Ndim, Value, KeyWord, InpName)
+      SUBROUTINE getpar_1d_l (MyMaster, Ndim, Value, KeyWord, InpName)
 !
 !***********************************************************************
 !                                                                      !
@@ -455,7 +453,7 @@
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
-!     localPET   Local Persistent Execution Thread (integer)           !
+!     MyMaster   Switch indicating Master process (logical)            !
 !     Ndim       Size logical variable dimension                       !
 !     KeyWord    Keyword associated with input parameter (string)      !
 !     InpName    Standard input filename (string; OPTIONAL)            !
@@ -466,15 +464,11 @@
 !                                                                      !
 !***********************************************************************
 !
-      USE mod_iounits, ONLY : stdout
-      USE mod_scalars, ONLY : exit_flag
-!
-      USE strings_mod, ONLY : FoundError
-!
 !  Imported variable declarations.
 !
+      logical, intent(in)  :: MyMaster
       logical, intent(out) :: Value(:)
-      integer, intent(in)  :: localPET
+!
       integer, intent(in)  :: Ndim
 !
       character (len=*), intent(in) :: KeyWord
@@ -503,8 +497,8 @@
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
      &        STATUS='old', IOSTAT=io_err, IOMSG=io_errmsg)
         IF (io_err.ne.0) THEN
-          IF (localPET.eq.0) WRITE (stdout,10) TRIM(InpName),           &
-     &                                         TRIM(io_errmsg)
+          IF (MyMaster) WRITE (stdout,10) TRIM(InpName),                &
+     &                                    TRIM(io_errmsg)
   10      FORMAT (/,' GETPAR_1D_L - Unable to open input script: ',a,   &
      &            /,15x,'ERROR: ',a)
           exit_flag=5
@@ -513,7 +507,7 @@
           GotFile=.TRUE.
         END IF
       ELSE
-        InpUnit=stdinp_unit(localPET, GotFile)
+        InpUnit=stdinp_unit(MyMaster, GotFile)
       END IF
 !
 !  Process requested parameter.
@@ -529,14 +523,14 @@
           END IF
         END IF
       END DO
-  20  IF (localPET.eq.0) THEN
+  20  IF (MyMaster) THEN
         WRITE (stdout,30) line
   30    FORMAT (/,' GETPAR_1D_L - Error while processing line: ',/,a)
       END IF
       exit_flag=4
   40  CONTINUE
       IF (.not.foundit) THEN
-        IF (localPET.eq.0) THEN
+        IF (MyMaster) THEN
           WRITE (stdout,50) TRIM(KeyWord)
   50    FORMAT (/,' GETPAR_1D_L - unable to find KeyWord: ',a,          &
      &          /,15x,'in ROMS standard input file.')
@@ -550,7 +544,7 @@
       RETURN
       END SUBROUTINE getpar_1d_l
 !
-      SUBROUTINE getpar_0d_r (localPET, Value, KeyWord, InpName)
+      SUBROUTINE getpar_0d_r (MyMaster, Value, KeyWord, InpName)
 !
 !***********************************************************************
 !                                                                      !
@@ -559,7 +553,7 @@
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
-!     localPET   Local Persistent Execution Thread (integer)           !
+!     MyMaster   Switch indicating Master process (logical)            !
 !     KeyWord    Keyword associated with input parameter (string)      !
 !     InpName    Standard input filename (string; OPTIONAL)            !
 !                                                                      !
@@ -569,14 +563,10 @@
 !                                                                      !
 !***********************************************************************
 !
-      USE mod_iounits, ONLY : stdout
-      USE mod_scalars, ONLY : exit_flag
-!
-      USE strings_mod, ONLY : FoundError
-!
 !  Imported variable declarations.
 !
-      integer, intent(in)  :: localPET
+      logical, intent(in)  :: MyMaster
+!
       real(r8), intent(out) :: Value
 !
       character (len=*), intent(in) :: KeyWord
@@ -607,8 +597,8 @@
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
      &        STATUS='old', IOSTAT=io_err, IOMSG=io_errmsg)
         IF (io_err.ne.0) THEN
-          IF (localPET.eq.0) WRITE (stdout,10) TRIM(InpName),           &
-     &                                         TRIM(io_errmsg)
+          IF (MyMaster) WRITE (stdout,10) TRIM(InpName),                &
+     &                                    TRIM(io_errmsg)
   10      FORMAT (/,' GETPAR_0D_R - Unable to open input script: ',a,   &
      &            /,15x,'ERROR: ',a)
           exit_flag=5
@@ -617,7 +607,7 @@
           GotFile=.TRUE.
         END IF
       ELSE
-        InpUnit=stdinp_unit(localPET, GotFile)
+        InpUnit=stdinp_unit(MyMaster, GotFile)
       END IF
 !
 !  Process requested parameter.
@@ -634,14 +624,14 @@
           END IF
         END IF
       END DO
-  20  IF (localPET.eq.0) THEN
+  20  IF (MyMaster) THEN
         WRITE (stdout,30) line
   30    FORMAT (/,' GETPAR_0D_R - Error while processing line: ',/,a)
       END IF
       exit_flag=4
   40  CONTINUE
       IF (.not.foundit) THEN
-        IF (localPET.eq.0) THEN
+        IF (MyMaster) THEN
           WRITE (stdout,50) TRIM(KeyWord)
   50    FORMAT (/,' GETPAR_0D_R - unable to find KeyWord: ',a,          &
      &          /,15x,'in ROMS standard input file.')
@@ -655,7 +645,7 @@
       RETURN
       END SUBROUTINE getpar_0d_r
 !
-      SUBROUTINE getpar_1d_r (localPET, Ndim, Value, KeyWord, InpName)
+      SUBROUTINE getpar_1d_r (MyMaster, Ndim, Value, KeyWord, InpName)
 !
 !***********************************************************************
 !                                                                      !
@@ -663,7 +653,7 @@
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
-!     localPET   Local Persistent Execution Thread (integer)           !
+!     MyMaster   Switch indicating Master process (logical)            !
 !     Ndim       Size integer variable dimension                       !
 !     KeyWord    Keyword associated with input parameter (string)      !
 !     InpName    Standard input filename (string; OPTIONAL)            !
@@ -674,15 +664,12 @@
 !                                                                      !
 !***********************************************************************
 !
-      USE mod_iounits, ONLY : stdout
-      USE mod_scalars, ONLY : exit_flag
-!
-      USE strings_mod, ONLY : FoundError
-!
 !  Imported variable declarations.
 !
-      integer, intent(in)  :: Ndim
-
+      logical, intent(in) :: MyMaster
+!
+      integer, intent(in) :: Ndim
+!
       real(r8), intent(out) :: Value(:)
 !
       character (len=*), intent(in) :: KeyWord
@@ -711,8 +698,8 @@
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
      &        STATUS='old', IOSTAT=io_err, IOMSG=io_errmsg)
         IF (io_err.ne.0) THEN
-          IF (localPET.eq.0) WRITE (stdout,10) TRIM(InpName),           &
-     &                                         TRIM(io_errmsg)
+          IF (MyMaster) WRITE (stdout,10) TRIM(InpName),                &
+     &                                    TRIM(io_errmsg)
   10      FORMAT (/,' GETPAR_1D_R - Unable to open input script: ',a,   &
      &            /,15x,'ERROR: ',a)
           exit_flag=5
@@ -721,7 +708,7 @@
           GotFile=.TRUE.
         END IF
       ELSE
-        InpUnit=stdinp_unit(localPET, GotFile)
+        InpUnit=stdinp_unit(MyMaster, GotFile)
       END IF
 !
 !  Process requested parameter.
@@ -737,14 +724,14 @@
           END IF
         END IF
       END DO
-  20  IF (localPET.eq.0) THEN
+  20  IF (MyMaster) THEN
         WRITE (stdout,30) line
   30    FORMAT (/,' GETPAR_1D_R - Error while processing line: ',/,a)
       END IF
       exit_flag=4
   40  CONTINUE
       IF (.not.foundit) THEN
-        IF (localPET.eq.0) THEN
+        IF (MyMaster) THEN
           WRITE (stdout,50) TRIM(KeyWord)
   50    FORMAT (/,' GETPAR_1D_R - unable to find KeyWord: ',a,          &
      &          /,15x,'in ROMS standard input file.')
@@ -758,7 +745,7 @@
       RETURN
       END SUBROUTINE getpar_1d_r
 !
-      SUBROUTINE getpar_0d_s (localPET, Value, KeyWord, InpName)
+      SUBROUTINE getpar_0d_s (MyMaster, Value, KeyWord, InpName)
 !
 !***********************************************************************
 !                                                                      !
@@ -766,7 +753,7 @@
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
-!     localPET   Local Persistent Execution Thread (integer)           !
+!     MyMaster   Switch indicating Master process (logical)            !
 !     KeyWord    Keyword associated with input parameter (string)      !
 !     InpName    Standard input filename (string; OPTIONAL)            !
 !                                                                      !
@@ -776,14 +763,9 @@
 !                                                                      !
 !***********************************************************************
 !
-      USE mod_iounits, ONLY : stdout
-      USE mod_scalars, ONLY : exit_flag
-!
-      USE strings_mod, ONLY : FoundError
-!
 !  Imported variable declarations.
 !
-      integer, intent(in)  :: localPET
+      logical, intent(in) :: MyMaster
 !
       character (len=*), intent( in) :: KeyWord
       character (len=*), intent(out) :: Value
@@ -813,8 +795,8 @@
         OPEN (InpUnit, FILE=TRIM(InpName), FORM='formatted',            &
      &        STATUS='old', IOSTAT=io_err, IOMSG=io_errmsg)
         IF (io_err.ne.0) THEN
-          IF (localPET.eq.0) WRITE (stdout,10) TRIM(InpName),           &
-     &                                         TRIM(io_errmsg)
+          IF (MyMaster) WRITE (stdout,10) TRIM(InpName),                &
+     &                                    TRIM(io_errmsg)
   10      FORMAT (/,' GETPAR_0D_S - Unable to open input script: ',a,   &
      &            /,15x,'ERROR: ',a)
           exit_flag=5
@@ -823,7 +805,7 @@
           GotFile=.TRUE.
         END IF
       ELSE
-        InpUnit=stdinp_unit(localPET, GotFile)
+        InpUnit=stdinp_unit(MyMaster, GotFile)
       END IF
 !
 !  Process requested parameter.
@@ -842,14 +824,14 @@
           END IF
         END IF
       END DO
-  20  IF (localPET.eq.0) THEN
+  20  IF (MyMaster) THEN
         WRITE (stdout,30) line
   30    FORMAT (/,' GETPAR_0D_S - Error while processing line: ',/,a)
       END IF
       exit_flag=4
   40  CONTINUE
       IF (.not.foundit) THEN
-        IF (localPET.eq.0) THEN
+        IF (MyMaster) THEN
           WRITE (stdout,50) TRIM(KeyWord)
   50    FORMAT (/,' GETPAR_0D_S - unable to find KeyWord: ',a,          &
      &          /,15x,'in ROMS standard input file.')

--- a/ROMS/Utility/stdinp_mod.F
+++ b/ROMS/Utility/stdinp_mod.F
@@ -31,14 +31,11 @@
 !
       USE mod_iounits,    ONLY : Iname, SourceFile, stdinp, stdout
       USE mod_scalars,    ONLY : exit_flag
-      USE strings_mod,    ONLY : FoundError
-
 #ifdef DISTRIBUTE
 !
       USE distribute_mod, ONLY : mp_bcasts
 #endif
-
-
+      USE strings_mod,    ONLY : FoundError
 !
       INTERFACE getpar_i
         MODULE PROCEDURE getpar_0d_i
@@ -58,6 +55,13 @@
       INTERFACE getpar_s
         MODULE PROCEDURE getpar_0d_s
       END INTERFACE getpar_s
+!
+      PUBLIC  :: getpar_i
+      PUBLIC  :: getpar_l
+      PUBLIC  :: getpar_r
+      PUBLIC  :: getpar_s
+      PUBLIC  :: stdinp_unit
+      PRIVATE
 !
       CONTAINS
 !
@@ -157,7 +161,7 @@
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
-!     MyMaster    Switch indicating Master process (logical)           !
+!     MyMaster   Switch indicating Master process (logical)            !
 !     KeyWord    Keyword associated with input parameter (string)      !
 !     InpName    Standard input filename (string; OPTIONAL)            !
 !                                                                      !

--- a/ROMS/Utility/stdout_mod.F
+++ b/ROMS/Utility/stdout_mod.F
@@ -16,7 +16,7 @@
 !  In some applications like coupling or disjointed mpi-communications,!
 !  it is advantageous to write standard output to a specific filename  !
 !  instead of the default Fortran standard output unit 6. If that is   !
-!  the case, it opens such formatted file for writing.                 !                                          !
+!  the case, it opens such formatted file for writing.                 !
 !                                                                      !
 !=======================================================================
 !
@@ -32,9 +32,21 @@
       implicit none
 
       PUBLIC  :: stdout_unit
-      PRIVATE
 !
+!-----------------------------------------------------------------------
+!  Module parameters.
+!-----------------------------------------------------------------------
+!
+!  The following switch tells if the standard output unit/file has
+!  been specified. It must be set up only once to avoid errors and
+!  is usually called at the beginning of ROMS_initialize. However,
+!  it is required earlier during ESM coupling configurations.
+!
+      logical, save :: Set_StdOutUnit = .TRUE.
+!
+!-----------------------------------------------------------------------
       CONTAINS
+!-----------------------------------------------------------------------
 !
       FUNCTION stdout_unit (MyMaster) RESULT (StdOutUnit)
 !
@@ -59,7 +71,8 @@
 !
 !  Local variable declararions
 !
-      integer :: StdOutUnit, io_err
+      integer :: io_err
+      integer :: StdOutUnit
 !
       character (len=10 )          :: stdout_file
       character (len=256)          :: io_errmsg
@@ -69,8 +82,10 @@
       SourceFile=MyFile
 !
 !-----------------------------------------------------------------------
-!  Determine ROMS standard input unit.
+!  Set ROMS standard input unit. If requested, set and open standard
+!  output file for writing.
 !-----------------------------------------------------------------------
+
 #ifdef ROMS_STDOUT
 !
 !  Set the Fortran standard output unit (default unit 6) to direct the
@@ -79,17 +94,17 @@
 !  separated from other components.
 !
 # if defined DISTRIBUTE && defined DISJOINTED
-       StdOutUnit=60+ForkColor
-       WRITE (stdout_file,'(a,i2.2,a)') 'log', ForkColor+1, '.roms'
+      StdOutUnit=60+ForkColor
+      WRITE (stdout_file,'(a,i2.2,a)') 'log', ForkColor+1, '.roms'
 # else
-       StdOutUnit=60
-       stdout_file='log.roms'
+      StdOutUnit=60
+      stdout_file='log.roms'
 # endif
 #else
 !
 ! Set default standard output unit in Fortran.
 !
-       StdOutUnit=6
+      StdOutUnit=6
 #endif
 
 #ifdef ROMS_STDOUT
@@ -98,27 +113,28 @@
 !  Open ROMS standard output file.
 !-----------------------------------------------------------------------
 !
-       IF (MyMaster) THEN
-         IF (Lappend) THEN
-           OPEN (StdOutUnit, FILE=TRIM(stdout_file), FORM='formatted',  &
-     &           STATUS='old', POSITION='append', ACTION='write',       &
-     &           IOSTAT=io_err, IOMSG=io_errmsg)
-         ELSE
-           OPEN (StdOutUnit, FILE=TRIM(stdout_file), FORM='formatted',  &
-     &           STATUS='replace', IOSTAT=io_err, IOMSG=io_errmsg)
-         END IF
-       END IF
+      IF (MyMaster) THEN
+        IF (Lappend) THEN
+          OPEN (StdOutUnit, FILE=TRIM(stdout_file),                     &
+     &          FORM='formatted', STATUS='old', POSITION='append',      &
+     &          ACTION='write', IOSTAT=io_err, IOMSG=io_errmsg)
+        ELSE
+          OPEN (StdOutUnit, FILE=TRIM(stdout_file),                     &
+     &          FORM='formatted', STATUS='replace',                     &
+     &          IOSTAT=io_err, IOMSG=io_errmsg)
+        END IF
+      END IF
 # ifdef DISTRIBUTE
-       CALL mp_bcasti (1, 1, io_err)
+      CALL mp_bcasti (1, 1, io_err)
 # endif
-       IF (io_err.ne.0) THEN
-         IF (MyMaster) WRITE (StdOutUnit,10) TRIM(stdout_file),         &
-     &                                       TRIM(io_errmsg)
-         exit_flag=5
- 10      FORMAT (/,' STDOUT_UNIT - Cannot open standard output file: ', &
-     &           a,/,11x,'ERROR: ',a)
-         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-       END IF
+      IF (io_err.ne.0) THEN
+        IF (MyMaster) WRITE (StdOutUnit,10) TRIM(stdout_file),          &
+     &                                      TRIM(io_errmsg)
+        exit_flag=5
+ 10     FORMAT (/,' STDOUT_UNIT - Cannot open standard output file: ',  &
+     &          a,/,15x,'ERROR: ',a)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      END IF
 #endif
 !
       END FUNCTION stdout_unit

--- a/ROMS/Utility/stdout_mod.F
+++ b/ROMS/Utility/stdout_mod.F
@@ -113,16 +113,14 @@
 !  Open ROMS standard output file.
 !-----------------------------------------------------------------------
 !
-      IF (MyMaster) THEN
-        IF (Lappend) THEN
-          OPEN (StdOutUnit, FILE=TRIM(stdout_file),                     &
-     &          FORM='formatted', STATUS='old', POSITION='append',      &
-     &          ACTION='write', IOSTAT=io_err, IOMSG=io_errmsg)
-        ELSE
-          OPEN (StdOutUnit, FILE=TRIM(stdout_file),                     &
-     &          FORM='formatted', STATUS='replace',                     &
-     &          IOSTAT=io_err, IOMSG=io_errmsg)
-        END IF
+      IF (Lappend) THEN
+        OPEN (StdOutUnit, FILE=TRIM(stdout_file),                       &
+     &        FORM='formatted', STATUS='old', POSITION='append',        &
+     &        ACTION='write', IOSTAT=io_err, IOMSG=io_errmsg)
+      ELSE
+        OPEN (StdOutUnit, FILE=TRIM(stdout_file),                       &
+     &        FORM='formatted', STATUS='replace',                       &
+     &        IOSTAT=io_err, IOMSG=io_errmsg)
       END IF
 # ifdef DISTRIBUTE
       CALL mp_bcasti (1, 1, io_err)

--- a/ROMS/Utility/stdout_mod.F
+++ b/ROMS/Utility/stdout_mod.F
@@ -1,0 +1,125 @@
+#include "cppdefs.h"
+      MODULE stdout_mod
+!
+!git $Id$
+!svn $Id$
+!================================================== Hernan G. Arango ===
+!  Copyright (c) 2002-2024 The ROMS/TOMS Group                         !
+!    Licensed under a MIT/X style license                              !
+!    See License_ROMS.md                                               !
+!=======================================================================
+!                                                                      !
+!  It sets the ROMS standard output unit to write verbose execution    !
+!  information. Notice that the default standard out unit in Fortran   !
+!  is 6.                                                               !
+!                                                                      !
+!  In some applications like coupling or disjointed mpi-communications,!
+!  it is advantageous to write standard output to a specific filename  !
+!  instead of the default Fortran standard output unit 6. If that is   !
+!  the case, it opens such formatted file for writing.                 !                                          !
+!                                                                      !
+!=======================================================================
+!
+      USE mod_iounits,  ONLY : SourceFile
+      USE mod_scalars,  ONLY : exit_flag
+!
+#ifdef DISTRIBUTE
+      USE distribute_mod, ONLY : mp_bcasti
+#endif
+      USE strings_mod,    ONLY : FoundError
+!
+      implicit none
+
+      PUBLIC  :: stdout_unit
+      PRIVATE
+!
+      CONTAINS
+!
+      FUNCTION stdout_unit (MyMaster) RESULT (StdOutUnit)
+!
+!***********************************************************************
+!                                                                      !
+!  This function determines ROMS standard output unit to write its     !
+!  running verbose information.                                        !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     MyMaster    Switch indicating Master process (logical)           !
+!                                                                      !
+!  On Output:                                                          !
+!                                                                      !
+!     StdOutUnit  Assigned standard output unit (integer; default=6)   !
+!                                                                      !
+!***********************************************************************
+!
+!  Imported variable declarations.
+!
+      logical, intent(in)  :: MyMaster
+!
+!  Local variable declararions
+!
+      integer :: StdOutUnit, io_err
+!
+      character (len=10 )          :: stdout_file
+      character (len=256)          :: io_errmsg
+      character (len=*), parameter :: MyFile =                          &
+     &  __FILE__//", stdout_unit"
+!
+      SourceFile=MyFile
+!
+!-----------------------------------------------------------------------
+!  Determine ROMS standard input unit.
+!-----------------------------------------------------------------------
+#ifdef ROMS_STDOUT
+!
+!  Set the Fortran standard output unit (default unit 6) to direct the
+!  ROMS run information to a specific filename. It is advantageous in
+!  coupling or disjointed applications that need ROMS information
+!  separated from other components.
+!
+# if defined DISTRIBUTE && defined DISJOINTED
+       StdOutUnit=60+ForkColor
+       WRITE (stdout_file,'(a,i2.2,a)') 'log', ForkColor+1, '.roms'
+# else
+       StdOutUnit=60
+       stdout_file='log.roms'
+# endif
+#else
+!
+! Set default standard output unit in Fortran.
+!
+       StdOutUnit=6
+#endif
+
+#ifdef ROMS_STDOUT
+!
+!-----------------------------------------------------------------------
+!  Open ROMS standard output file.
+!-----------------------------------------------------------------------
+!
+       IF (MyMaster) THEN
+         IF (Lappend) THEN
+           OPEN (StdOutUnit, FILE=TRIM(stdout_file), FORM='formatted',  &
+     &           STATUS='old', POSITION='append', ACTION='write',       &
+     &           IOSTAT=io_err, IOMSG=io_errmsg)
+         ELSE
+           OPEN (StdOutUnit, FILE=TRIM(stdout_file), FORM='formatted',  &
+     &           STATUS='replace', IOSTAT=io_err, IOMSG=io_errmsg)
+         END IF
+       END IF
+# ifdef DISTRIBUTE
+       CALL mp_bcasti (1, 1, io_err)
+# endif
+       IF (io_err.ne.0) THEN
+         IF (MyMaster.eq.0) WRITE (StdOutUnit,10) TRIM(stdout_file),    &
+     &                                            TRIM(io_errmsg)
+         exit_flag=5
+ 10      FORMAT (/,' STDOUT_UNIT - Cannot open standard output file: ', &
+     &           a,/,11x,'ERROR: ',a)
+         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+       END IF
+#endif
+!
+      END FUNCTION stdout_unit
+!
+      END MODULE stdout_mod

--- a/ROMS/Utility/stdout_mod.F
+++ b/ROMS/Utility/stdout_mod.F
@@ -21,7 +21,7 @@
 !=======================================================================
 !
       USE mod_iounits,  ONLY : SourceFile
-      USE mod_scalars,  ONLY : exit_flag
+      USE mod_scalars,  ONLY : NoError, exit_flag
 !
 #ifdef DISTRIBUTE
       USE distribute_mod, ONLY : mp_bcasti

--- a/ROMS/Utility/stdout_mod.F
+++ b/ROMS/Utility/stdout_mod.F
@@ -20,8 +20,9 @@
 !                                                                      !
 !=======================================================================
 !
-      USE mod_iounits,  ONLY : SourceFile
-      USE mod_scalars,  ONLY : NoError, exit_flag
+      USE mod_parallel
+      USE mod_iounits
+      USE mod_scalars
 !
 #ifdef DISTRIBUTE
       USE distribute_mod, ONLY : mp_bcasti

--- a/ROMS/Utility/stdout_mod.F
+++ b/ROMS/Utility/stdout_mod.F
@@ -24,9 +24,6 @@
       USE mod_iounits
       USE mod_scalars
 !
-#ifdef DISTRIBUTE
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
       USE strings_mod,    ONLY : FoundError
 !
       implicit none
@@ -113,6 +110,7 @@
 !  Open ROMS standard output file.
 !-----------------------------------------------------------------------
 !
+      io_err=0
       IF (Lappend) THEN
         OPEN (StdOutUnit, FILE=TRIM(stdout_file),                       &
      &        FORM='formatted', STATUS='old', POSITION='append',        &
@@ -122,9 +120,6 @@
      &        FORM='formatted', STATUS='replace',                       &
      &        IOSTAT=io_err, IOMSG=io_errmsg)
       END IF
-# ifdef DISTRIBUTE
-      CALL mp_bcasti (1, 1, io_err)
-# endif
       IF (io_err.ne.0) THEN
         IF (MyMaster) WRITE (StdOutUnit,10) TRIM(stdout_file),          &
      &                                      TRIM(io_errmsg)

--- a/ROMS/Utility/stdout_mod.F
+++ b/ROMS/Utility/stdout_mod.F
@@ -111,8 +111,8 @@
        CALL mp_bcasti (1, 1, io_err)
 # endif
        IF (io_err.ne.0) THEN
-         IF (MyMaster.eq.0) WRITE (StdOutUnit,10) TRIM(stdout_file),    &
-     &                                            TRIM(io_errmsg)
+         IF (MyMaster) WRITE (StdOutUnit,10) TRIM(stdout_file),         &
+     &                                       TRIM(io_errmsg)
          exit_flag=5
  10      FORMAT (/,' STDOUT_UNIT - Cannot open standard output file: ', &
      &           a,/,11x,'ERROR: ',a)

--- a/ROMS/Utility/strings.F
+++ b/ROMS/Utility/strings.F
@@ -92,7 +92,7 @@
         foundit=.TRUE.
         IF (Master) THEN
           WRITE (stdout,10) flag, line, TRIM(routine)
-  10      FORMAT (' Found Error: ', i2.2, t20, 'Line: ', i0,            &
+  10      FORMAT (' Found Error: ', i0, t20, 'Line: ', i0,              &
      &            t35, 'Source: ', a)
         END IF
         FLUSH (stdout)

--- a/ROMS/Utility/strings.F
+++ b/ROMS/Utility/strings.F
@@ -95,7 +95,7 @@
   10      FORMAT (' Found Error: ', i2.2, t20, 'Line: ', i0,            &
      &            t35, 'Source: ', a)
         END IF
-        CALL my_flush (stdout)
+        FLUSH (stdout)
       END IF
 
       RETURN
@@ -190,7 +190,7 @@
   10      FORMAT (' Found Error: ', i2.2, t20, 'Line: ', i0,            &
      &            t35, 'Source: ', a)
         END IF
-        CALL my_flush (stdout)
+        FLUSH (stdout)
       END IF
 
       RETURN
@@ -290,7 +290,7 @@
   10      FORMAT (' Found Error: ', i2.2, t20, 'Line: ', i0,            &
      &            t35, 'Source: ', a)
         END IF
-        CALL my_flush (stdout)
+        FLUSH (stdout)
       END IF
 
       RETURN

--- a/ROMS/Utility/timers.F
+++ b/ROMS/Utility/timers.F
@@ -69,7 +69,7 @@
 !
       IF (Master) THEN
         WRITE (stdout,'(a,a)') '==> Entering ', TRIM(routine)
-        CALL my_flush (stdout)
+        FLUSH (stdout)
       END IF
 #endif
 !
@@ -131,7 +131,7 @@
           WRITE (stdout,10) ' Node #', PETrank,                         &
      &                      ' (pid=',proc(0,MyModel,ng),') is active.'
 # endif
-          CALL my_flush (stdout)
+          FLUSH (stdout)
 #else
           WRITE (stdout,10) ' Thread #', MyThread,                      &
      &                      ' (pid=',proc(0,MyModel,ng),') is active.'
@@ -217,7 +217,7 @@
 !
       IF (Master) THEN
         WRITE (stdout,'(a,a)') '<== Exiting  ', TRIM(routine)
-        CALL my_flush (stdout)
+        FLUSH (stdout)
       END IF
 #endif
 !
@@ -297,7 +297,7 @@
           WRITE (stdout,10) ' Node   #', PETrank,                       &
      &                      ' CPU:', Tend(PETrank+1)
 # endif
-          CALL my_flush (stdout)
+          FLUSH (stdout)
 #else
           WRITE (stdout,10) ' Thread #', MyThread, ' CPU:',             &
      &                      Cend(region,MyModel,ng)

--- a/ROMS/Utility/yaml_parser.F
+++ b/ROMS/Utility/yaml_parser.F
@@ -842,13 +842,15 @@
 !
           IF (self%list(ipair)%is_sequence) THEN
             Lstr=LEN_TRIM(Vstring)
-            nvalues=COUNT((/(Vstring(j:j), j=1,Lstr)/) == CHAR(44)) + 1
+            nvalues=yaml_CountKeys(Vstring, CHAR(44))
 !
             IF (.not.ALLOCATED(S)) THEN
               ALLOCATE ( S(npairs) )                   ! main structure
             END IF
+            IF (i.eq.1) THEN
+              S(1:npairs)%has_vector=.TRUE.
+            END IF
             ALLOCATE ( S(i)%vector(nvalues) )          ! sub-structure
-            S(i)%has_vector=.TRUE.
 !
             is=1
             DO j=1,nvalues
@@ -881,7 +883,9 @@
             IF (.not.ALLOCATED(S)) THEN
               ALLOCATE ( S(npairs) )
             END IF
-            S(i)%has_vector=.FALSE.
+            IF (i.eq.1) THEN
+              S(1:npairs)%has_vector=.FALSE.
+            END IF
 !
             IF (yaml_Error(yaml_AssignString(S(i)%value,                &
      &                                       Vstring, LenStr),          &
@@ -901,10 +905,14 @@
 !
           IF (self%list(ipair)%is_sequence) THEN
             Lstr=LEN_TRIM(Vstring)
-            nvalues=COUNT((/(Vstring(j:j), j=1,Lstr)/) == CHAR(44)) + 1
+            nvalues=yaml_CountKeys(Vstring, CHAR(44))
 !
-            ALLOCATE ( S(nvalues) )
-            S(i)%has_vector=.FALSE.
+            IF (.not.ALLOCATED(S)) THEN
+              ALLOCATE ( S(nvalues) )
+            END IF
+            IF (i.eq.1) THEN
+              S(1:nvalues)%has_vector=.FALSE.
+            END IF
 !
             is=1
             DO j=1,nvalues
@@ -933,7 +941,9 @@
 !
           ELSE
 !
-            ALLOCATE ( S(1) )
+            IF (.not.ALLOCATED(S)) THEN
+              allocate ( S(1) )
+            END IF
             S(1)%has_vector=.FALSE.
 !
             IF (yaml_Error(yaml_AssignString(S(1)%value,                &
@@ -1636,7 +1646,7 @@
 !                                                                      !
 !  nkeys=COUNT((/ (string(i:i), i=1,Lstr) /) == token) + 1             !
 !                                                                      !
-!  But compilier like 'gfortran' cannot handle such abstraction.       !
+!  But compiliers like 'gfortran' cannot handle such abstraction.      !
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !


### PR DESCRIPTION
- This PR corrects a problem with the definition of the ROMS standard output unit variable **`stdout`** in **gfortran**. 

  - A new module, **`stdout_mod.F`**, is added to set the ROMS standard output unit to write verbose execution information. Notice that Fortran's default standard output unit is **six**, **`stdout=6`**.  
  - In some applications like coupling (**`ROMS_STDOUT`**) or disjointed MPI-communications (**`DISJOINTED`**), it is advantageous to write standard output to a specific filename instead of the default Fortran standard output unit **six**. If that is the case, it opens such a formatted file for writing:
 
```f90
#ifdef ROMS_STDOUT
# if defined DISTRIBUTE && defined DISJOINTED
       StdOutUnit=60+ForkColor
       WRITE (stdout_file,'(a,i2.2,a)') 'log', ForkColor+1, '.roms'
# else
       StdOutUnit=60
       stdout_file='log.roms'
# endif
#else
       StdOutUnit=6
#endif
 ```
  Then, it opens the standard output for writing:

```f90
#ifdef ROMS_STDOUT
     io_err=0
     IF (Lappend) THEN
        OPEN (StdOutUnit, FILE=TRIM(stdout_file),                       &
     &        FORM='formatted', STATUS='old', POSITION='append',        &
     &        ACTION='write', IOSTAT=io_err, IOMSG=io_errmsg)
      ELSE
        OPEN (StdOutUnit, FILE=TRIM(stdout_file),                       &
     &        FORM='formatted', STATUS='replace',                       &
     &        IOSTAT=io_err, IOMSG=io_errmsg)
      END IF
      IF (io_err.ne.0) THEN
        IF (MyMaster) WRITE (StdOutUnit,10) TRIM(stdout_file),          &
     &                                      TRIM(io_errmsg)
        exit_flag=5
 10     FORMAT (/,' STDOUT_UNIT - Cannot open standard output file: ',  &
     &          a,/,15x,'ERROR: ',a)
        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
      END IF
#endif
```

- It also updates GNU make configuration (**.mk**) files for splitting between nc-config and nf-config, which can be installed in different directories:

```make
ifdef USE_NETCDF4
        NC_CONFIG ?= nc-config
   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
  ifneq ($(TEST_NC_CONFIG),)
             LIBS += $(shell $(NC_CONFIG) --libs)
  endif
        NF_CONFIG ?= nf-config
    NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
             LIBS += $(shell $(NF_CONFIG) --flibs)
           INCDIR += $(NETCDF_INCDIR) $(INCDIR)
else
    NETCDF_INCDIR ?= /opt/intelsoft/serial/netcdf3/include
    NETCDF_LIBDIR ?= /opt/intelsoft/serial/netcdf3/lib
      NETCDF_LIBS ?= -lnetcdf
             LIBS += -L$(NETCDF_LIBDIR) $(NETCDF_LIBS)
           INCDIR += $(NETCDF_INCDIR) $(INCDIR)
endif
```
- ROMS can be compiled now with the **ifx** intel compiler, which will replace **ifort** at the end of the year.
- It updates the **DATA** model NUOPC module to allow time management with units **`hours since YYY-MM-DD`**.
- It uses the Fortran intrinsic **FLUSH** function instead of **CALL my_flush** everywhere.
----
## UFS Coupling System

The **`ROMS-UFS`** interface is fully functional, and the prototype **ROMS-DATA** coupling component for Hurricane Irene works using **`CDEPS/CMEPS`** with either **ifort** or **gfortran**. Please check:

- https://github.com/myroms/roms_test/blob/main/IRENE/Coupling/roms_data_cdeps/Readme.md
- https://github.com/myroms/roms_test/tree/main/IRENE/Coupling/roms_data_cmeps/Readme.md

Thanks to [Ufuk Turunçoğlu](https://github.com/uturuncoglu) for his hard work and help.