### PR TITLE
Updated RPCG solver for mixed precision

### DIFF
--- a/ROMS/Modules/mod_fourdvar.F
+++ b/ROMS/Modules/mod_fourdvar.F
@@ -155,19 +155,19 @@
           integer , allocatable :: ObsCount(:)
           integer , allocatable :: ObsReject(:)
 #  ifdef FOUR_DVAR
-          real(r8), allocatable :: BackCost(:)
-          real(r8), allocatable :: Cost0(:)
-          real(r8), allocatable :: CostFun(:)
-          real(r8), allocatable :: CostFunOld(:)
-          real(r8), allocatable :: CostNorm(:)
-          real(r8), allocatable :: ObsCost(:)
-          real(r8), allocatable :: DataPenalty(:)
+          real(dp), allocatable :: BackCost(:)
+          real(dp), allocatable :: Cost0(:)
+          real(dp), allocatable :: CostFun(:)
+          real(dp), allocatable :: CostFunOld(:)
+          real(dp), allocatable :: CostNorm(:)
+          real(dp), allocatable :: ObsCost(:)
+          real(dp), allocatable :: DataPenalty(:)
 #   if defined DATALESS_LOOPS    || defined RBL4DVAR  || \
        defined SENSITIVITY_4DVAR || defined SP4DVAR   || \
        defined TL_RBL4DVAR
-          real(r8), allocatable :: NLPenalty(:)
+          real(dp), allocatable :: NLPenalty(:)
 #   endif
-          real(r8), allocatable :: NLobsCost(:)
+          real(dp), allocatable :: NLobsCost(:)
 
 #   if defined BALANCE_OPERATOR && defined ZETA_ELLIPTIC
           real(r8), allocatable :: bc_ak(:)
@@ -199,12 +199,12 @@
           real(r8), allocatable :: SurveyTime(:)
 
 #  ifdef RPCG
-          real(r8), allocatable :: cg_pxout(:)
-          real(r8), allocatable :: cg_pxsave(:)
-          real(r8), allocatable :: cg_pxsum(:)
-          real(r8), allocatable :: cg_Dpxsum(:)
-          real(r8), allocatable :: tl_cg_pxsave(:)
-          real(r8), allocatable :: ad_cg_pxsave(:)
+          real(dp), allocatable :: cg_pxout(:)
+          real(dp), allocatable :: cg_pxsave(:)
+          real(dp), allocatable :: cg_pxsum(:)
+          real(dp), allocatable :: cg_Dpxsum(:)
+          real(dp), allocatable :: tl_cg_pxsave(:)
+          real(dp), allocatable :: ad_cg_pxsave(:)
 #  endif
 
         END TYPE T_FOURDVAR
@@ -647,75 +647,75 @@
 !
 #  if defined SENSITIVITY_4DVAR || defined TL_RBL4DVAR  || \
       defined TL_R4DVAR
-        real(r8), allocatable :: ad_cg_beta(:)
+        real(dp), allocatable :: ad_cg_beta(:)
 
-        real(r8), allocatable :: tl_cg_beta(:)
+        real(dp), allocatable :: tl_cg_beta(:)
 #  endif
-        real(r8), allocatable :: cg_alpha(:,:)
-        real(r8), allocatable :: cg_beta(:,:)
-        real(r8), allocatable :: cg_tau(:,:)
+        real(dp), allocatable :: cg_alpha(:,:)
+        real(dp), allocatable :: cg_beta(:,:)
+        real(dp), allocatable :: cg_tau(:,:)
 !
 !  Ritz values maximum error limit.
 !
-        real(r8) :: RitzMaxErr
+        real(dp) :: RitzMaxErr
 !
 !  Converged Ritz eigenvalues used to approximate Hessian matrix during
 !  preconditioning.
 !
-        real(r8), allocatable :: Ritz(:)
+        real(dp), allocatable :: Ritz(:)
 !
 !  Orthogonal eigenvectors of Lanczos recurrence term Q(k)T(k).
 !
 #  ifdef WEAK_CONSTRAINT
-        real(r8), allocatable :: cg_zv(:,:,:)
+        real(dp), allocatable :: cg_zv(:,:,:)
 #  else
-        real(r8), allocatable :: cg_zv(:,:)
+        real(dp), allocatable :: cg_zv(:,:)
 #  endif
 !
 !  Lanczos algorithm coefficients.
 !
 #  if defined SENSITIVITY_4DVAR || defined TL_RBL4DVAR  || \
       defined TL_R4DVAR
-        real(r8), allocatable :: ad_cg_delta(:)
-        real(r8), allocatable :: ad_cg_QG(:)
-        real(r8), allocatable :: ad_cg_Gnorm(:)
+        real(dp), allocatable :: ad_cg_delta(:)
+        real(dp), allocatable :: ad_cg_QG(:)
+        real(dp), allocatable :: ad_cg_Gnorm(:)
 
-        real(r8), allocatable :: tl_cg_delta(:)
-        real(r8), allocatable :: tl_cg_QG(:)
+        real(dp), allocatable :: tl_cg_delta(:)
+        real(dp), allocatable :: tl_cg_QG(:)
 #   ifdef RPCG
-        real(r8), allocatable :: tl_cg_Gnorm_v(:)
-        real(r8), allocatable :: ad_cg_Gnorm_v(:)
+        real(dp), allocatable :: tl_cg_Gnorm_v(:)
+        real(dp), allocatable :: ad_cg_Gnorm_v(:)
 #   else
-        real(r8), allocatable :: tl_cg_Gnorm(:)
+        real(dp), allocatable :: tl_cg_Gnorm(:)
 #   endif
 #  endif
-        real(r8), allocatable :: cg_delta(:,:)
-        real(r8), allocatable :: cg_gamma(:,:)
+        real(dp), allocatable :: cg_delta(:,:)
+        real(dp), allocatable :: cg_gamma(:,:)
 !
 !  Initial gradient vector normalization factor.
 !
-        real(r8), allocatable :: cg_Gnorm(:)
-        real(r8), allocatable :: cg_Gnorm_v(:)
-        real(r8), allocatable :: cg_Gnorm_y(:)
+        real(dp), allocatable :: cg_Gnorm(:)
+        real(dp), allocatable :: cg_Gnorm_v(:)
+        real(dp), allocatable :: cg_Gnorm_y(:)
 !
 !  Reduction in the gradient norm; excess cost function.
 !
-        real(r8), allocatable :: cg_Greduc(:,:)
+        real(dp), allocatable :: cg_Greduc(:,:)
 !
 !  Lanczos vector normalization factor.
 !
-        real(r8), allocatable :: cg_QG(:,:)
+        real(dp), allocatable :: cg_QG(:,:)
 !
 !  Lanczos recurrence symmetric, tridiagonal matrix, T(k).
 !
-        real(r8), allocatable :: cg_Tmatrix(:,:)
-        real(r8), allocatable :: cg_zu(:,:)
+        real(dp), allocatable :: cg_Tmatrix(:,:)
+        real(dp), allocatable :: cg_zu(:,:)
 !
 !  Eigenvalues of the Lanczos recurrence term Q(k)T(k)
 !  algorithm and their relative error (accuaracy).
 !
-        real(r8), allocatable :: cg_Ritz(:,:)
-        real(r8), allocatable :: cg_RitzErr(:,:)
+        real(dp), allocatable :: cg_Ritz(:,:)
+        real(dp), allocatable :: cg_RitzErr(:,:)
 # endif
 # if defined BALANCE_OPERATOR
 !

--- a/ROMS/Modules/mod_netcdf.F
+++ b/ROMS/Modules/mod_netcdf.F
@@ -25,7 +25,11 @@
       USE mod_scalars
       USE netcdf
 !
-      USE strings_mod, ONLY : FoundError
+#ifdef DISTRIBUTE
+      USE distribute_mod, ONLY : mp_bcastf, mp_bcasti, mp_bcastl,       &
+     &                           mp_bcasts
+#endif
+      USE strings_mod,    ONLY : FoundError
 !
       implicit none
 !
@@ -43,6 +47,8 @@
 #ifdef SINGLE_PRECISION
         MODULE PROCEDURE netcdf_get_fvar_0dp
         MODULE PROCEDURE netcdf_get_fvar_1dp
+        MODULE PROCEDURE netcdf_get_fvar_2dp
+        MODULE PROCEDURE netcdf_get_fvar_3dp
 #endif
         MODULE PROCEDURE netcdf_get_fvar_0d
         MODULE PROCEDURE netcdf_get_fvar_1d
@@ -79,6 +85,7 @@
         MODULE PROCEDURE netcdf_put_fvar_0dp
         MODULE PROCEDURE netcdf_put_fvar_1dp
         MODULE PROCEDURE netcdf_put_fvar_2dp
+        MODULE PROCEDURE netcdf_put_fvar_3dp
 #endif
         MODULE PROCEDURE netcdf_put_fvar_0d
         MODULE PROCEDURE netcdf_put_fvar_1d
@@ -269,11 +276,6 @@
 !     VarID        ID of requested variable (integer)                  !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -362,12 +364,6 @@
 !     WARNING: This is information is rewritten during each CALL.      !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti, mp_bcasts
-#endif
-
 !
 !  Imported variable declarations.
 !
@@ -1429,11 +1425,6 @@
 !     WARNING: This is information is rewritten during each CALL.      !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti, mp_bcastf, mp_bcasts
-#endif
 !
 !  Imported variable declarations.
 !
@@ -1922,11 +1913,6 @@
 !     VarID        ID of requested variable (integer)                  !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -2004,11 +1990,6 @@
 !                    attribute is found (logical array)                !
 !                                                                      !
 !=======================================================================
-
-# if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcastf, mp_bcasti
-# endif
 !
 !  Imported variable declarations.
 !
@@ -2194,11 +2175,6 @@
 !                    attribute is found (logical array)                !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcastf, mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -2383,11 +2359,6 @@
 !                    attribute is found (logical array)                !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti, mp_bcasts
-#endif
 !
 !  Imported variable declarations.
 !
@@ -2586,11 +2557,6 @@
 !    CALL netcdf_get_fvar (ng, iNLM, 'file.nc', 'VarName', fvar(1))    !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcastf, mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -2612,16 +2578,16 @@
 !
 !  Local variable declarations.
 !
-#if !defined PARALLEL_IO && defined DISTRIBUTE
+# if !defined PARALLEL_IO && defined DISTRIBUTE
       logical :: DoBroadcast
 !
-#endif
+# endif
 
       integer :: my_ncid, status, varid
 
-#if !defined PARALLEL_IO && defined DISTRIBUTE
+# if !defined PARALLEL_IO && defined DISTRIBUTE
       integer, dimension(2) :: ibuffer
-#endif
+# endif
 !
       real(dp), dimension(1) :: my_A
 !
@@ -2641,7 +2607,7 @@
         my_ncid=ncid
       END IF
 
-#if !defined PARALLEL_IO && defined DISTRIBUTE
+# if !defined PARALLEL_IO && defined DISTRIBUTE
 !
 !  Determine if the read data is only needed and allocated by the master
 !  node ins distribute-memory applications.
@@ -2651,7 +2617,7 @@
       ELSE
         DoBroadcast=broadcast
       END IF
-#endif
+# endif
 !
 !  Read in variable.
 !
@@ -2678,7 +2644,7 @@
         END IF
       END IF
 
-#if !defined PARALLEL_IO && defined DISTRIBUTE
+# if !defined PARALLEL_IO && defined DISTRIBUTE
 !
 !  Broadcast read variable to all processors in the group.
 !
@@ -2690,7 +2656,7 @@
       IF (DoBroadcast.and.(exit_flag.eq.NoError)) THEN
         CALL mp_bcastf (ng, model, A)
       END IF
-#endif
+# endif
 !
 !  Compute minimum and maximum values of read variable. Notice that
 !  the same read value is assigned since a scalar variable was
@@ -2758,11 +2724,6 @@
 !    CALL netcdf_get_fvar (ng, iNLM, 'file.nc', 'VarName', fvar(:,1))  !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcastf, mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -2784,17 +2745,17 @@
 !
 !  Local variable declarations.
 !
-#if !defined PARALLEL_IO && defined DISTRIBUTE
+# if !defined PARALLEL_IO && defined DISTRIBUTE
       logical :: DoBroadcast
-#endif
+# endif
       logical, dimension(3) :: foundit
 !
       integer :: i, my_ncid, status, varid
 
       integer, dimension(1) :: Asize
-#if !defined PARALLEL_IO && defined DISTRIBUTE
+# if !defined PARALLEL_IO && defined DISTRIBUTE
       integer, dimension(2) :: ibuffer
-#endif
+# endif
 !
       real(dp) :: Afactor, Aoffset, Aspval
 
@@ -2829,7 +2790,7 @@
         my_ncid=ncid
       END IF
 
-#if !defined PARALLEL_IO && defined DISTRIBUTE
+# if !defined PARALLEL_IO && defined DISTRIBUTE
 !
 !  Determine if the read data is only needed and allocated by the master
 !  node ins distribute-memory applications.
@@ -2839,7 +2800,7 @@
       ELSE
         Dobroadcast=broadcast
       END IF
-#endif
+# endif
 !
 !  Read in variable.
 !
@@ -2865,7 +2826,7 @@
         END IF
       END IF
 
-#if !defined PARALLEL_IO && defined DISTRIBUTE
+# if !defined PARALLEL_IO && defined DISTRIBUTE
 !
 !  Broadcast read variable to all processors in the group.
 !
@@ -2877,7 +2838,7 @@
       IF (DoBroadcast.and.(exit_flag.eq.NoError)) THEN
         CALL mp_bcastf (ng, model, A)
       END IF
-#endif
+# endif
 !
 !  Check if the following attributes: "scale_factor", "add_offset", and
 !  "_FillValue" are present in the input NetCDF variable:
@@ -2963,6 +2924,508 @@
 !
       RETURN
       END SUBROUTINE netcdf_get_fvar_1dp
+!
+      SUBROUTINE netcdf_get_fvar_2dp (ng, model, ncname, myVarName, A,  &
+     &                                ncid, start, total, broadcast,    &
+     &                                min_val, max_val)
+!
+!=======================================================================
+!                                                                      !
+!  This routine reads requested double-precision 2D-array variable     !
+!  from specified NetCDF file.                                         !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     ng           Nested grid number (integer)                        !
+!     model        Calling model identifier (integer)                  !
+!     ncname       NetCDF file name (string)                           !
+!     myVarName    Variable name (string)                              !
+!     ncid         NetCDF file ID (integer, OPTIONAL)                  !
+!     start        Starting index where the first of the data values   !
+!                    will be read along each dimension (integer,       !
+!                    OPTIONAL)                                         !
+!     total        Number of data values to be read along each         !
+!                    dimension (integer, OPTIONAL)                     !
+!     broadcast    Switch to broadcast read values from root to all    !
+!                    members of the communicator in distributed-       !
+!                    memory applications (logical, OPTIONAL,           !
+!                    default=TRUE)                                     !
+!                                                                      !
+!  On Ouput:                                                           !
+!                                                                      !
+!     A            Read 2D-array variable (real)                       !
+!     min_val      Read data minimum value (real, OPTIONAL)            !
+!     max_val      Read data maximum value (real, OPTIONAL)            !
+!                                                                      !
+!  Examples:                                                           !
+!                                                                      !
+!    CALL netcdf_get_fvar (ng, iNLM, 'file.nc', 'VarName', fvar)       !
+!    CALL netcdf_get_fvar (ng, iNLM, 'file.nc', 'VarName', fvar(0:,:)) !
+!    CALL netcdf_get_fvar (ng, iNLM, 'file.nc', 'VarName', fvar(0:,0:))!
+!    CALL netcdf_get_fvar (ng, iNLM, 'file.nc', 'VarName', fvar(:,:,1))!
+!                                                                      !
+!=======================================================================
+!
+!  Imported variable declarations.
+!
+      logical, intent(in), optional :: broadcast
+!
+      integer, intent(in) :: ng, model
+
+      integer, intent(in), optional :: ncid
+      integer, intent(in), optional :: start(:)
+      integer, intent(in), optional :: total(:)
+!
+      character (len=*), intent(in) :: ncname
+      character (len=*), intent(in) :: myVarName
+!
+      real(dp), intent(out), optional :: min_val
+      real(dp), intent(out), optional :: max_val
+
+      real(dp), intent(out) :: A(:,:)
+!
+!  Local variable declarations.
+!
+# if !defined PARALLEL_IO && defined DISTRIBUTE
+      logical :: Dobroadcast
+# endif
+      logical, dimension(3) :: foundit
+!
+      integer :: i, j, my_ncid, status, varid
+
+      integer, dimension(2) :: Asize
+
+# if !defined PARALLEL_IO && defined DISTRIBUTE
+      integer, dimension(2) :: ibuffer
+# endif
+!
+      real(dp) :: Afactor, Aoffset, Aspval
+
+      real(dp), parameter :: Aepsilon = 1.0E-8_r8
+
+      real(dp), dimension(3) :: AttValue
+!
+      character (len=12), dimension(3) :: AttName
+
+      character (len=*), parameter :: MyFile =                          &
+     &  __FILE__//", netcdf_get_fvar_2dp"
+!
+!-----------------------------------------------------------------------
+!  Read in a double-precision 2D-array variable.
+!-----------------------------------------------------------------------
+!
+      IF (PRESENT(start).and.PRESENT(total)) THEN
+        Asize(1)=total(1)
+        Asize(2)=total(2)
+      ELSE
+        Asize(1)=UBOUND(A, DIM=1)
+        Asize(2)=UBOUND(A, DIM=2)
+      END IF
+!
+!  If NetCDF file ID is not provided, open NetCDF for reading.
+!
+      IF (.not.PRESENT(ncid)) THEN
+        CALL netcdf_open (ng, model, TRIM(ncname), 0, my_ncid)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      ELSE
+        my_ncid=ncid
+      END IF
+
+# if !defined PARALLEL_IO && defined DISTRIBUTE
+!
+!  Determine if the read data is only needed and allocated by the master
+!  node ins distribute-memory applications.
+!
+      IF (.not.PRESENT(broadcast)) THEN
+        DoBroadcast=.TRUE.
+      ELSE
+        DoBroadcast=broadcast
+      END IF
+# endif
+!
+!  Read in variable.
+!
+      IF (InpThread) THEN
+        status=nf90_inq_varid(my_ncid, TRIM(myVarName), varid)
+        IF (status.eq.nf90_noerr) THEN
+          IF (PRESENT(start).and.PRESENT(total)) THEN
+            status=nf90_get_var(my_ncid, varid, A, start, total)
+          ELSE
+            status=nf90_get_var(my_ncid, varid, A)
+          END IF
+          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+            WRITE (stdout,10) TRIM(myVarName), TRIM(ncname),            &
+     &                        TRIM(SourceFile), nf90_strerror(status)
+            exit_flag=2
+            ioerror=status
+          END IF
+        ELSE
+          WRITE (stdout,20) TRIM(myVarName), TRIM(ncname),              &
+     &                      TRIM(SourceFile), nf90_strerror(status),    &
+     &                      nf90_strerror(status)
+          exit_flag=2
+          ioerror=status
+        END IF
+      END IF
+
+# if !defined PARALLEL_IO && defined DISTRIBUTE
+!
+!  Broadcast read variable to all processors in the group.
+!
+      ibuffer(1)=exit_flag
+      ibuffer(2)=ioerror
+      CALL mp_bcasti (ng, model, ibuffer)
+      exit_flag=ibuffer(1)
+      ioerror=ibuffer(2)
+      IF (DoBroadcast.and.(exit_flag.eq.NoError)) THEN
+        CALL mp_bcastf (ng, model, A)
+      END IF
+# endif
+!
+!  Check if the following attributes: "scale_factor", "add_offset", and
+!  "_FillValue" are present in the input NetCDF variable:
+!
+!  If the "scale_value" attribute is present, the data is multiplied by
+!  this factor after reading.
+!  If the "add_offset" attribute is present, this value is added to the
+!  data after reading.
+!  If both "scale_factor" and "add_offset" attributes are present, the
+!  data are first scaled before the offset is added.
+!  If the "_FillValue" attribute is present, the data having this value
+!  is treated as missing and it is replaced with zero. This feature it
+!  is usually related with the land/sea masking.
+!
+      AttName(1)='scale_factor'
+      AttName(2)='add_offset  '
+      AttName(3)='_FillValue  '
+
+      CALL netcdf_get_fatt (ng, model, ncname, varid, AttName,          &
+     &                      AttValue, foundit,                          &
+     &                      ncid = my_ncid)
+
+      IF (exit_flag.eq.NoError) THEN
+        IF (.not.foundit(1)) THEN
+          Afactor=1.0_r8
+        ELSE
+          Afactor=AttValue(1)
+        END IF
+
+        IF (.not.foundit(2)) THEN
+          Aoffset=0.0_r8
+        ELSE
+          Aoffset=AttValue(2)
+        END IF
+
+        IF (.not.foundit(3)) THEN
+          Aspval=spval_check
+        ELSE
+          Aspval=AttValue(3)
+        END IF
+
+        DO j=1,Asize(2)                       ! zero out missing values
+          DO i=1,Asize(1)
+            IF ((foundit(3).and.(ABS(A(i,j)-Aspval).lt.Aepsilon)).or.   &
+     &          (.not.foundit(3).and.(ABS(A(i,j)).ge.ABS(Aspval)))) THEN
+              A(i,j)=0.0_r8
+            END IF
+          END DO
+        END DO
+
+        IF (foundit(1)) THEN                  ! scale data
+          DO j=1,Asize(2)
+            DO i=1,Asize(1)
+              A(i,j)=Afactor*A(i,j)
+            END DO
+          END DO
+        END IF
+
+        IF (foundit(2)) THEN                  ! add data offset
+          DO j=1,Asize(2)
+            DO i=1,Asize(1)
+              A(i,j)=A(i,j)+Aoffset
+            END DO
+          END DO
+        END IF
+      END IF
+!
+!  Compute minimum and maximum values of read variable.
+!
+      IF (PRESENT(min_val)) THEN
+        min_val=MINVAL(A)
+      END IF
+      IF (PRESENT(max_val)) THEN
+        max_val=MAXVAL(A)
+      END IF
+!
+!  If NetCDF file ID is not provided, close input NetCDF file.
+!
+      IF (.not.PRESENT(ncid)) THEN
+        CALL netcdf_close (ng, model, my_ncid, ncname, .FALSE.)
+      END IF
+!
+  10  FORMAT (/,' NETCDF_GET_FVAR_2DP - error while reading variable:', &
+     &        2x,a,/,23x,'in input file:',2x,a,/,23x,'call from:',2x,a, &
+     &        /,23x,a)
+  20  FORMAT (/,' NETCDF_GET_FVAR_2DP - error while inquiring ID for ', &
+     &        'variable:',2x,a,/,23x,'in input file:',2x,a,/,23x,       &
+     &        'call from:',2x,a,/,23x,a)
+!
+      RETURN
+      END SUBROUTINE netcdf_get_fvar_2dp
+!
+      SUBROUTINE netcdf_get_fvar_3dp (ng, model, ncname, myVarName, A,  &
+     &                                ncid, start, total, broadcast,    &
+     &                                min_val, max_val)
+!
+!=======================================================================
+!                                                                      !
+!  This routine reads requested double-precision 3D-array variable     !
+!  from specified NetCDF file.                                         !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     ng           Nested grid number (integer)                        !
+!     model        Calling model identifier (integer)                  !
+!     ncname       NetCDF file name (string)                           !
+!     myVarName    Variable name (string)                              !
+!     ncid         NetCDF file ID (integer, OPTIONAL)                  !
+!     start        Starting index where the first of the data values   !
+!                    will be read along each dimension (integer,       !
+!                    OPTIONAL)                                         !
+!     total        Number of data values to be read along each         !
+!                    dimension (integer, OPTIONAL)                     !
+!     broadcast    Switch to broadcast read values from root to all    !
+!                    members of the communicator in distributed-       !
+!                    memory applications (logical, OPTIONAL,           !
+!                    default=TRUE)                                     !
+!                                                                      !
+!  On Ouput:                                                           !
+!                                                                      !
+!     A            Read 3D-array variable (real)                       !
+!     min_val      Read data minimum value (real, OPTIONAL)            !
+!     max_val      Read data maximum value (real, OPTIONAL)            !
+!                                                                      !
+!  Examples:                                                           !
+!                                                                      !
+!    CALL netcdf_get_fvar (ng, iNLM, 'file.nc', 'VarName', fvar)       !
+!                                                                      !
+!=======================================================================
+!
+!  Imported variable declarations.
+!
+      logical, intent(in), optional :: broadcast
+!
+      integer, intent(in) :: ng, model
+
+      integer, intent(in), optional :: ncid
+      integer, intent(in), optional :: start(:)
+      integer, intent(in), optional :: total(:)
+!
+      character (len=*), intent(in) :: ncname
+      character (len=*), intent(in) :: myVarName
+!
+      real(dp), intent(out), optional :: min_val
+      real(dp), intent(out), optional :: max_val
+
+      real(dp), intent(out) :: A(:,:,:)
+!
+!  Local variable declarations.
+!
+# if !defined PARALLEL_IO && defined DISTRIBUTE
+      logical :: DoBroadcast
+# endif
+      logical, dimension(3) :: foundit
+!
+      integer :: i, j, k, my_ncid, status, varid
+
+      integer, dimension(3) :: Asize
+
+# if !defined PARALLEL_IO && defined DISTRIBUTE
+      integer, dimension(2) :: ibuffer
+# endif
+!
+      real(dp) :: Afactor, Aoffset, Aspval
+
+      real(dp), parameter :: Aepsilon = 1.0E-8_r8
+
+      real(dp), dimension(3) :: AttValue
+!
+      character (len=12), dimension(3) :: AttName
+
+      character (len=*), parameter :: MyFile =                          &
+     &  __FILE__//", netcdf_get_fvar_3dp"
+!
+!-----------------------------------------------------------------------
+!  Read in a double-precision 3D-array variable.
+!-----------------------------------------------------------------------
+!
+      IF (PRESENT(start).and.PRESENT(total)) THEN
+        Asize(1)=total(1)
+        Asize(2)=total(2)
+        Asize(3)=total(3)
+      ELSE
+        Asize(1)=UBOUND(A, DIM=1)
+        Asize(2)=UBOUND(A, DIM=2)
+        Asize(3)=UBOUND(A, DIM=3)
+      END IF
+!
+!  If NetCDF file ID is not provided, open NetCDF for reading.
+!
+      IF (.not.PRESENT(ncid)) THEN
+        CALL netcdf_open (ng, model, TRIM(ncname), 0, my_ncid)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      ELSE
+        my_ncid=ncid
+      END IF
+
+# if !defined PARALLEL_IO && defined DISTRIBUTE
+!
+!  Determine if the read data is only needed and allocated by the master
+!  node ins distribute-memory applications.
+!
+      IF (.not.PRESENT(broadcast)) THEN
+        DoBroadcast=.TRUE.
+      ELSE
+        DoBroadcast=broadcast
+      END IF
+# endif
+!
+!  Read in variable.
+!
+      IF (InpThread) THEN
+        status=nf90_inq_varid(my_ncid, TRIM(myVarName), varid)
+        IF (status.eq.nf90_noerr) THEN
+          IF (PRESENT(start).and.PRESENT(total)) THEN
+            status=nf90_get_var(my_ncid, varid, A, start, total)
+          ELSE
+            status=nf90_get_var(my_ncid, varid, A)
+          END IF
+          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+            WRITE (stdout,10) TRIM(myVarName), TRIM(ncname),            &
+     &                        TRIM(SourceFile), nf90_strerror(status)
+            exit_flag=2
+            ioerror=status
+          END IF
+        ELSE
+          WRITE (stdout,20) TRIM(myVarName), TRIM(ncname),              &
+     &                      TRIM(SourceFile), nf90_strerror(status)
+          exit_flag=2
+          ioerror=status
+        END IF
+      END IF
+
+# if !defined PARALLEL_IO && defined DISTRIBUTE
+!
+!  Broadcast read variable to all processors in the group.
+!
+      ibuffer(1)=exit_flag
+      ibuffer(2)=ioerror
+      CALL mp_bcasti (ng, model, ibuffer)
+      exit_flag=ibuffer(1)
+      ioerror=ibuffer(2)
+      IF (DoBroadcast.and.(exit_flag.eq.NoError)) THEN
+        CALL mp_bcastf (ng, model, A)
+      END IF
+# endif
+!
+!  Check if the following attributes: "scale_factor", "add_offset", and
+!  "_FillValue" are present in the input NetCDF variable:
+!
+!  If the "scale_value" attribute is present, the data is multiplied by
+!  this factor after reading.
+!  If the "add_offset" attribute is present, this value is added to the
+!  data after reading.
+!  If both "scale_factor" and "add_offset" attributes are present, the
+!  data are first scaled before the offset is added.
+!  If the "_FillValue" attribute is present, the data having this value
+!  is treated as missing and it is replaced with zero. This feature it
+!  is usually related with the land/sea masking.
+!
+      AttName(1)='scale_factor'
+      AttName(2)='add_offset  '
+      AttName(3)='_FillValue  '
+
+      CALL netcdf_get_fatt (ng, model, ncname, varid, AttName,          &
+     &                      AttValue, foundit,                          &
+     &                      ncid = my_ncid)
+
+      IF (exit_flag.eq.NoError) THEN
+        IF (.not.foundit(1)) THEN
+          Afactor=1.0_r8
+        ELSE
+          Afactor=AttValue(1)
+        END IF
+
+        IF (.not.foundit(2)) THEN
+          Aoffset=0.0_r8
+        ELSE
+          Aoffset=AttValue(2)
+        END IF
+
+        IF (.not.foundit(3)) THEN
+          Aspval=spval_check
+        ELSE
+          Aspval=AttValue(3)
+        END IF
+
+        DO k=1,Asize(3)                       ! zero out missing values
+          DO j=1,Asize(2)
+            DO i=1,Asize(1)
+              IF ((foundit(3).and.                                      &
+     &             (ABS(A(i,j,k)-Aspval).lt.Aepsilon)).or.              &
+     &            (.not.foundit(3).and.                                 &
+     &             (ABS(A(i,j,k)).ge.ABS(Aspval)))) THEN
+                A(i,j,k)=0.0_r8
+              END IF
+            END DO
+          END DO
+        END DO
+
+        IF (foundit(1)) THEN                  ! scale data
+          DO k=1,Asize(3)
+            DO j=1,Asize(2)
+              DO i=1,Asize(1)
+                A(i,j,k)=Afactor*A(i,j,k)
+              END DO
+            END DO
+          END DO
+        END IF
+
+        IF (foundit(2)) THEN                  ! add data offset
+          DO k=1,Asize(3)
+            DO j=1,Asize(2)
+              DO i=1,Asize(1)
+                A(i,j,k)=A(i,j,k)+Aoffset
+              END DO
+            END DO
+          END DO
+        END IF
+      END IF
+!
+!  Compute minimum and maximum values of read variable.
+!
+      IF (PRESENT(min_val)) THEN
+        min_val=MINVAL(A)
+      END IF
+      IF (PRESENT(max_val)) THEN
+        max_val=MAXVAL(A)
+      END IF
+!
+!  If NetCDF file ID is not provided, close input NetCDF file.
+!
+      IF (.not.PRESENT(ncid)) THEN
+        CALL netcdf_close (ng, model, my_ncid, ncname, .FALSE.)
+      END IF
+!
+  10  FORMAT (/,' NETCDF_GET_FVAR_3DP - error while reading variable:', &
+     &        2x,a,/,23x,'in input file:',2x,a,/,23x,'call from:',2x,a, &
+     &        /,23x,a)
+  20  FORMAT (/,' NETCDF_GET_FVAR_3DP - error while inquiring ID for ', &
+     &        'variable:',2x,a,/,23x,'in input file:',2x,a,/,23x,       &
+     &        'call from:',2x,a,/,23x,a)
+!
+      RETURN
+      END SUBROUTINE netcdf_get_fvar_3dp
 #endif
 !
       SUBROUTINE netcdf_get_fvar_0d (ng, model, ncname, myVarName, A,   &
@@ -3003,11 +3466,6 @@
 !    CALL netcdf_get_fvar (ng, iNLM, 'file.nc', 'VarName', fvar(1))    !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcastf, mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -3175,11 +3633,6 @@
 !    CALL netcdf_get_fvar (ng, iNLM, 'file.nc', 'VarName', fvar(:,1))  !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcastf, mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -3421,11 +3874,6 @@
 !    CALL netcdf_get_fvar (ng, iNLM, 'file.nc', 'VarName', fvar(:,:,1))!
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcastf, mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -3671,11 +4119,6 @@
 !    CALL netcdf_get_fvar (ng, iNLM, 'file.nc', 'VarName', fvar)       !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcastf, mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -3930,11 +4373,6 @@
 !    CALL netcdf_get_fvar (ng, iNLM, 'file.nc', 'VarName', fvar)       !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcastf, mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -4193,11 +4631,6 @@
 !    CALL netcdf_get_lvar (ng, iNLM, 'file.nc', 'VarName', lvar(1))    !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti, mp_bcastl
-#endif
 !
 !  Imported variable declarations.
 !
@@ -4363,11 +4796,6 @@
 !    CALL netcdf_get_lvar (ng, iNLM, 'file.nc', 'VarName', lvar(:,1))  !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti, mp_bcastl
-#endif
 !
 !  Imported variable declarations.
 !
@@ -4532,11 +4960,6 @@
 !    CALL netcdf_get_ivar (ng, iNLM, 'file.nc', 'VarName', ivar(1))    !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -4664,11 +5087,6 @@
 !    CALL netcdf_get_ivar (ng, iNLM, 'file.nc', 'VarName', ivar(:,1))  !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -4794,11 +5212,6 @@
 !    CALL netcdf_get_ivar (ng, iNLM, 'file.nc', 'VarName', ivar(:,:,1))!
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -4932,11 +5345,6 @@
 !    CALL netcdf_get_svar (ng, iNLM, 'file.nc', 'VarName', ivar(1))    !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti, mp_bcasts
-#endif
 !
 !  Imported variable declarations.
 !
@@ -5069,11 +5477,6 @@
 !     A            Read 1D-array variable or array element (string)    !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti, mp_bcasts
-#endif
 !
 !  Imported variable declarations.
 !
@@ -5203,11 +5606,6 @@
 !     A            Read 2D-array variable or array element (string)    !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti, mp_bcasts
-#endif
 !
 !  Imported variable declarations.
 !
@@ -5337,11 +5735,6 @@
 !     A            Read 3D-array variable or element (string)          !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti, mp_bcasts
-#endif
 !
 !  Imported variable declarations.
 !
@@ -5477,9 +5870,6 @@
 !=======================================================================
 !
       USE dateclock_mod,  ONLY : datenum, datestr, time_units
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-      USE distribute_mod, ONLY : mp_bcastf, mp_bcasti
-#endif
       USE strings_mod,    ONLY : lowercase
 !
 !  Imported variable declarations.
@@ -5759,9 +6149,6 @@
 !=======================================================================
 !
       USE dateclock_mod,  ONLY : datenum, datestr, time_units
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-      USE distribute_mod, ONLY : mp_bcastf, mp_bcasti
-#endif
       USE strings_mod,    ONLY : lowercase
 !
 !  Imported variable declarations.
@@ -6022,9 +6409,9 @@
 !
 !=======================================================================
 !                                                                      !
-!  This routine writes a double-precision floating-point scalar        !
-!  variable into a NetCDF file. If the NetCDF ID is not provided,      !
-!  it opens the file, writes data, and then closes the file.           !
+!  This routine writes a double-precision scalar variable into a       !
+!  NetCDF file. If the NetCDF ID is not provided, it opens the file,   !
+!  writes data, and then closes the file.                              !
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
@@ -6048,11 +6435,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-# if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-# endif
 !
 !  Imported variable declarations.
 !
@@ -6081,7 +6463,7 @@
      &  __FILE__//", netcdf_put_fvar_0dp"
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a double-precision scalar variable.
 !-----------------------------------------------------------------------
 !
 !  If file ID is not provided, open file for writing.
@@ -6144,11 +6526,11 @@
       END IF
 !
   10  FORMAT (/,' NETCDF_PUT_FVAR_0DP - error while inquiring ID for ', &
-     &        'variable:',2x,a,/,22x,'in input file:',2x,a,/,22x,       &
-     &        'call from:',2x,a,/,22x,a)
+     &        'variable:',2x,a,/,23x,'in input file:',2x,a,/,23x,       &
+     &        'call from:',2x,a,/,23x,a)
   20  FORMAT (/,' NETCDF_PUT_FVAR_0DP - error while writing variable:', &
-     &        2x,a,/,22x,'in input file:',2x,a,/,22x,'call from:',2x,a, &
-     &        /,22x,a)
+     &        2x,a,/,23x,'in input file:',2x,a,/,23x,'call from:',2x,a, &
+     &        /,23x,a)
 !
       RETURN
       END SUBROUTINE netcdf_put_fvar_0dp
@@ -6158,9 +6540,9 @@
 !
 !=======================================================================
 !                                                                      !
-!  This routine writes a double-precision floating-point 1D-array      !
-!  variable into a file. If the NetCDF ID is not provided, it opens    !
-!  the file, writes data, and then closes the file.                    !
+!  This routine writes a double-precision 1D-array variable into a     !
+!  file. If the NetCDF ID is not provided, it opens the file, writes   !
+!  data, and then closes the file.                                     !
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
@@ -6184,11 +6566,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-# if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-# endif
 !
 !  Imported variable declarations.
 !
@@ -6215,7 +6592,7 @@
      &  __FILE__//", netcdf_put_fvar_1dp"
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a double-precision 1D-array variable.
 !-----------------------------------------------------------------------
 !
 !  If file ID is not provided, open file for writing.
@@ -6273,11 +6650,11 @@
       END IF
 !
   10  FORMAT (/,' NETCDF_PUT_FVAR_1DP - error while inquiring ID for ', &
-     &        'variable:',2x,a,/,22x,'in input file:',2x,a,/,22x,       &
-     &        'call from:',2x,a,/,22x,a)
+     &        'variable:',2x,a,/,23x,'in input file:',2x,a,/,23x,       &
+     &        'call from:',2x,a,/,23x,a)
   20  FORMAT (/,' NETCDF_PUT_FVAR_1DP - error while writing variable:', &
-     &        2x,a,/,22x,'in input file:',2x,a,/,22x,'call from:',2x,a, &
-     &        /,22x,a)
+     &        2x,a,/,23x,'in input file:',2x,a,/,23x,'call from:',2x,a, &
+     &        /,23x,a)
 !
       RETURN
       END SUBROUTINE netcdf_put_fvar_1dp
@@ -6287,9 +6664,9 @@
 !
 !=======================================================================
 !                                                                      !
-!  This routine writes a double-precision floating-point 2D-array      !
-!  variable into a file. If the NetCDF ID is not provided, it opens    !
-!  the file, writes data, and then closes the file.                    !
+!  This routine writes a double-precision 2D-array variable into a     !
+!  file. If the NetCDF ID is not provided, it opens the file, writes   !
+!  data, and then closes the file.                                     !
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
@@ -6313,11 +6690,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-# if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-# endif
 !
 !  Imported variable declarations.
 !
@@ -6344,7 +6716,7 @@
      &  __FILE__//", netcdf_put_fvar_2dp"
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a double-precision 2D-array variable.
 !-----------------------------------------------------------------------
 !
 !  If file ID is not provided, open file for writing.
@@ -6402,14 +6774,138 @@
       END IF
 !
   10  FORMAT (/,' NETCDF_PUT_FVAR_2DP - error while inquiring ID for ', &
-     &        'variable:',2x,a,/,22x,'in input file:',2x,a,/,22x,       &
-     &        'call from:',2x,a,/22x,a)
+     &        'variable:',2x,a,/,23x,'in input file:',2x,a,/,22x,       &
+     &        'call from:',2x,a,/23x,a)
   20  FORMAT (/,' NETCDF_PUT_FVAR_2DP - error while writing variable:', &
-     &        2x,a,/,22x,'in input file:',2x,a,/,22x,'call from:',2x,a, &
-     &        /,22x,a)
+     &        2x,a,/,23x,'in input file:',2x,a,/,23x,'call from:',2x,a, &
+     &        /,23x,a)
 !
       RETURN
       END SUBROUTINE netcdf_put_fvar_2dp
+!
+      SUBROUTINE netcdf_put_fvar_3dp (ng, model, ncname, myVarName, A,  &
+     &                                start, total, ncid, varid)
+!
+!=======================================================================
+!                                                                      !
+!  This routine writes a double-precision 3D-array variable into a     !
+!  file. If the NetCDF ID is not provided, it opens the file, writes   !
+!  data, and then closes the file.                                     !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     ng           Nested grid number (integer)                        !
+!     model        Calling model identifier (integer)                  !
+!     ncname       NetCDF file name (string)                           !
+!     myVarName    Variable name (string)                              !
+!     A            Data value(s) to be written (real)                  !
+!     start        Starting index where the first of the data values   !
+!                    will be written along each dimension (integer)    !
+!     total        Number of data values to be written along each      !
+!                    dimension (integer)                               !
+!     ncid         NetCDF file ID (integer, OPTIONAL)                  !
+!     varid        NetCDF variable ID (integer, OPTIONAL)              !
+!                                                                      !
+!  On Ouput:                                                           !
+!                                                                      !
+!     exit_flag    Error flag (integer) stored in MOD_SCALARS          !
+!     ioerror      NetCDF return code (integer) stored in MOD_IOUNITS  !
+!                                                                      !
+!  Notice: This routine must be used to write only nontiled variables. !
+!                                                                      !
+!=======================================================================
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, model
+
+      integer, intent(in) :: start(:), total(:)
+
+      integer, intent(in), optional :: ncid, varid
+!
+      real(dp), intent(in) :: A(:,:,:)
+!
+      character (len=*), intent(in) :: ncname
+      character (len=*), intent(in) :: myVarName
+!
+!  Local variable declarations.
+!
+      integer :: my_ncid, my_varid, status
+
+# if !defined PARALLEL_IO && defined DISTRIBUTE
+      integer, dimension(2) :: ibuffer
+# endif
+!
+      character (len=*), parameter :: MyFile =                          &
+     &  __FILE__//", netcdf_put_fvar_3dp"
+!
+!-----------------------------------------------------------------------
+!  Read in a double-precision 3D-array variable.
+!-----------------------------------------------------------------------
+!
+!  If file ID is not provided, open file for writing.
+!
+      IF (.not.PRESENT(ncid)) THEN
+        CALL netcdf_open (ng, model, TRIM(ncname), 1, my_ncid)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      ELSE
+        my_ncid=ncid
+      END IF
+!
+!  If variable ID is not provided, inquire its value.
+!
+      IF (OutThread) THEN
+        IF (.not.PRESENT(varid)) THEN
+          status=nf90_inq_varid(my_ncid, TRIM(myVarName), my_varid)
+          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+            WRITE (stdout,10) TRIM(myVarName), TRIM(ncname),            &
+     &                        TRIM(SourceFile), nf90_strerror(status)
+            exit_flag=3
+            ioerror=status
+          END IF
+        ELSE
+          my_varid=varid
+        END IF
+!
+!  Write out data.
+!
+        IF (exit_flag.eq.NoError) THEN
+          status=nf90_put_var(my_ncid, my_varid, A, start, total)
+          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+            WRITE (stdout,20) TRIM(myVarName), TRIM(ncname),            &
+     &                        TRIM(SourceFile), nf90_strerror(status)
+            exit_flag=3
+            ioerror=status
+          END IF
+        END IF
+      END IF
+
+# if !defined PARALLEL_IO && defined DISTRIBUTE
+!
+!  Broadcast error flags to all processors in the group.
+!
+      ibuffer(1)=exit_flag
+      ibuffer(2)=ioerror
+      CALL mp_bcasti (ng, model, ibuffer)
+      exit_flag=ibuffer(1)
+      ioerror=ibuffer(2)
+# endif
+!
+!  Close input NetCDF file.
+!
+      IF (.not.PRESENT(ncid)) THEN
+        CALL netcdf_close (ng, model, my_ncid, ncname, .FALSE.)
+      END IF
+!
+  10  FORMAT (/,' NETCDF_PUT_FVAR_3DP - error while inquiring ID for ', &
+     &        'variable:',2x,a,/,23x,'in input file:',2x,a,/,22x,       &
+     &        'call from:',2x,a,/,23x,a)
+  20  FORMAT (/,' NETCDF_PUT_FVAR_3DP - error while writing variable:', &
+     &        2x,a,/,23x,'in input file:',2x,a,/,23x,'call from:',2x,a, &
+     &        /,23x,a)
+!
+      RETURN
+      END SUBROUTINE netcdf_put_fvar_3dp
 #endif
 !
       SUBROUTINE netcdf_put_fvar_0d (ng, model, ncname, myVarName, A,   &
@@ -6443,11 +6939,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -6579,11 +7070,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -6610,7 +7096,7 @@
      &  __FILE__//", netcdf_put_fvar_1d"
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a floating-point 1D-array variable.
 !-----------------------------------------------------------------------
 !
 !  If file ID is not provided, open file for writing.
@@ -6708,11 +7194,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -6739,7 +7220,7 @@
      &  __FILE__//", netcdf_put_fvar_2d"
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a floating-point 2D-array variable.
 !-----------------------------------------------------------------------
 !
 !  If file ID is not provided, open file for writing.
@@ -6837,11 +7318,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -6868,7 +7344,7 @@
      &  __FILE__//", netcdf_put_fvar_3d"
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a floating-point 3D-array variable.
 !-----------------------------------------------------------------------
 !
 !  If file ID is not provided, open file for writing.
@@ -6966,11 +7442,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -6997,7 +7468,7 @@
      &  __FILE__//", netcdf_put_fvar_4d"
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a floating-point 4D-array variable.
 !-----------------------------------------------------------------------
 !
 !  If NetCDF file ID is not provided, open NetCDF for writing.
@@ -7095,11 +7566,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -7231,11 +7697,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -7360,11 +7821,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -7492,11 +7948,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -7642,16 +8093,6 @@
 !                                                                      !
 !=======================================================================
 !
-      USE mod_param
-      USE mod_parallel
-      USE mod_iounits
-      USE mod_scalars
-!
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
-      USE strings_mod,    ONLY : FoundError
-!
 !  Imported variable declarations.
 !
       integer, intent(in) :: ng, model
@@ -7791,11 +8232,6 @@
 !  Notice: This routine must be used to write only nontiled variables. !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -7944,11 +8380,6 @@
 !     ioerror      NetCDF return code (integer) stored in MOD_IOUNITS  !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -8089,11 +8520,6 @@
 !     ioerror      NetCDF return code (integer) stored in MOD_IOUNITS  !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -8228,11 +8654,6 @@
 !     ioerror      NetCDF return code (integer) stored in MOD_IOUNITS  !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -8367,11 +8788,6 @@
 !     ioerror      NetCDF return code (integer) stored in MOD_IOUNITS  !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -8482,11 +8898,6 @@
 !     Lupdate      Update global attribute (logical, OPTIONAl)         !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -8648,11 +9059,6 @@
 !     ncid         NetCDF file ID (integer)                            !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -8785,11 +9191,6 @@
 !          NetCDF-4 format type file.                                  !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -8865,11 +9266,6 @@
 !     ncid         NetCDF file ID (integer)                            !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -9014,11 +9410,6 @@
 !          NetCDF-4 format type files.                                 !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !
@@ -9087,11 +9478,6 @@
 !  See NetCDF user manual for more details.                            !
 !                                                                      !
 !=======================================================================
-
-#if !defined PARALLEL_IO && defined DISTRIBUTE
-!
-      USE distribute_mod, ONLY : mp_bcasti
-#endif
 !
 !  Imported variable declarations.
 !

--- a/ROMS/Modules/mod_pio_netcdf.F
+++ b/ROMS/Modules/mod_pio_netcdf.F
@@ -54,6 +54,8 @@
 # ifdef SINGLE_PRECISION
         MODULE PROCEDURE pio_netcdf_get_fvar_0dp
         MODULE PROCEDURE pio_netcdf_get_fvar_1dp
+        MODULE PROCEDURE pio_netcdf_get_fvar_2dp
+        MODULE PROCEDURE pio_netcdf_get_fvar_3dp
 # endif
         MODULE PROCEDURE pio_netcdf_get_fvar_0d
         MODULE PROCEDURE pio_netcdf_get_fvar_1d
@@ -95,6 +97,7 @@
         MODULE PROCEDURE pio_netcdf_put_fvar_0dp
         MODULE PROCEDURE pio_netcdf_put_fvar_1dp
         MODULE PROCEDURE pio_netcdf_put_fvar_2dp
+        MODULE PROCEDURE pio_netcdf_put_fvar_3dp
 # endif
         MODULE PROCEDURE pio_netcdf_put_fvar_0d
         MODULE PROCEDURE pio_netcdf_put_fvar_1d
@@ -3275,6 +3278,451 @@
 !
       RETURN
       END SUBROUTINE pio_netcdf_get_fvar_1dp
+!
+      SUBROUTINE pio_netcdf_get_fvar_2dp (ng, model, ncname, myVarName, &
+     &                                    A, pioFile, start, total,     &
+     &                                    broadcast, min_val, max_val)
+!
+!=======================================================================
+!                                                                      !
+!  This routine reads requested double-precision 2D-array variable     !
+!  from specified NetCDF file.                                         !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     ng           Nested grid number (integer)                        !
+!     model        Calling model identifier (integer)                  !
+!     ncname       NetCDF file name (string)                           !
+!     myVarName    Variable name (string)                              !
+!     pioFile      PIO file descriptor, TYPE(File_desc_t), OPTIONAL    !
+!                    pioFile%fh         file handler                   !
+!                    pioFile%iosystem   IO system descriptor (struct)  !
+!     start        Starting index where the first of the data values   !
+!                    will be read along each dimension (integer,       !
+!                    OPTIONAL)                                         !
+!     total        Number of data values to be read along each         !
+!                    dimension (integer, OPTIONAL)                     !
+!     broadcast    Switch to broadcast read values from root to all    !
+!                    members of the communicator in distributed-       !
+!                    memory applications (logical, OPTIONAL). It is    !
+!                    ignored since PIO library broadcasts the values   !
+!                    to all member in the group by default.            !
+!                                                                      !
+!  On Ouput:                                                           !
+!                                                                      !
+!     A            Read 2D-array variable (real)                       !
+!     min_val      Read data minimum value (real, OPTIONAL)            !
+!     max_val      Read data maximum value (real, OPTIONAL)            !
+!                                                                      !
+!  Examples:                                                           !
+!                                                                      !
+!    CALL pio_netcdf_get_fvar (ng, iNLM, 'f.nc', 'VarName', A)         !
+!    CALL pio_netcdf_get_fvar (ng, iNLM, 'f.nc', 'VarName', A(0:,:))   !
+!    CALL pio_netcdf_get_fvar (ng, iNLM, 'f.nc', 'VarName', A(0:,0:))  !
+!    CALL pio_netcdf_get_fvar (ng, iNLM, 'f.nc', 'VarName', A(:,:,1))  !
+!                                                                      !
+!=======================================================================
+!
+!  Imported variable declarations.
+!
+      logical, intent(in), optional :: broadcast
+!
+      integer, intent(in) :: ng, model
+
+      integer, intent(in), optional :: start(:)
+      integer, intent(in), optional :: total(:)
+!
+      character (len=*), intent(in) :: ncname
+      character (len=*), intent(in) :: myVarName
+!
+      real(dp), intent(out), optional :: min_val
+      real(dp), intent(out), optional :: max_val
+
+      real(dp), intent(out) :: A(:,:)
+!
+      TYPE (File_desc_t), intent(in), optional :: pioFile
+!
+!  Local variable declarations.
+!
+      logical, dimension(3) :: foundit
+!
+      integer :: i, j, status
+
+      integer, dimension(2) :: Asize
+!
+      real(dp) :: Afactor, Aoffset, Aspval
+
+      real(dp), parameter :: Aepsilon = 1.0E-8_r8
+
+      real(dp), dimension(3) :: AttValue
+!
+      character (len=12), dimension(3) :: AttName
+
+      character (len=*), parameter :: MyFile =                          &
+     &  __FILE__//", pio_netcdf_get_fvar_2dp"
+!
+      TYPE (File_desc_t) :: my_pioFile
+      TYPE (Var_desc_t)  :: my_pioVar
+!
+!-----------------------------------------------------------------------
+!  Read in a floating-point 2D-array variable.
+!-----------------------------------------------------------------------
+!
+      IF (PRESENT(start).and.PRESENT(total)) THEN
+        Asize(1)=total(1)
+        Asize(2)=total(2)
+      ELSE
+        Asize(1)=UBOUND(A, DIM=1)
+        Asize(2)=UBOUND(A, DIM=2)
+      END IF
+!
+!  If file descriptor is not provided, open NetCDF for reading.
+!
+      IF (.not.PRESENT(pioFile)) THEN
+        CALL pio_netcdf_open (ng, model, TRIM(ncname), 0, my_pioFile)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      ELSE
+        my_pioFile=pioFile
+      END IF
+!
+!  Read in variable.
+!
+      status=PIO_inq_varid(my_pioFile, TRIM(myVarName), my_pioVar)
+      IF (status.eq.PIO_noerr) THEN
+        IF (PRESENT(start).and.PRESENT(total)) THEN
+          status=PIO_get_var(my_pioFile, my_pioVar, start, total, A)
+        ELSE
+          status=PIO_get_var(my_pioFile, my_pioVar, A)
+        END IF
+        IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+          IF (Master) WRITE (stdout,10) TRIM(myVarName), TRIM(ncname),  &
+     &                                  TRIM(SourceFile)
+          exit_flag=2
+          ioerror=status
+        END IF
+      ELSE
+        IF (Master) WRITE (stdout,20) TRIM(myVarName), TRIM(ncname),    &
+     &                                TRIM(SourceFile)
+        exit_flag=2
+        ioerror=status
+      END IF
+!
+!  Check if the following attributes: "scale_factor", "add_offset", and
+!  "_FillValue" are present in the input NetCDF variable:
+!
+!  If the "scale_value" attribute is present, the data is multiplied by
+!  this factor after reading.
+!  If the "add_offset" attribute is present, this value is added to the
+!  data after reading.
+!  If both "scale_factor" and "add_offset" attributes are present, the
+!  data are first scaled before the offset is added.
+!  If the "_FillValue" attribute is present, the data having this value
+!  is treated as missing and it is replaced with zero. This feature it
+!  is usually related with the land/sea masking.
+!
+      AttName(1)='scale_factor'
+      AttName(2)='add_offset  '
+      AttName(3)='_FillValue  '
+
+      CALL pio_netcdf_get_fatt (ng, model, ncname, my_pioVar,           &
+     &                          AttName, AttValue, foundit,             &
+     &                          pioFile = my_pioFile)
+
+      IF (exit_flag.eq.NoError) THEN
+        IF (.not.foundit(1)) THEN
+          Afactor=1.0_r8
+        ELSE
+          Afactor=AttValue(1)
+        END IF
+
+        IF (.not.foundit(2)) THEN
+          Aoffset=0.0_r8
+        ELSE
+          Aoffset=AttValue(2)
+        END IF
+
+        IF (.not.foundit(3)) THEN
+          Aspval=spval_check
+        ELSE
+          Aspval=AttValue(3)
+        END IF
+
+        DO j=1,Asize(2)                       ! zero out missing values
+          DO i=1,Asize(1)
+            IF ((foundit(3).and.(ABS(A(i,j)-Aspval).lt.Aepsilon)).or.   &
+     &          (.not.foundit(3).and.(ABS(A(i,j)).ge.ABS(Aspval)))) THEN
+              A(i,j)=0.0_r8
+            END IF
+          END DO
+        END DO
+
+        IF (foundit(1)) THEN                  ! scale data
+          DO j=1,Asize(2)
+            DO i=1,Asize(1)
+              A(i,j)=Afactor*A(i,j)
+            END DO
+          END DO
+        END IF
+
+        IF (foundit(2)) THEN                  ! add data offset
+          DO j=1,Asize(2)
+            DO i=1,Asize(1)
+              A(i,j)=A(i,j)+Aoffset
+            END DO
+          END DO
+        END IF
+      END IF
+!
+!  Compute minimum and maximum values of read variable.
+!
+      IF (PRESENT(min_val)) THEN
+        min_val=MINVAL(A)
+      END IF
+      IF (PRESENT(max_val)) THEN
+        max_val=MAXVAL(A)
+      END IF
+!
+!  If file descriptor is not provided, close input NetCDF file.
+!
+      IF (.not.PRESENT(pioFile)) THEN
+        CALL pio_netcdf_close (ng, model, my_pioFile, ncname, .FALSE.)
+      END IF
+!
+  10  FORMAT (/,' PIO_NETCDF_GET_FVAR_2DP - error while reading ',      &
+     &        'variable:',2x,a,/,27x,'in input file:',2x,a,             &
+     &        /,27x,'call from:',2x,a)
+  20  FORMAT (/,' PIO_NETCDF_GET_FVAR_2DP0 - error while inquiring ',   &
+     &        'descriptor for variable:',2x,a,/,27x,'in input file:',   &
+     &        2x,a,/,27x,'call from:',2x,a)
+!
+      RETURN
+      END SUBROUTINE pio_netcdf_get_fvar_2dp
+!
+      SUBROUTINE pio_netcdf_get_fvar_3dp (ng, model, ncname, myVarName, &
+     &                                    A, pioFile, start, total,     &
+     &                                    broadcast, min_val, max_val)
+!
+!=======================================================================
+!                                                                      !
+!  This routine reads requested double-precision 3D-array variable     !
+!  from specified NetCDF file.                                         !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     ng           Nested grid number (integer)                        !
+!     model        Calling model identifier (integer)                  !
+!     ncname       NetCDF file name (string)                           !
+!     myVarName    Variable name (string)                              !
+!     pioFile      PIO file descriptor, TYPE(File_desc_t), OPTIONAL    !
+!                    pioFile%fh         file handler                   !
+!                    pioFile%iosystem   IO system descriptor (struct)  !
+!     start        Starting index where the first of the data values   !
+!                    will be read along each dimension (integer,       !
+!                    OPTIONAL)                                         !
+!     total        Number of data values to be read along each         !
+!                    dimension (integer, OPTIONAL)                     !
+!     broadcast    Switch to broadcast read values from root to all    !
+!                    members of the communicator in distributed-       !
+!                    memory applications (logical, OPTIONAL). It is    !
+!                    ignored since PIO library broadcasts the values   !
+!                    to all member in the group by default.            !
+!                                                                      !
+!  On Ouput:                                                           !
+!                                                                      !
+!     A            Read 3D-array variable (real)                       !
+!     min_val      Read data minimum value (real, OPTIONAL)            !
+!     max_val      Read data maximum value (real, OPTIONAL)            !
+!                                                                      !
+!  Examples:                                                           !
+!                                                                      !
+!    CALL pio_netcdf_get_fvar (ng, iNLM, 'f.nc', 'VarName', A)         !
+!                                                                      !
+!=======================================================================
+!
+!  Imported variable declarations.
+!
+      logical, intent(in), optional :: broadcast
+!
+      integer, intent(in) :: ng, model
+
+      integer, intent(in), optional :: start(:)
+      integer, intent(in), optional :: total(:)
+!
+      character (len=*), intent(in) :: ncname
+      character (len=*), intent(in) :: myVarName
+!
+      real(dp), intent(out), optional :: min_val
+      real(dp), intent(out), optional :: max_val
+
+      real(dp), intent(out) :: A(:,:,:)
+!
+      TYPE (File_desc_t), intent(in), optional :: pioFile
+!
+!  Local variable declarations.
+!
+      logical, dimension(3) :: foundit
+!
+      integer :: i, j, k, status
+
+      integer, dimension(3) :: Asize
+!
+      real(dp) :: Afactor, Aoffset, Aspval
+
+      real(dp), parameter :: Aepsilon = 1.0E-8_r8
+
+      real(dp), dimension(3) :: AttValue
+!
+      character (len=12), dimension(3) :: AttName
+
+      character (len=*), parameter :: MyFile =                          &
+     &  __FILE__//", pio_netcdf_get_fvar_3dp"
+!
+      TYPE (File_desc_t) :: my_pioFile
+      TYPE (Var_desc_t)  :: my_pioVar
+!
+!-----------------------------------------------------------------------
+!  Read in a floating-point 2D-array variable.
+!-----------------------------------------------------------------------
+!
+      IF (PRESENT(start).and.PRESENT(total)) THEN
+        Asize(1)=total(1)
+        Asize(2)=total(2)
+        Asize(3)=total(3)
+      ELSE
+        Asize(1)=UBOUND(A, DIM=1)
+        Asize(2)=UBOUND(A, DIM=2)
+        Asize(3)=UBOUND(A, DIM=3)
+      END IF
+!
+!  If file descriptor is not provided, open NetCDF for reading.
+!
+      IF (.not.PRESENT(pioFile)) THEN
+        CALL pio_netcdf_open (ng, model, TRIM(ncname), 0, my_pioFile)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      ELSE
+        my_pioFile=pioFile
+      END IF
+!
+!  Read in variable.
+!
+      status=PIO_inq_varid(my_pioFile, TRIM(myVarName), my_pioVar)
+      IF (status.eq.PIO_noerr) THEN
+        IF (PRESENT(start).and.PRESENT(total)) THEN
+          status=PIO_get_var(my_pioFile, my_pioVar, start, total, A)
+        ELSE
+          status=PIO_get_var(my_pioFile, my_pioVar, A)
+        END IF
+        IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+          IF (Master) WRITE (stdout,10) TRIM(myVarName), TRIM(ncname),  &
+     &                                  TRIM(SourceFile)
+          exit_flag=2
+          ioerror=status
+        END IF
+      ELSE
+        IF (Master) WRITE (stdout,20) TRIM(myVarName), TRIM(ncname),    &
+     &                                TRIM(SourceFile)
+        exit_flag=2
+        ioerror=status
+      END IF
+!
+!  Check if the following attributes: "scale_factor", "add_offset", and
+!  "_FillValue" are present in the input NetCDF variable:
+!
+!  If the "scale_value" attribute is present, the data is multiplied by
+!  this factor after reading.
+!  If the "add_offset" attribute is present, this value is added to the
+!  data after reading.
+!  If both "scale_factor" and "add_offset" attributes are present, the
+!  data are first scaled before the offset is added.
+!  If the "_FillValue" attribute is present, the data having this value
+!  is treated as missing and it is replaced with zero. This feature it
+!  is usually related with the land/sea masking.
+!
+      AttName(1)='scale_factor'
+      AttName(2)='add_offset  '
+      AttName(3)='_FillValue  '
+
+      CALL pio_netcdf_get_fatt (ng, model, ncname, my_pioVar,           &
+     &                          AttName, AttValue, foundit,             &
+     &                          pioFile = my_pioFile)
+
+      IF (exit_flag.eq.NoError) THEN
+        IF (.not.foundit(1)) THEN
+          Afactor=1.0_r8
+        ELSE
+          Afactor=AttValue(1)
+        END IF
+
+        IF (.not.foundit(2)) THEN
+          Aoffset=0.0_r8
+        ELSE
+          Aoffset=AttValue(2)
+        END IF
+
+        IF (.not.foundit(3)) THEN
+          Aspval=spval_check
+        ELSE
+          Aspval=AttValue(3)
+        END IF
+
+        DO k=1,Asize(3)                       ! zero out missing values
+          DO j=1,Asize(2)
+            DO i=1,Asize(1)
+              IF ((foundit(3).and.                                      &
+     &             (ABS(A(i,j,k)-Aspval).lt.Aepsilon)).or.              &
+     &            (.not.foundit(3).and.                                 &
+     &             (ABS(A(i,j,k)).ge.ABS(Aspval)))) THEN
+                A(i,j,k)=0.0_r8
+              END IF
+            END DO
+          END DO
+        END DO
+
+        IF (foundit(1)) THEN                  ! scale data
+          DO k=1,Asize(3)
+            DO j=1,Asize(2)
+              DO i=1,Asize(1)
+                A(i,j,k)=Afactor*A(i,j,k)
+              END DO
+            END DO
+          END DO
+        END IF
+
+        IF (foundit(2)) THEN                  ! add data offset
+          DO k=1,Asize(3)
+            DO j=1,Asize(2)
+              DO i=1,Asize(1)
+                A(i,j,k)=A(i,j,k)+Aoffset
+              END DO
+            END DO
+          END DO
+        END IF
+      END IF
+!
+!  Compute minimum and maximum values of read variable.
+!
+      IF (PRESENT(min_val)) THEN
+        min_val=MINVAL(A)
+      END IF
+      IF (PRESENT(max_val)) THEN
+        max_val=MAXVAL(A)
+      END IF
+!
+!  If file descriptor is not provided, close input NetCDF file.
+!
+      IF (.not.PRESENT(pioFile)) THEN
+        CALL pio_netcdf_close (ng, model, my_pioFile, ncname, .FALSE.)
+      END IF
+!
+  10  FORMAT (/,' PIO_NETCDF_GET_FVAR_3DP - error while reading ',      &
+     &        'variable:',2x,a,/,27x,'in input file:',2x,a,             &
+     &        /,27x,'call from:',2x,a)
+  20  FORMAT (/,' PIO_NETCDF_GET_FVAR_3DP - error while inquiring ',    &
+     &        'descriptor for variable:',2x,a,/,27x,'in input file:',   &
+     &        2x,a,/,27x,'call from:',2x,a)
+!
+      RETURN
+      END SUBROUTINE pio_netcdf_get_fvar_3dp
 # endif
 !
       SUBROUTINE pio_netcdf_get_fvar_0d (ng, model, ncname, myVarName,  &
@@ -6140,7 +6588,7 @@
       TYPE (Var_desc_t)  :: my_pioVar
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a double-precision 1D-array variable.
 !-----------------------------------------------------------------------
 !
 !  If file descriptor is not provided, open file for writing.
@@ -6255,7 +6703,7 @@
       TYPE (Var_desc_t)  :: my_pioVar
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a double-precision 2D-array variable.
 !-----------------------------------------------------------------------
 !
 !  If file descriptor is not provided, open file for writing.
@@ -6308,6 +6756,121 @@
 !
       RETURN
       END SUBROUTINE pio_netcdf_put_fvar_2dp
+!
+      SUBROUTINE pio_netcdf_put_fvar_3dp (ng, model, ncname, myVarName, &
+     &                                    A, start, total,              &
+     &                                    pioFile, pioVar)
+!
+!=======================================================================
+!                                                                      !
+!  It writes a double-precision 3D-array variable into a NetCDF file.  !
+!  If the file descritor is not provided, it opens the file, writes    !
+!  data, and then closes the file.                                     !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     ng           Nested grid number (integer)                        !
+!     model        Calling model identifier (integer)                  !
+!     ncname       NetCDF file name (string)                           !
+!     myVarName    Variable name (string)                              !
+!     A            Data value(s) to be written (real)                  !
+!     start        Starting index where the first of the data values   !
+!                    will be written along each dimension (integer)    !
+!     total        Number of data values to be written along each      !
+!                    dimension (integer)                               !
+!     pioFile      PIO file descriptor, TYPE(File_desc_t), OPTIONAL    !
+!                    pioFile%fh         file handler                   !
+!                    pioFile%iosystem   IO system descriptor (struct)  !
+!     pioVar       PIO variable descriptor, TYPE(Var_desc_t), OPTIONAL !
+!                    pioVar%varID       Variable ID                    !
+!                    pioVar%ncid        File ID                        !
+!                                                                      !
+!  On Ouput:                                                           !
+!                                                                      !
+!     exit_flag    Error flag (integer) stored in MOD_SCALARS          !
+!     ioerror      NetCDF return code (integer) stored in MOD_IOUNITS  !
+!                                                                      !
+!  Notice: This routine must be used to write only nontiled variables. !
+!                                                                      !
+!=======================================================================
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, model
+      integer, intent(in) :: start(:), total(:)
+!
+      real(dp), intent(in) :: A(:,:,:)
+!
+      character (len=*), intent(in) :: ncname
+      character (len=*), intent(in) :: myVarName
+!
+      TYPE (File_desc_t), intent(in), optional :: pioFile
+      TYPE (Var_desc_t),  intent(in), optional :: pioVar
+!
+!  Local variable declarations.
+!
+      integer :: status
+!
+      character (len=*), parameter :: MyFile =                          &
+     &  __FILE__//", pio_netcdf_put_fvar_3dp"
+!
+      TYPE (File_desc_t) :: my_pioFile
+      TYPE (Var_desc_t)  :: my_pioVar
+!
+!-----------------------------------------------------------------------
+!  Read in a double-repcision 3D-array variable.
+!-----------------------------------------------------------------------
+!
+!  If file descriptor is not provided, open file for writing.
+!
+      IF (.not.PRESENT(pioFile)) THEN
+        CALL pio_netcdf_open (ng, model, TRIM(ncname), 1, my_pioFile)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      ELSE
+        my_pioFile=pioFile
+      END IF
+!
+!  If variable descriptor is not provided, inquire its value.
+!
+      IF (.not.PRESENT(pioVar)) THEN
+        status=PIO_inq_varid(my_pioFile, TRIM(myVarName), my_pioVar)
+        IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+          IF (Master) WRITE (stdout,10) TRIM(myVarName), TRIM(ncname),  &
+     &                                  TRIM(SourceFile)
+          exit_flag=3
+          ioerror=status
+        END IF
+      ELSE
+        my_pioVar=pioVar
+      END IF
+!
+!  Write out data.
+!
+      IF (exit_flag.eq.NoError) THEN
+        status=PIO_put_var(my_pioFile, my_pioVar, start, total, A)
+        IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+          IF (Master) WRITE (stdout,20) TRIM(myVarName), TRIM(ncname),  &
+     &                                  TRIM(SourceFile)
+          exit_flag=3
+          ioerror=status
+        END IF
+      END IF
+!
+!  Close input file.
+!
+      IF (.not.PRESENT(pioFile)) THEN
+        CALL pio_netcdf_close (ng, model, my_pioFile, ncname, .FALSE.)
+      END IF
+!
+  10  FORMAT (/,' PIO_NETCDF_PUT_FVAR_3DP - error while inquiring ',    &
+     &        'descriptor for variable:',2x,a,/,27x,'in input file:',   &
+     &        2x,a,/,27x,'call from:',2x,a,/,27x,a)
+  20  FORMAT (/,' PIO_NETCDF_PUT_FVAR_3DP - error while writing ',      &
+     &        'variable:',2x,a,/,27x,'in input file:',2x,a,             &
+     &        /,27x,'call from:',2x,a,/,27x,a)
+!
+      RETURN
+      END SUBROUTINE pio_netcdf_put_fvar_3dp
 #endif
 !
       SUBROUTINE pio_netcdf_put_fvar_0d (ng, model, ncname, myVarName,  &
@@ -6493,7 +7056,7 @@
       TYPE (Var_desc_t)  :: my_pioVar
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a floating-point 1D-array variable.
 !-----------------------------------------------------------------------
 !
 !  If file descriptor is not provided, open file for writing.
@@ -6608,7 +7171,7 @@
       TYPE (Var_desc_t)  :: my_pioVar
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a floating-point 2D-array variable.
 !-----------------------------------------------------------------------
 !
 !  If file descriptor is not provided, open file for writing.
@@ -6723,7 +7286,7 @@
       TYPE (Var_desc_t)  :: my_pioVar
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a floating-point 3D-array variable.
 !-----------------------------------------------------------------------
 !
 !  If file descriptor is not provided, open file for writing.
@@ -6838,7 +7401,7 @@
       TYPE (Var_desc_t)  :: my_pioVar
 !
 !-----------------------------------------------------------------------
-!  Read in a floating-point scalar variable.
+!  Read in a floating-point 4D-array variable.
 !-----------------------------------------------------------------------
 !
 !  If file descriptor is not provided, open file for writing.

--- a/ROMS/Utility/cgradient.F
+++ b/ROMS/Utility/cgradient.F
@@ -677,9 +677,9 @@
       integer :: Linp, Lout, Lscale, Lwrk, Lwrk1, i, j, ic
       integer :: info, itheta1
 !
-      real(r8) :: norm, zbeta, ztheta1
+      real(dp) :: norm, zbeta, ztheta1
 
-      real(r8), dimension(2*Ninner-2) :: work
+      real(dp), dimension(2*Ninner-2) :: work
 !
       character (len=13) :: string
 

--- a/ROMS/Utility/congrad.F
+++ b/ROMS/Utility/congrad.F
@@ -132,6 +132,15 @@
 !
       implicit none
 !
+! Interface for mixed precision minimization.
+!
+      INTERFACE rprecond
+# ifdef SINGLE_PRECISION
+        MODULE PROCEDURE rprecond_dp
+# endif 
+        MODULE PROCEDURE rprecond_r8
+      END INTERFACE rprecond
+!
       PUBLIC  :: congrad
       PUBLIC  :: cg_read_congrad
 !
@@ -144,8 +153,8 @@
 # if defined PIO_LIBRARY && defined DISTRIBUTE
       PRIVATE :: cg_write_congrad_pio
 # endif
-      PRIVATE :: RPevecs
-      PRIVATE :: rprecond
+!
+      PRIVATE
 !
       CONTAINS
 !
@@ -166,22 +175,22 @@
 !
       integer :: i, ic, j, iobs, ivec, Lscale, info
 !
-      real(r8) :: zbet, eps, preducv, preducy
+      real(dp) :: zbet, eps, preducv, preducy
 # ifdef MINRES
-      real(r8) :: zsum, zck, zgk
+      real(dp) :: zsum, zck, zgk
 # endif
-      real(r8) :: Jopt, Jf, Jmod, Jdata, Jb, Jobs, Jact, cff
+      real(dp) :: Jopt, Jf, Jmod, Jdata, Jb, Jobs, Jact, cff
 
-      real(r8), dimension(NinnLoop) :: zu, zgam
-      real(r8), dimension(NinnLoop) :: ztemp1, ztemp2, zu1, zu2
-      real(r8), dimension(Ndatum(ng)) :: px, pgrad, zw, zt
-      real(r8), dimension(Ndatum(ng)) :: zhv, zht, zd
-      real(r8), dimension(Ninner,3) :: zwork
-      real(r8), dimension(2*(NinnLoop-1)) :: work
-      real(r8), dimension(Ninner,Ninner) :: zgv
+      real(dp), dimension(NinnLoop) :: zu, zgam
+      real(dp), dimension(NinnLoop) :: ztemp1, ztemp2, zu1, zu2
+      real(dp), dimension(Ndatum(ng)) :: px, pgrad, zw, zt
+      real(dp), dimension(Ndatum(ng)) :: zhv, zht, zd
+      real(dp), dimension(Ninner,3) :: zwork
+      real(dp), dimension(2*(NinnLoop-1)) :: work
+      real(dp), dimension(Ninner,Ninner) :: zgv
 # ifdef MINRES
-      real(r8), dimension(innLoop,innLoop) :: ztriT, zLT, zLTt
-      real(r8), dimension(innLoop) :: tau, zwork1, ze, zeref
+      real(dp), dimension(innLoop,innLoop) :: ztriT, zLT, zLTt
+      real(dp), dimension(innLoop) :: tau, zwork1, ze, zeref
 # endif
 !
       character (len=13) :: string
@@ -222,16 +231,16 @@
 !  Initialize internal parameters.  This is needed here for output
 !  reasons.
 !
-        Jopt=0.0_r8
-        Jf=0.0_r8
-        Jdata=0.0_r8
-        Jmod=0.0_r8
-        Jb=0.0_r8
-        Jobs=0.0_r8
-        Jact=0.0_r8
-        eps=0.0_r8
-        preducv=0.0_r8
-        preducy=0.0_r8
+        Jopt=0.0_dp
+        Jf=0.0_dp
+        Jdata=0.0_dp
+        Jmod=0.0_dp
+        Jb=0.0_dp
+        Jobs=0.0_dp
+        Jact=0.0_dp
+        eps=0.0_dp
+        preducv=0.0_dp
+        preducy=0.0_dp
 !
 !-----------------------------------------------------------------------
 !  Initialization step, innloop = 0.
@@ -257,8 +266,8 @@
 !  For the first outer-loop, x0=0.
 !
             DO iobs=1,Ndatum(ng)
-              px(iobs)=0.0_r8
-              cg_pxsave(iobs)=0.0_r8
+              px(iobs)=0.0_dp
+              cg_pxsave(iobs)=0.0_dp
             END DO
 !
 !  If this is the first pass of the inner loop, set up the vectors and
@@ -280,7 +289,7 @@
 !
 ! Convert pgrad from x-space to v-space.
 !
-              IF (ObsErr(iobs).NE.0.0_r8) THEN
+              IF (ObsErr(iobs).ne.0.0_r8) THEN
                 pgrad(iobs)=pgrad(iobs)/SQRT(ObsErr(iobs))
               END IF
               vgrad0(iobs)=pgrad(iobs)
@@ -296,8 +305,8 @@
      &                       pgrad)
             END IF
 !
-            cg_Gnorm_y(outLoop)=0.0_r8
-            cg_Gnorm_v(outLoop)=0.0_r8
+            cg_Gnorm_y(outLoop)=0.0_dp
+            cg_Gnorm_v(outLoop)=0.0_dp
             DO iobs=1,Ndatum(ng)
               zgrad0(iobs,outLoop)=pgrad(iobs)
               cg_Gnorm_y(outLoop)=cg_Gnorm_y(outLoop)+                  &
@@ -325,25 +334,25 @@
 ! Convert ADmodVal from v-space to x-space.
 !
             DO iobs=1,Ndatum(ng)
-              IF (ObsErr(iobs).NE.0.0_r8) THEN
+              IF (ObsErr(iobs).ne.0.0_r8) THEN
                 ADmodVal(iobs)=ADmodVal(iobs)/SQRT(ObsErr(iobs))
               END IF
             END DO
 
-            cg_QG(1,outLoop)=0.0_r8
+            cg_QG(1,outLoop)=0.0_dp
             DO iobs=1,Ndatum(ng)
                cg_QG(1,outLoop)=cg_QG(1,outLoop)+                       &
      &                          zcglwk(iobs,1,outLoop)*                 &
      &                          zgrad0(iobs,outLoop)
             END DO
 
-            preducv=1.0_r8
-            preducy=1.0_r8
+            preducv=1.0_dp
+            preducy=1.0_dp
 !
 ! Compute the actual penalty function terms.
 !
-            Jb=0.0_r8
-            Jobs=0.0_r8
+            Jb=0.0_dp
+            Jobs=0.0_dp
             DO iobs=1,Ndatum(ng)
               Jobs=Jobs+vgrad0s(iobs)*vgrad0s(iobs)
             END DO
@@ -373,7 +382,7 @@
 !  contribution to the starting gradient) from x-space to v-space.
 !
               DO iobs=1,Ndatum(ng)
-                IF (ObsErr(iobs).NE.0.0_r8) THEN
+                IF (ObsErr(iobs).ne.0.0_r8) THEN
                   ADmodVal(iobs)=ADmodVal(iobs)/SQRT(ObsErr(iobs))
                   cg_innov(iobs)=cg_innov(iobs)/SQRT(ObsErr(iobs))
                 END IF
@@ -387,7 +396,7 @@
 !
                 pgrad(iobs)=ObsScale(iobs)*TLmodVal(iobs)
                 gdgw(iobs)=pgrad(iobs)
-                IF (ObsErr(iobs).NE.0.0_r8) THEN
+                IF (ObsErr(iobs).ne.0.0_r8) THEN
                   pgrad(iobs)=pgrad(iobs)/SQRT(ObsErr(iobs))
                   vgrad0s(iobs)=pgrad(iobs)+cg_innov(iobs)+             &
      &                                      cg_pxsave(iobs)
@@ -410,8 +419,8 @@
      &                         pgrad)
               END IF
 
-              cg_Gnorm_y(outLoop)=0.0_r8
-              cg_Gnorm_v(outLoop)=0.0_r8
+              cg_Gnorm_y(outLoop)=0.0_dp
+              cg_Gnorm_v(outLoop)=0.0_dp
               DO iobs=1,Ndatum(ng)
                 zgrad0(iobs,outLoop)=pgrad(iobs)
                 cg_Gnorm_y(outLoop)=cg_Gnorm_y(outLoop)+                &
@@ -438,11 +447,11 @@
               END IF
 !
               DO iobs=1,Ndatum(ng)
-                IF (ObsErr(iobs).NE.0.0_r8) THEN
+                IF (ObsErr(iobs).ne.0.0_r8) THEN
                   ADmodVal(iobs)=ADmodVal(iobs)/SQRT(ObsErr(iobs))
                 END IF
               END DO
-              cg_QG(1,outLoop)=0.0_r8
+              cg_QG(1,outLoop)=0.0_dp
               DO iobs=1,Ndatum(ng)
                 cg_QG(1,outLoop)=cg_QG(1,outLoop)+                      &
      &                           zcglwk(iobs,1,outLoop)*                &
@@ -453,8 +462,8 @@
 
           END IF
 
-          preducv=1.0_r8
-          preducy=1.0_r8
+          preducv=1.0_dp
+          preducy=1.0_dp
 !
 !-----------------------------------------------------------------------
 !  Minimization step, innLoop > 0.
@@ -475,7 +484,7 @@
 !
 !  Convert gradient contribution from x-space to v-space.
 !
-            IF (ObsErr(iobs).NE.0.0_r8) THEN
+            IF (ObsErr(iobs).ne.0.0_r8) THEN
               pgrad(iobs)=pgrad(iobs)/SQRT(ObsErr(iobs))
             END IF
           END DO
@@ -504,7 +513,7 @@
             CALL rprecond (ng, Lscale, Ltrans, outLoop, NinnLoop, pgrad)
           END IF
 !
-          cg_delta(innLoop,outLoop)=0.0_r8
+          cg_delta(innLoop,outLoop)=0.0_dp
           DO iobs=1,Ndatum(ng)
             cg_delta(innLoop,outLoop)=cg_delta(innLoop,outLoop)+        &
      &                                zcglwk(iobs,innLoop,outLoop)*     &
@@ -513,7 +522,7 @@
 !
 !  Exit, if not a positive definite algorithm.
 !
-          IF (cg_delta(innLoop,outLoop).le.0.0_r8) THEN
+          IF (cg_delta(innLoop,outLoop).le.0.0_dp) THEN
             WRITE (stdout,20) cg_delta(innLoop,outLoop), outLoop,       &
      &                        innLoop
             exit_flag=8
@@ -536,7 +545,7 @@
 !  Orthonormalize against previous Lanczos vectors.
 !
           DO ivec=innLoop,1,-1
-            cg_dla(ivec,outLoop)=0.0_r8
+            cg_dla(ivec,outLoop)=0.0_dp
             DO iobs=1,Ndatum(ng)
               cg_dla(ivec,outLoop)=cg_dla(ivec,outLoop)+pgrad(iobs)*    &
      &                             zcglwk(iobs,ivec,outLoop)
@@ -548,7 +557,7 @@
             END DO
           END DO
 !
-          cg_beta(innLoop+1,outLoop)=0.0_r8
+          cg_beta(innLoop+1,outLoop)=0.0_dp
           DO iobs=1,Ndatum(ng)
             cg_beta(innLoop+1,outLoop)=cg_beta(innLoop+1,outLoop)+      &
      &                                 pgrad(iobs)*pgrad(iobs)
@@ -560,7 +569,7 @@
      &                                     cg_beta(innLoop+1,outLoop)
           END DO
 !
-          cg_QG(innLoop+1,outLoop)=0.0_r8
+          cg_QG(innLoop+1,outLoop)=0.0_dp
           DO iobs=1,Ndatum(ng)
             cg_QG(innLoop+1,outLoop)=cg_QG(innLoop+1,outLoop)+          &
      &                               zcglwk(iobs,innLoop+1,outLoop)*    &
@@ -576,7 +585,7 @@
 !
 !  Perform a LQ factorization of the tridiagonal matrix.
 !
-          ztriT=0.0_r8
+          ztriT=0.0_dp
           DO i=1,innLoop
             ztriT(i,i)=cg_delta(i,outLoop)
           END DO
@@ -590,8 +599,8 @@
 !
 !   Isolate L=zLT and its transpose.
 !
-          zLT=0.0_r8
-          zLTt=0.0_r8
+          zLT=0.0_dp
+          zLTt=0.0_dp
           DO i=1,innLoop
             DO j=1,i
               zLT(i,j)=ztriT(i,j)
@@ -605,19 +614,19 @@
 !
 !   Now form ze=beta1*Q*e1.
 !
-          ze=0.0_r8
+          ze=0.0_dp
           DO i=1,innLoop
             ze(i)=-cg_QG(i,outLoop)
           END DO
           DO i=1,innLoop
             DO j=1,innLoop
-              zeref(j)=0.0_r8
+              zeref(j)=0.0_dp
             END DO
-            zeref(i)=1.0_r8
+            zeref(i)=1.0_dp
             DO j=i+1,innLoop
               zeref(j)=ztriT(i,j)
             END DO
-            zsum=0.0_r8
+            zsum=0.0_dp
             DO j=1,innLoop
               zsum=zsum+ze(j)*zeref(j)
             END DO
@@ -676,7 +685,7 @@
           END DO
 
           DO iobs=1,Ndatum(ng)
-            px(iobs)=0.0_r8
+            px(iobs)=0.0_dp
             DO ivec=1,innLoop
               px(iobs)=px(iobs)+zcglwk(iobs,ivec,outLoop)*zwork(ivec,3)
               zw(iobs)=zw(iobs)-zcglwk(iobs,ivec,outLoop)*              &
@@ -695,7 +704,7 @@
 !
 !  Compute the reduction in the gradient Ax-b (in y-space).
 !
-          preducy=0.0_r8
+          preducy=0.0_dp
           DO iobs=1,Ndatum(ng)
             preducy=preducy+zw(iobs)*zw(iobs)
           END DO
@@ -709,7 +718,7 @@
             CALL rprecond (ng, Lscale, Ltrans, outLoop, NinnLoop, zw)
           END IF
 !
-          preducv=0.0_r8
+          preducv=0.0_dp
           DO iobs=1,Ndatum(ng)
             preducv=preducv+zw(iobs)*zw(iobs)
           END DO
@@ -778,7 +787,7 @@
             END IF
           END DO
           DO ivec=1,innLoop
-            ztemp1(ivec)=0.0_r8
+            ztemp1(ivec)=0.0_dp
             DO iobs=1,Ndatum(ng)
               ztemp1(ivec)=ztemp1(ivec)+                                &
      &                     zcglwk(iobs,ivec,outLoop)*zhv(iobs)
@@ -788,19 +797,19 @@
 !
 !   Now form ze=Q*ztemp1.
 !
-          ze=0.0_r8
+          ze=0.0_dp
           DO i=1,innLoop
             ze(i)=ztemp1(i)
           END DO
           DO i=1,innLoop
             DO j=1,innLoop
-              zeref(j)=0.0_r8
+              zeref(j)=0.0_dp
             END DO
-            zeref(i)=1.0_r8
+            zeref(i)=1.0_dp
             DO j=i+1,innLoop
               zeref(j)=ztriT(i,j)
             END DO
-            zsum=0.0_r8
+            zsum=0.0_dp
             DO j=1,innLoop
               zsum=zsum+ze(j)*zeref(j)
             END DO
@@ -849,7 +858,7 @@
           END DO
 # endif
           DO iobs=1,Ndatum(ng)
-            zhv(iobs)=0.0_r8
+            zhv(iobs)=0.0_dp
           END DO
           DO iobs=1,Ndatum(ng)
             DO ivec=1,innLoop
@@ -861,9 +870,9 @@
 !  Compute Jb.
 !
           DO ivec=1,innLoop
-            ztemp1(ivec)=0.0_r8
+            ztemp1(ivec)=0.0_dp
             DO iobs=1,Ndatum(ng)
-              IF (ObsErr(iobs).NE.0.0_r8) THEN
+              IF (ObsErr(iobs).ne.0.0_r8) THEN
                 ztemp1(ivec)=ztemp1(ivec)+                              &
      &                       zcglwk(iobs,ivec,outLoop)*zhv(iobs)/       &
      &                       SQRT(ObsErr(iobs))
@@ -874,19 +883,19 @@
 !
 !   Now form ze=Q*ztemp1.
 !
-          ze=0.0_r8
+          ze=0.0_dp
           DO i=1,innLoop
             ze(i)=ztemp1(i)
           END DO
           DO i=1,innLoop
             DO j=1,innLoop
-              zeref(j)=0.0_r8
+              zeref(j)=0.0_dp
             END DO
-            zeref(i)=1.0_r8
+            zeref(i)=1.0_dp
             DO j=i+1,innLoop
               zeref(j)=ztriT(i,j)
             END DO
-            zsum=0.0_r8
+            zsum=0.0_dp
             DO j=1,innLoop
               zsum=zsum+ze(j)*zeref(j)
             END DO
@@ -934,39 +943,39 @@
           END DO
 # endif
           DO iobs=1,Ndatum(ng)
-            zht(iobs)=0.0_r8
+            zht(iobs)=0.0_dp
           END DO
           DO iobs=1,Ndatum(ng)
             DO ivec=1,innLoop
-              IF (ObsErr(iobs).NE.0.0_r8) THEN
+              IF (ObsErr(iobs).ne.0.0_r8) THEN
                 zht(iobs)=zht(iobs)+                                    &
      &                    ztemp2(ivec)*zcglwk(iobs,ivec,outLoop)/       &
      &                    SQRT(ObsErr(iobs))
               END IF
             END DO
           END DO
-          Jb=0.0_r8
+          Jb=0.0_dp
           DO iobs=1,Ndatum(ng)
             IF (ObsErr(iobs).ne.0.0_r8) THEN
               cff=cg_pxsave(iobs)/SQRT(ObsErr(iobs))
-              Jb=Jb+zd(iobs)*zht(iobs)-2.0_r8*cff*zhv(iobs)+            &
+              Jb=Jb+zd(iobs)*zht(iobs)-2.0_dp*cff*zhv(iobs)+            &
      &           cff*gdgw(iobs)
             END IF
           END DO
 !
 !  Compute Jobs.
 !
-          Jobs=0.0_r8
+          Jobs=0.0_dp
           IF (outLoop.eq.1.or.(.not.LhotStart)) THEN
             DO iobs=1,Ndatum(ng)
-              IF (ObsErr(iobs).NE.0.0_r8) THEN
+              IF (ObsErr(iobs).ne.0.0_r8) THEN
                 cff=zhv(iobs)-zd(iobs)
                 Jobs=Jobs+cff*cff/ObsErr(iobs)
               END IF
             END DO
           ELSE
             DO iobs=1,Ndatum(ng)
-              IF (ObsErr(iobs).NE.0.0_r8) THEN
+              IF (ObsErr(iobs).ne.0.0_r8) THEN
                 cff=gdgw(iobs)-zhv(iobs)+cg_innov(iobs)*SQRT(ObsErr(iobs))
                 Jobs=Jobs+cff*cff/ObsErr(iobs)
               END IF
@@ -1127,7 +1136,7 @@
 !  Check for exploding or negative Ritz values.
 !
             DO ivec=1,innLoop
-              IF (cg_RitzErr(ivec,outLoop).lt.0.0_r8) THEN
+              IF (cg_RitzErr(ivec,outLoop).lt.0.0_dp) THEN
                 WRITE (stdout,*) ' CONGRAD - negative Ritz value found.'
                 exit_flag=8
                 GO TO 10
@@ -1285,7 +1294,7 @@
 !
       integer :: iobs, ivec, jn, jk, ij, ingood
 !
-      real(r8) :: dla
+      real(dp) :: dla
 !
 !-----------------------------------------------------------------------
 !  Compute and store converged eigenvectors of (R_n+Cobs).
@@ -1305,7 +1314,7 @@
       DO jn=NinnLoop,1,-1
         ij=ij+1
         DO iobs=1,Ndatum(ng)
-          vcglev(iobs,ij,outLoop)=0.0_r8
+          vcglev(iobs,ij,outLoop)=0.0_dp
         END DO
         DO jk=1,NinnLoop
           DO iobs=1,Ndatum(ng)
@@ -1315,7 +1324,7 @@
           END DO
         END DO
         DO jk=1,ij-1
-          dla=0.0_r8
+          dla=0.0_dp
           DO iobs=1,Ndatum(ng)
             dla=dla+vcglev(iobs,jk,outLoop)*vcglev(iobs,ij,outLoop)
           END DO
@@ -1324,7 +1333,7 @@
      &                              dla*vcglev(iobs,jk,outLoop)
           END DO
         END DO
-        dla=0.0_r8
+        dla=0.0_dp
         DO iobs=1,Ndatum(ng)
           dla=dla+vcglev(iobs,ij,outLoop)*vcglev(iobs,ij,outLoop)
         END DO
@@ -1335,9 +1344,177 @@
 !
       RETURN
       END SUBROUTINE RPevecs
+
+# ifdef SINGLE_PRECISION
 !
 !***********************************************************************
-      SUBROUTINE rprecond (ng, Lscale, Ltrans, outLoop, NinnLoop, py)
+      SUBROUTINE rprecond_dp (ng, Lscale, Ltrans, outLoop, NinnLoop, py)
+!***********************************************************************
+!                                                                      !
+!  This routine is the preconditioner in observation space.            !
+!                                                                      !
+!***********************************************************************
+!
+!  Imported variable declarations
+!
+      logical, intent(in) :: Ltrans
+!
+      integer, intent(in) :: ng, Lscale, outLoop, NinnLoop
+!
+      real(dp), intent(inout) :: py(Ndatum(ng))
+!
+!  Local variable declarations.
+!
+      integer :: is, ie, inc, iss, i
+      integer :: nol, nols, nole, ninc
+      integer :: ingood
+      integer :: iobs, nvec
+!
+      real(dp) :: dla, fac, facritz
+!
+!  Set the do-loop indices for the sequential preconditioner
+!  loop.
+!
+      IF (Ltrans) THEN
+        nols=outLoop-1
+        nole=1
+        ninc=-1
+      ELSE
+        nols=1
+        nole=outLoop-1
+        ninc=1
+      END IF
+!
+!  Apply the preconditioners derived from all previous outer-loops
+!  sequentially.
+!
+      DO nol=nols,nole,ninc
+!
+!  Determine the number of Ritz vectors to use.
+!  For Lritz=.TRUE., choose HvecErr to be larger.
+!
+        ingood=0
+        DO i=1,NinnLoop
+          IF (cg_RitzErr(i,nol).le.RitzMaxErr) THEN
+            ingood=ingood+1
+          END IF
+        END DO
+        IF (NritzEV.gt.0) THEN
+          nConvRitz=NritzEV
+          ingood=nConvRitz
+        ELSE
+          nConvRitz=ingood
+        END IF
+!
+        IF (Lscale.gt.0) THEN
+          is=1
+          ie=ingood
+          inc=1
+        ELSE
+          is=ingood
+          ie=1
+          inc=-1
+        END IF
+!
+        IF (Ltrans) THEN
+          iss=is
+          is=ie
+          ie=iss
+          inc=-inc
+        END IF
+!
+!  Lscale determines the form of the preconditioner:
+!
+!     1= LMP (NOT CODED YET)
+!    -1= Inverse LMP (NOT CODED YET)
+!     2= Square root LMP
+!    -2= Inverse square root LMP
+!
+        DO nvec=is,ie,inc
+!
+          fac=0.0_dp
+!
+          IF (Lritz) THEN
+!
+!  Note that the primitive Ritz vectors cg_zv are stored in order of
+!  ascending Ritz values.
+!
+            facritz=cg_beta(NinnLoop+1,nol)*                            &
+     &              cg_zv(NinnLoop,NinnLoop+1-nvec,nol)
+!
+!  Compute dot-product of py with q_k+1 from previous outer-loop.
+!
+            IF (.not.Ltrans) THEN
+              dla=0.0_dp
+              DO iobs=1,Ndatum(ng)
+                dla=dla+zcglwk(iobs,NinnLoop+1,nol)*py(iobs)
+              END DO
+              facritz=facritz*dla
+            END IF
+
+          END IF
+!
+!  Compute the dot-product of py with the Ritz vectors from previous
+!  outer-loop.
+!
+!  Note that vcglev are arranged in order of descending Ritz values,
+!  while the Ritz values themselves that are stored in cg_Ritz are in
+!  ascending order.
+!
+          dla=0.0_dp
+          DO iobs=1,Ndatum(ng)
+            dla=dla+vcglev(iobs,nvec,nol)*py(iobs)
+          END DO
+!
+!  NOTE: Lscale=1 and Lscale=-1 cases are not complete yet.
+!
+          IF (Lscale.eq.-1) THEN
+            fac=(cg_Ritz(NinnLoop+1-nvec,nol)-1.0_dp)*dla
+          ELSE IF (Lscale.eq.1) THEN
+            fac=(1.0_dp/cg_Ritz(NinnLoop+1-nvec,nol)-1.0_dp)*dla
+          ELSE IF (Lscale.eq.-2) THEN
+            fac=(SQRT(cg_Ritz(NinnLoop+1-nvec,nol))-1.0_dp)*dla
+          ELSE IF (Lscale.eq.2) THEN
+            fac=(1.0_dp/SQRT(cg_Ritz(NinnLoop+1-nvec,nol))-1.0_dp)*dla
+          END IF
+!
+          IF (.not.Ltrans) THEN
+            IF (Lritz.and.(Lscale.eq.-2)) THEN
+              fac=fac+facritz/SQRT(cg_Ritz(NinnLoop+1-nvec,nol))
+            END IF
+            IF (Lritz.and.(Lscale.eq.2)) THEN
+              fac=fac-facritz/cg_Ritz(NinnLoop+1-nvec,nol)
+            END IF
+          END IF
+!
+          DO iobs=1,Ndatum(ng)
+             py(iobs)=py(iobs)+fac*vcglev(iobs,nvec,nol)
+          END DO
+!
+          IF (Lritz.and.Ltrans) THEN
+
+            IF (Lscale.eq.2) THEN
+              fac=-facritz*dla/cg_Ritz(NinnLoop+1-nvec,nol)
+            END IF
+            IF (Lscale.eq.-2) THEN
+              fac=facritz*dla/SQRT(cg_Ritz(NinnLoop+1-nvec,nol))
+            END IF
+
+            DO iobs=1,Ndatum(ng)
+               py(iobs)=py(iobs)+fac*zcglwk(iobs,NinnLoop+1,nol)
+            END DO
+
+          END IF
+
+        END DO
+      END DO
+!
+      RETURN
+      END SUBROUTINE rprecond_dp
+# endif
+!
+!***********************************************************************
+      SUBROUTINE rprecond_r8 (ng, Lscale, Ltrans, outLoop, NinnLoop, py)
 !***********************************************************************
 !                                                                      !
 !  This routine is the preconditioner in observation space.            !
@@ -1421,7 +1598,7 @@
 !
         DO nvec=is,ie,inc
 !
-          fac=0.0_r8
+          fac=0.0_dp
 !
           IF (Lritz) THEN
 !
@@ -1434,7 +1611,7 @@
 !  Compute dot-product of py with q_k+1 from previous outer-loop.
 !
             IF (.not.Ltrans) THEN
-              dla=0.0_r8
+              dla=0.0_dp
               DO iobs=1,Ndatum(ng)
                 dla=dla+zcglwk(iobs,NinnLoop+1,nol)*py(iobs)
               END DO
@@ -1450,7 +1627,7 @@
 !  while the Ritz values themselves that are stored in cg_Ritz are in
 !  ascending order.
 !
-          dla=0.0_r8
+          dla=0.0_dp
           DO iobs=1,Ndatum(ng)
             dla=dla+vcglev(iobs,nvec,nol)*py(iobs)
           END DO
@@ -1458,13 +1635,13 @@
 !  NOTE: Lscale=1 and Lscale=-1 cases are not complete yet.
 !
           IF (Lscale.eq.-1) THEN
-            fac=(cg_Ritz(NinnLoop+1-nvec,nol)-1.0_r8)*dla
+            fac=(cg_Ritz(NinnLoop+1-nvec,nol)-1.0_dp)*dla
           ELSE IF (Lscale.eq.1) THEN
-            fac=(1.0_r8/cg_Ritz(NinnLoop+1-nvec,nol)-1.0_r8)*dla
+            fac=(1.0_dp/cg_Ritz(NinnLoop+1-nvec,nol)-1.0_dp)*dla
           ELSE IF (Lscale.eq.-2) THEN
-            fac=(SQRT(cg_Ritz(NinnLoop+1-nvec,nol))-1.0_r8)*dla
+            fac=(SQRT(cg_Ritz(NinnLoop+1-nvec,nol))-1.0_dp)*dla
           ELSE IF (Lscale.eq.2) THEN
-            fac=(1.0_r8/SQRT(cg_Ritz(NinnLoop+1-nvec,nol))-1.0_r8)*dla
+            fac=(1.0_dp/SQRT(cg_Ritz(NinnLoop+1-nvec,nol))-1.0_dp)*dla
           END IF
 !
           IF (.not.Ltrans) THEN
@@ -1499,7 +1676,7 @@
       END DO
 !
       RETURN
-      END SUBROUTINE rprecond
+      END SUBROUTINE rprecond_r8
 !
 !***********************************************************************
       SUBROUTINE cg_write_congrad (ng, model, innLoop, outLoop,         &
@@ -1519,8 +1696,8 @@
 !
       integer, intent(in) :: ng, model, innLoop, outLoop, NinnLoop
 !
-      real(r8), intent(in) :: Jf, Jdata, Jmod, Jopt, preducv, preducy
-      real(r8), intent(in) :: Jb, Jobs, Jact
+      real(dp), intent(in) :: Jf, Jdata, Jmod, Jopt, preducv, preducy
+      real(dp), intent(in) :: Jb, Jobs, Jact
 !
 !  Local variable declarations.
 !
@@ -1573,8 +1750,8 @@
 !
       integer, intent(in) :: ng, model, innLoop, outLoop, NinnLoop
 !
-      real(r8), intent(in) :: Jf, Jdata, Jmod, Jopt, preducv, preducy
-      real(r8), intent(in) :: Jb, Jobs, Jact
+      real(dp), intent(in) :: Jf, Jdata, Jmod, Jopt, preducv, preducy
+      real(dp), intent(in) :: Jb, Jobs, Jact
 !
 !  Local variable declarations.
 !
@@ -1847,8 +2024,8 @@
 !
       integer, intent(in) :: ng, model, innLoop, outLoop, NinnLoop
 !
-      real(r8), intent(in) :: Jf, Jdata, Jmod, Jopt, preducv, preducy
-      real(r8), intent(in) :: Jb, Jobs, Jact
+      real(dp), intent(in) :: Jf, Jdata, Jmod, Jopt, preducv, preducy
+      real(dp), intent(in) :: Jb, Jobs, Jact
 !
 !  Local variable declarations.
 !

--- a/ROMS/Utility/distribute.F
+++ b/ROMS/Utility/distribute.F
@@ -66,6 +66,8 @@
 # ifdef SINGLE_PRECISION
         MODULE PROCEDURE mp_bcastf_0dp   ! double-precision exchanges
         MODULE PROCEDURE mp_bcastf_1dp   ! double-precision exchanges
+        MODULE PROCEDURE mp_bcastf_2dp   ! double-precision exchanges
+        MODULE PROCEDURE mp_bcastf_3dp   ! double-precision exchanges
 # endif
         MODULE PROCEDURE mp_bcastf_0d
         MODULE PROCEDURE mp_bcastf_1d
@@ -184,9 +186,9 @@
 !
 !***********************************************************************
 !                                                                      !
-!  This routine broadcasts a double-precision floating-point scalar    !
-!  variable to all processors in the communicator. It is called by     !
-!  all the members in the group.                                       !
+!  This routine broadcasts a double-precision scalar variable to all   !
+!  processors in the communicator. It is called by all the members in  !
+!  the group.                                                          !
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
@@ -272,9 +274,9 @@
 !
 !***********************************************************************
 !                                                                      !
-!  This routine broadcasts a 1D double precission floating-point,      !
-!  non-tiled, array to all processors in the communicator. It is       !
-!  called by all the members in the group.                             !
+!  This routine broadcasts a 1D double-precission, non-tiled, array    !
+!  to all processors in the communicator. It is called by all the      !
+!  members in the group.                                               !
 !                                                                      !
 !  On Input:                                                           !
 !                                                                      !
@@ -356,6 +358,193 @@
 !
       RETURN
       END SUBROUTINE mp_bcastf_1dp
+!
+      SUBROUTINE mp_bcastf_2dp (ng, model, A, InpComm)
+!
+!***********************************************************************
+!                                                                      !
+!  This routine broadcasts a 2D double-preision, non-tiled, array      !
+!  to all processors in the communicator. It is called by all the      !
+!  members in the group.                                               !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     ng         Nested grid number.                                   !
+!     model      Calling model identifier.                             !
+!     A          2D array to broadcast (real).                         !
+!     InpComm    Communicator handle (integer, OPTIONAL).              !
+!                                                                      !
+!  On Output:                                                          !
+!                                                                      !
+!     A          Broadcasted 2D array.                                 !
+!                                                                      !
+!***********************************************************************
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, model
+
+      integer, intent(in), optional :: InpComm
+!
+      real(dp), intent(inout) :: A(:,:)
+!
+!  Local variable declarations
+!
+      integer :: Lstr, MyCOMM, MyError, Npts, Serror
+
+      integer :: Asize(2)
+!
+      character (len=MPI_MAX_ERROR_STRING) :: string
+
+      character (len=*), parameter :: MyFile =                          &
+     &  __FILE__//", mp_bcastf_2dp"
+
+#  ifdef PROFILE
+!
+!-----------------------------------------------------------------------
+!  Turn on time clocks.
+!-----------------------------------------------------------------------
+!
+      CALL wclock_on (ng, model, 64, __LINE__, MyFile)
+#  endif
+#  ifdef MPI
+!
+!-----------------------------------------------------------------------
+!  Set distributed-memory communicator handle (context ID).
+!-----------------------------------------------------------------------
+!
+      IF (PRESENT(InpComm)) THEN
+        MyCOMM=InpComm
+      ELSE
+        MyCOMM=OCN_COMM_WORLD
+      END IF
+#  endif
+!
+!-----------------------------------------------------------------------
+!  Broadcast requested variable.
+!-----------------------------------------------------------------------
+!
+      Asize(1)=UBOUND(A, DIM=1)
+      Asize(2)=UBOUND(A, DIM=2)
+      Npts=Asize(1)*Asize(2)
+
+#  ifdef MPI
+      CALL mpi_bcast (A, Npts, MP_FLOAT, MyMaster, MyCOMM, MyError)
+      IF (MyError.ne.MPI_SUCCESS) THEN
+        CALL mpi_error_string (MyError, string, Lstr, Serror)
+        Lstr=LEN_TRIM(string)
+        WRITE (stdout,10) 'MPI_BCAST', MyRank, MyError, string(1:Lstr)
+ 10     FORMAT (/,' MP_BCASTF_2DP - error during ',a,' call, Node = ',  &
+     &          i3.3,' Error = ',i3,/,13x,a)
+        exit_flag=2
+        RETURN
+      END IF
+#  endif
+#  ifdef PROFILE
+!
+!-----------------------------------------------------------------------
+!  Turn off time clocks.
+!-----------------------------------------------------------------------
+!
+      CALL wclock_off (ng, model, 64, __LINE__, MyFile)
+#  endif
+!
+      RETURN
+      END SUBROUTINE mp_bcastf_2dp
+!
+      SUBROUTINE mp_bcastf_3dp (ng, model, A, InpComm)
+!
+!***********************************************************************
+!                                                                      !
+!  This routine broadcasts a 3D double-precision, non-tiled, array     !
+!  to all processors in the communicator. It is called by all the      !
+!  members in the group.                                               !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     ng         Nested grid number.                                   !
+!     model      Calling model identifier.                             !
+!     A          3D array to broadcast (real).                         !
+!     InpComm    Communicator handle (integer, OPTIONAL).              !
+!                                                                      !
+!  On Output:                                                          !
+!                                                                      !
+!     A          Broadcasted 3D array.                                 !
+!                                                                      !
+!***********************************************************************
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, model
+
+      integer, intent(in), optional :: InpComm
+!
+      real(dp), intent(inout) :: A(:,:,:)
+!
+!  Local variable declarations
+!
+      integer :: Lstr, MyCOMM, MyError, Npts, Serror
+
+      integer :: Asize(3)
+!
+      character (len=MPI_MAX_ERROR_STRING) :: string
+
+      character (len=*), parameter :: MyFile =                          &
+     &  __FILE__//", mp_bcastf_3d"
+
+#  ifdef PROFILE
+!
+!-----------------------------------------------------------------------
+!  Turn on time clocks.
+!-----------------------------------------------------------------------
+!
+      CALL wclock_on (ng, model, 64, __LINE__, MyFile)
+#  endif
+#  ifdef MPI
+!
+!-----------------------------------------------------------------------
+!  Set distributed-memory communicator handle (context ID).
+!-----------------------------------------------------------------------
+!
+      IF (PRESENT(InpComm)) THEN
+        MyCOMM=InpComm
+      ELSE
+        MyCOMM=OCN_COMM_WORLD
+      END IF
+#  endif
+!
+!-----------------------------------------------------------------------
+!  Broadcast requested variable.
+!-----------------------------------------------------------------------
+!
+      Asize(1)=UBOUND(A, DIM=1)
+      Asize(2)=UBOUND(A, DIM=2)
+      Asize(3)=UBOUND(A, DIM=3)
+      Npts=Asize(1)*Asize(2)*Asize(3)
+
+#  ifdef MPI
+      CALL mpi_bcast (A, Npts, MP_FLOAT, MyMaster, MyCOMM, MyError)
+      IF (MyError.ne.MPI_SUCCESS) THEN
+        CALL mpi_error_string (MyError, string, Lstr, Serror)
+        Lstr=LEN_TRIM(string)
+        WRITE (stdout,10) 'MPI_BCAST', MyRank, MyError, string(1:Lstr)
+ 10     FORMAT (/,' MP_BCASTF_3DP - error during ',a,' call, Node = ',  &
+     &          i3.3,' Error = ',i3,/,13x,a)
+        exit_flag=2
+        RETURN
+      END IF
+#  endif
+#  ifdef PROFILE
+!
+!-----------------------------------------------------------------------
+!  Turn off time clocks.
+!-----------------------------------------------------------------------
+!
+      CALL wclock_off (ng, model, 64, __LINE__, MyFile)
+#  endif
+!
+      RETURN
+      END SUBROUTINE mp_bcastf_3dp
 # endif
 !
       SUBROUTINE mp_bcastf_0d (ng, model, A, InpComm)

--- a/ROMS/Utility/rpcg_lanczos.F
+++ b/ROMS/Utility/rpcg_lanczos.F
@@ -129,19 +129,19 @@
 !  Initialize internal parameters.  This is needed here for output
 !  reasons.
 !
-      Jopt=0.0_r8
-      Jf=0.0_r8
-      Jdata=0.0_r8
-      Jmod=0.0_r8
+      Jopt=0.0_dp
+      Jf=0.0_dp
+      Jdata=0.0_dp
+      Jmod=0.0_dp
       Jb=Jb0(outLoop-1)
-      Jobs=0.0_r8
-      Jact=0.0_r8
+      Jobs=0.0_dp
+      Jact=0.0_dp
       RitzMaxErr=HevecErr
-      eps=0.0_r8
-      preducv=0.0_r8
-      preducy=0.0_r8
-      zwork=0.0_r8
-      zgv=0.0_r8
+      eps=0.0_dp
+      preducv=0.0_dp
+      preducy=0.0_dp
+      zwork=0.0_dp
+      zgv=0.0_dp
 
 !
       MASTER_THREAD : IF (Master) THEN
@@ -175,10 +175,10 @@
 !
           IF (outLoop.eq.1) THEN
             DO iobs=1,Ndatum(ng)+1
-              px(iobs)=0.0_r8
+              px(iobs)=0.0_dp
             END DO
             DO iobs=1,Ndatum(ng)
-              Hbk(iobs,outLoop)=0.0_r8
+              Hbk(iobs,outLoop)=0.0_dp
             END DO
           ELSE
 !! NOTE: CODE WILL NOT WORK FOR R4D-Var AT THE MOMENT SINCE THIS IS
@@ -219,7 +219,7 @@
               pgrad(iobs)=ObsScale(iobs)*                               &
      &                    (ObsVal(iobs)-TLmodVal(iobs))
 # endif
-              IF (ObsErr(iobs).NE.0.0_r8) THEN
+              IF (ObsErr(iobs).ne.0.0_r8) THEN
                  pgrad(iobs)=pgrad(iobs)/ObsErr(iobs)
               END IF
               vgrad0(iobs)=pgrad(iobs)
@@ -229,7 +229,7 @@
 !  AUGMENTED
 !  Augment the residual vector.
 !
-            pgrad(Ndatum(ng)+1)=1.0_r8
+            pgrad(Ndatum(ng)+1)=1.0_dp
             vgrad0(Ndatum(ng)+1)=pgrad(Ndatum(ng)+1)
             vgrad0s(Ndatum(ng)+1)=vgrad0(Ndatum(ng)+1)
 !
@@ -258,8 +258,8 @@
               ADmodVal(iobs)=zgrad0(iobs,outLoop)
             END DO
 !
-          preducv=1.0_r8
-          preducy=1.0_r8
+          preducv=1.0_dp
+          preducy=1.0_dp
 !
 !-----------------------------------------------------------------------
 !  Minimization step, innLoop > 0.
@@ -274,7 +274,7 @@
 !  Complete the computation of the Lanczos vector from previous inner-loop
 !
           IF (innLoop.EQ.1) THEN
-            cg_Gnorm_v(outLoop)=0.0_r8
+            cg_Gnorm_v(outLoop)=0.0_dp
             DO iobs=1,Ndatum(ng)
               cg_Gnorm_v(outLoop)=cg_Gnorm_v(outLoop)+                  &
      &                            TLmodVal(iobs)*vgrad0(iobs)
@@ -331,18 +331,18 @@
               TLmodVal(iobs)=TLmodVal(iobs)/cg_Gnorm_v(outLoop)
             END DO
 !
-            preducv=1.0_r8
-            preducy=1.0_r8
+            preducv=1.0_dp
+            preducy=1.0_dp
 !
 !  Compute the actual penalty function terms.
 !
-            Jobs=0.0_r8
+            Jobs=0.0_dp
 !
 !  NO AUGMENTED TERM HERE.
 !
             Jact=Jb
             DO iobs=1,Ndatum(ng)
-              IF (ObsErr(iobs).NE.0.0_r8) THEN
+              IF (ObsErr(iobs).ne.0.0_r8) THEN
                 Jact=Jact+ObsErr(iobs)*vgrad0s(iobs)*vgrad0s(iobs)
               END IF
             END DO
@@ -363,7 +363,7 @@
 !
 !  Selime's code:  beta=pgrad*HBH'*pgrad=cg_beta
 !
-            cg_beta(innLoop,outLoop)=0.0_r8
+            cg_beta(innLoop,outLoop)=0.0_dp
             DO iobs=1,Ndatum(ng)
               cg_beta(innLoop,outLoop)=cg_beta(innLoop,outLoop)+        &
      &                                 pgrad(iobs)*TLmodVal(iobs)
@@ -417,7 +417,7 @@
 !
 !  Selime's code:  cg_QG=zgrad0*HBH'*zcglwk
 !
-            cg_QG(innLoop,outLoop)=0.0_r8
+            cg_QG(innLoop,outLoop)=0.0_dp
             DO iobs=1,Ndatum(ng)
               cg_QG(innLoop,outLoop)=cg_QG(innLoop,outLoop)+            &
      &                               TLmodVal(iobs)*                    &
@@ -442,7 +442,7 @@
      &                                    outLoop)*                     &
      &                             vgrad0(Ndatum(ng)+1)
 !TEST
-!TEST       IF (innLoop.gt.1) cg_QG(innLoop,outLoop)=0.0_r8
+!TEST       IF (innLoop.gt.1) cg_QG(innLoop,outLoop)=0.0_dp
 !TEST
 !
 !  Calculate the new solution based upon the new, orthonormalized
@@ -478,7 +478,7 @@
 !  AUGMENTED.
 !
             DO iobs=1,Ndatum(ng)+1
-              px(iobs)=0.0_r8
+              px(iobs)=0.0_dp
               DO ivec=1,innLoop-1
                 px(iobs)=px(iobs)+                                      &
      &                   zcglwk(iobs,ivec,outLoop)*zwork(ivec,3)
@@ -498,7 +498,7 @@
 !
 !  Compute the reduction in the gradient Ax-b (in y-space).
 !
-!AMM        preducy=0.0_r8
+!AMM        preducy=0.0_dp
 !AMM        DO iobs=1,Ndatum(ng)
 !AMM          preducy=preducy+zw(iobs)*zw(iobs)
 !AMM        END DO
@@ -512,7 +512,7 @@
               CALL rprecond (ng, Lscale, Laug, outLoop, NinnLoop-1, zw)
             END IF
 !
-            preducv=0.0_r8
+            preducv=0.0_dp
 !
 !  AUGMENTED.
 !
@@ -581,9 +581,9 @@
 !
             DO ivec=1,innLoop-1
               IF (ivec.eq.1) THEN
-                zfact(ivec)=1.0_r8/cg_Gnorm_v(outLoop)
+                zfact(ivec)=1.0_dp/cg_Gnorm_v(outLoop)
               ELSE
-                zfact(ivec)=1.0_r8/cg_beta(ivec,outLoop)
+                zfact(ivec)=1.0_dp/cg_beta(ivec,outLoop)
               ENDIF
             END DO
 !
@@ -599,9 +599,9 @@
               zhv(iobs)=zd(iobs)
             END DO
             DO ivec=1,innLoop-1
-              ztemp1(ivec)=0.0_r8
-              ztemp3(ivec)=0.0_r8
-              ztemp4(ivec)=0.0_r8
+              ztemp1(ivec)=0.0_dp
+              ztemp3(ivec)=0.0_dp
+              ztemp4(ivec)=0.0_dp
               DO iobs=1,Ndatum(ng)
                 ztemp1(ivec)=ztemp1(ivec)+                              &
      &                       TLmodVal_S(iobs,ivec,outLoop)*             &
@@ -648,7 +648,7 @@
      &                     Jb0(outLoop-1)*                              &
      &                     vcglwk(Ndatum(ng)+1,ivec,outLoop)
 !TEST
-              ztemp4(ivec)=0.0_r8
+              ztemp4(ivec)=0.0_dp
 !TEST
             END DO
             zbet=cg_delta(1,outLoop)
@@ -674,25 +674,25 @@
             Jb=Jb0(outLoop-1)
             Jact=Jb
             DO iobs=1,Ndatum(ng)
-              IF (ObsErr(iobs).NE.0.0_r8) THEN
+              IF (ObsErr(iobs).ne.0.0_r8) THEN
                 Jact=Jact+ObsErr(iobs)*vgrad0s(iobs)*vgrad0s(iobs)
               END IF
             END DO
             DO ivec=1,innLoop-1
               Jb=Jb+ztemp2(ivec)*ztemp2(ivec)
 !TEST         Jact=Jact-ztemp1(ivec)*ztemp2(ivec)+                      &
-!    &             2.0_r8*ztemp2(ivec)*ztemp3(ivec)
+!    &             2.0_dp*ztemp2(ivec)*ztemp3(ivec)
               Jact=Jact-ztemp1(ivec)*ztemp2(ivec)
             END DO
             DO iobs=1,Ndatum(ng)
-              Jb=Jb-2.0_r8*px(iobs)*Hbk(iobs,outLoop)
+              Jb=Jb-2.0_dp*px(iobs)*Hbk(iobs,outLoop)
 !TEST
-              Jact=Jact+2.0_r8*px(iobs)*Hbk(iobs,outLoop)
+              Jact=Jact+2.0_dp*px(iobs)*Hbk(iobs,outLoop)
 !TEST
             END DO
-            Jb=Jb-2.0_r8*px(Ndatum(ng)+1)*Jb0(outLoop-1)
+            Jb=Jb-2.0_dp*px(Ndatum(ng)+1)*Jb0(outLoop-1)
 !TEST
-            Jact=Jact+2.0_r8*px(Ndatum(ng)+1)*Jb0(outLoop-1)
+            Jact=Jact+2.0_dp*px(Ndatum(ng)+1)*Jb0(outLoop-1)
 !TEST
             Jobs=Jact-Jb
 
@@ -717,14 +717,14 @@
 !
 !  Convert gradient contribution from x-space to v-space.
 !
-            IF (ObsErr(iobs).NE.0.0_r8) THEN
+            IF (ObsErr(iobs).ne.0.0_r8) THEN
 !
 !  Selime code: w=t1/R. No augmented term here since Raug^-1=[R^-1 0].
 !
               pgrad(iobs)=pgrad(iobs)/ObsErr(iobs)
             END IF
           END DO
-          pgrad(Ndatum(ng)+1)=0.0_r8
+          pgrad(Ndatum(ng)+1)=0.0_dp
 !
 !  Selime code: w=t1/R+z1
 !
@@ -747,7 +747,7 @@
             END DO
           END IF
 !
-          cg_delta(innLoop,outLoop)=0.0_r8
+          cg_delta(innLoop,outLoop)=0.0_dp
 !
 !  Selime's code: alpha=w'*t1=cg_delta
 !
@@ -773,7 +773,7 @@
 !
 !  Exit, if not a positive definite algorithm.
 !
-          IF (cg_delta(innLoop,outLoop).le.0.0_r8) THEN
+          IF (cg_delta(innLoop,outLoop).le.0.0_dp) THEN
             WRITE (stdout,20) cg_delta(innLoop,outLoop), outLoop,       &
      &                        innLoop
             exit_flag=8
@@ -795,9 +795,9 @@
 !
           DO ivec=1,innLoop
             IF (ivec.eq.1) THEN
-              zfact(ivec)=1.0_r8/cg_Gnorm_v(outLoop)
+              zfact(ivec)=1.0_dp/cg_Gnorm_v(outLoop)
             ELSE
-              zfact(ivec)=1.0_r8/cg_beta(ivec,outLoop)
+              zfact(ivec)=1.0_dp/cg_beta(ivec,outLoop)
             ENDIF
           END DO
 !
@@ -806,7 +806,7 @@
 !  AUGMENTED
 !
           DO ivec=innLoop,1,-1
-            cg_dla(ivec,outLoop)=0.0_r8
+            cg_dla(ivec,outLoop)=0.0_dp
             DO iobs=1,Ndatum(ng)
               cg_dla(ivec,outLoop)=cg_dla(ivec,outLoop)+                &
      &                             pgrad(iobs)*                         &
@@ -1000,7 +1000,7 @@
 !  Check for exploding or negative Ritz values.
 !
             DO ivec=1,innLoop-1
-              IF (cg_RitzErr(ivec,outLoop).lt.0.0_r8) THEN
+              IF (cg_RitzErr(ivec,outLoop).lt.0.0_dp) THEN
                 WRITE (stdout,*) ' RPCG_LANCZOS - negative Ritz value', &
      &                           ' found.'
                 exit_flag=8
@@ -1202,7 +1202,7 @@
         ij=ij+1
 !                                                             AUGMENTED
         DO iobs=1,Ndatum(ng)
-          vcglev(iobs,ij,outLoop)=0.0_r8
+          vcglev(iobs,ij,outLoop)=0.0_dp
         END DO
         DO jk=1,NinnLoop
           DO iobs=1,Ndatum(ng)
@@ -1218,14 +1218,14 @@
 !
         DO jk=1,ij-1
           DO iobs=1,Ndatum(ng)
-            zt(iobs)=0.0_r8
+            zt(iobs)=0.0_dp
           END DO
           DO iobs=1,Ndatum(ng)
             DO jkk=1,NinnLoop
               IF (jkk.eq.1) THEN
-                zfact=1.0_r8/cg_Gnorm_v(outLoop)
+                zfact=1.0_dp/cg_Gnorm_v(outLoop)
               ELSE
-                zfact=1.0_r8/cg_beta(jkk,outLoop)
+                zfact=1.0_dp/cg_beta(jkk,outLoop)
               ENDIF
               zt(iobs)=zt(iobs)+                                        &
      &                 (TLmodVal_S(iobs,jkk,outLoop)*                   &
@@ -1235,7 +1235,7 @@
      &                 cg_zv(jkk,jk,outLoop)
             END DO
           END DO
-          dla=0.0_r8
+          dla=0.0_dp
           DO iobs=1,Ndatum(ng)
             dla=dla+zt(iobs)*vcglev(iobs,ij,outLoop)
           END DO
@@ -1244,7 +1244,7 @@
      &                              dla*zt(iobs)
           END DO
         END DO
-        dla=0.0_r8
+        dla=0.0_dp
 !                                                            AUGMENTED
         DO iobs=1,Ndatum(ng)
           dla=dla+vcglev(iobs,ij,outLoop)*vcglev(iobs,ij,outLoop)
@@ -1329,14 +1329,14 @@
 !
         DO nvec=is,ie,inc
           DO iobs=1,Ndatum(ng)
-            zt(iobs)=0.0_r8
+            zt(iobs)=0.0_dp
           END DO
           DO iobs=1,Ndatum(ng)
             DO jk=1,NinnLoop
               IF (jk.eq.1) THEN
-                zfact=1.0_r8/cg_Gnorm_v(nol)
+                zfact=1.0_dp/cg_Gnorm_v(nol)
               ELSE
-                zfact=1.0_r8/cg_beta(jk,nol)
+                zfact=1.0_dp/cg_beta(jk,nol)
               ENDIF
               zt(iobs)=zt(iobs)+                                        &
      &                 (TLmodVal_S(iobs,jk,nol)*                        &
@@ -1347,12 +1347,12 @@
             END DO
           END DO
 !
-          dla=0.0_r8
+          dla=0.0_dp
           DO iobs=1,Ndatum(ng)
             dla=dla+zt(iobs)*py(iobs)
           END DO
           IF (Lritz) THEN
-            dlar=0.0_r8
+            dlar=0.0_dp
             DO iobs=1,Ndatum(ng)
               dlar=dlar+                                                &
      &             (TLmodVal_S(iobs,NinnLoop+1,nol)/                    &
@@ -1366,9 +1366,9 @@
 !  NOTE: Lscale=1 and Lscale=-1 cases are not complete yet.
 !
           IF (Lscale.eq.-1) THEN
-            fac=(cg_Ritz(NinnLoop+1-nvec,nol)-1.0_r8)*dla
+            fac=(cg_Ritz(NinnLoop+1-nvec,nol)-1.0_dp)*dla
           ELSE
-            fac=(1.0_r8/cg_Ritz(NinnLoop+1-nvec,nol)-1.0_r8)*dla
+            fac=(1.0_dp/cg_Ritz(NinnLoop+1-nvec,nol)-1.0_dp)*dla
           END IF
 !
           DO iobs=1,Ndatum(ng)

--- a/ROMS/Utility/rpcg_lanczos.F
+++ b/ROMS/Utility/rpcg_lanczos.F
@@ -84,17 +84,17 @@
 !
       integer :: i, ic, j, iobs, ivec, Lscale, info
 !
-      real(r8) :: zbet, eps, preducv, preducy
-      real(r8) :: Jopt, Jf, Jmod, Jdata, Jb, Jobs, Jact, cff
+      real(dp) :: zbet, eps, preducv, preducy
+      real(dp) :: Jopt, Jf, Jmod, Jdata, Jb, Jobs, Jact, cff
 !
-      real(r8), dimension(NinnLoop) :: zu, zgam, zfact, ztemp3
-      real(r8), dimension(NinnLoop) :: ztemp1, ztemp2, zu1, zu2
-      real(r8), dimension(NinnLoop) :: ztemp4
-      real(r8), dimension(Ndatum(ng)+1) :: px, pgrad, zw, zt
-      real(r8), dimension(Ndatum(ng)+1) :: zhv, zht, zd
-      real(r8), dimension(Ninner,3) :: zwork
-      real(r8), dimension(2*(NinnLoop-1)) :: work
-      real(r8), dimension(Ninner,Ninner) :: zgv
+      real(dp), dimension(NinnLoop) :: zu, zgam, zfact, ztemp3
+      real(dp), dimension(NinnLoop) :: ztemp1, ztemp2, zu1, zu2
+      real(dp), dimension(NinnLoop) :: ztemp4
+      real(dp), dimension(Ndatum(ng)+1) :: px, pgrad, zw, zt
+      real(dp), dimension(Ndatum(ng)+1) :: zhv, zht, zd
+      real(dp), dimension(Ninner,3) :: zwork
+      real(dp), dimension(2*(NinnLoop-1)) :: work
+      real(dp), dimension(Ninner,Ninner) :: zgv
 !
       character (len=13) :: string
 
@@ -1180,8 +1180,8 @@
 !
       integer :: iobs, ivec, jn, jk, ij, jkk, ingood
 !
-      real(r8) :: dla, zfact
-      real(r8), dimension(Ndatum(ng)+1) :: zt
+      real(dp) :: dla, zfact
+      real(dp), dimension(Ndatum(ng)+1) :: zt
 !
 !-----------------------------------------------------------------------
 !  Compute and store converged eigenvectors of (R_n+Cobs).
@@ -1271,7 +1271,7 @@
       logical, intent(in) :: Laug
       integer, intent(in) :: ng, Lscale, outLoop, NinnLoop
 !
-      real(r8), intent(inout) :: py(Ndatum(ng)+1)            ! AUGMENTED
+      real(dp), intent(inout) :: py(Ndatum(ng)+1)            ! AUGMENTED
 !
 !  Local variable declarations.
 !
@@ -1280,9 +1280,9 @@
       integer :: ingood
       integer :: iobs, nvec, ivec
 !
-      real(r8) :: dla, dlar, fac, facritz, zfact
-      real(r8), dimension(NinnLoop) :: zvect
-      real(r8), dimension(Ndatum(ng)+1) :: zt
+      real(dp) :: dla, dlar, fac, facritz, zfact
+      real(dp), dimension(NinnLoop) :: zvect
+      real(dp), dimension(Ndatum(ng)+1) :: zt
 !
 !  Set the do-loop indices for the sequential preconditioner
 !  loop.
@@ -1427,8 +1427,8 @@
 !
       integer, intent(in) :: ng, model, innLoop, outLoop
 
-      real(r8), intent(in) :: Jf, Jdata, Jmod, Jopt, preducv, preducy
-      real(r8), intent(in) :: Jb, Jobs, Jact
+      real(dp), intent(in) :: Jf, Jdata, Jmod, Jopt, preducv, preducy
+      real(dp), intent(in) :: Jb, Jobs, Jact
 !
 !  Local variable declarations.
 !
@@ -1477,8 +1477,8 @@
 !
       integer, intent(in) :: ng, model, innLoop, outLoop
 
-      real(r8), intent(in) :: Jf, Jdata, Jmod, Jopt, preducv, preducy
-      real(r8), intent(in) :: Jb, Jobs, Jact
+      real(dp), intent(in) :: Jf, Jdata, Jmod, Jopt, preducv, preducy
+      real(dp), intent(in) :: Jb, Jobs, Jact
 !
 !  Local variable declarations.
 !
@@ -1760,8 +1760,8 @@
 !
       integer, intent(in) :: ng, model, innLoop, outLoop
 
-      real(r8), intent(in) :: Jf, Jdata, Jmod, Jopt, preducv, preducy
-      real(r8), intent(in) :: Jb, Jobs, Jact
+      real(dp), intent(in) :: Jf, Jdata, Jmod, Jopt, preducv, preducy
+      real(dp), intent(in) :: Jb, Jobs, Jact
 !
 !  Local variable declarations.
 !


### PR DESCRIPTION
A few routines were updated to allow compiling and running **split 4D-Var** with mixed precision.

The **split 4D-Var** algorithms (like **`RBL4DVAR_SPLIT`**) recommend the mixed precision approach to accelerate computations. The executing script (see **`submit_split_rbl4dvar.sh`**) uses multiple **ROMS** executables, which runs the **outer loop** in double precision (nonlinear background trajectory, **prior**) and single precision in the **inner loops** (tangent linear and adjoint minimization, **increment** phase).

In this update, several of the variables needed by the **RPCG** solver are declared in double precision to reduce the impact of rounding error and the convergence of the minimization algorithm (**`rpcg_lanczos.F`**) when computing dot-products and Ritz eigenvalues and eigenvectors.

In such cases, we use the **`real(dp)`** to declare specific internal variables. For example, in **`rpcg_lanczos.F`**, we have:

``` f90
!
!  Local variable declarations.
!
      logical :: Ltrans, Laug
!
      integer :: i, ic, j, iobs, ivec, Lscale, info
!
      real(dp) :: zbet, eps, preducv, preducy
      real(dp) :: Jopt, Jf, Jmod, Jdata, Jb, Jobs, Jact, cff
!
      real(dp), dimension(NinnLoop) :: zu, zgam, zfact, ztemp3
      real(dp), dimension(NinnLoop) :: ztemp1, ztemp2, zu1, zu2
      real(dp), dimension(NinnLoop) :: ztemp4
      real(dp), dimension(Ndatum(ng)+1) :: px, pgrad, zw, zt
      real(dp), dimension(Ndatum(ng)+1) :: zhv, zht, zd
      real(dp), dimension(Ninner,3) :: zwork
      real(dp), dimension(2*(NinnLoop-1)) :: work
      real(dp), dimension(Ninner,Ninner) :: zgv
```