### PR TITLE
Corrected initialization and added calls for background state in JEDI configuration

### DIFF
--- a/ROMS/Adjoint/ad_main3d.F
+++ b/ROMS/Adjoint/ad_main3d.F
@@ -310,7 +310,7 @@
               ng=GridNumber(ig,nl)
               DO tile=first_tile(ng),last_tile(ng),+1
                 CALL ad_set_data (ng, tile)
-# ifdef FORWARD_READ
+# if defined FORWARD_READ || defined JEDI
                 CALL set_depth (ng, tile, iADM)
 # endif
 # ifdef TIDE_GENERATING_FORCES
@@ -320,7 +320,7 @@
             END DO
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
-# ifdef FORWARD_READ
+# if defined FORWARD_READ || defined JEDI
 !
 !-----------------------------------------------------------------------
 !  Compute BASIC STATE horizontal mass fluxes (Hz*u/n and Hz*v/m).

--- a/ROMS/Adjoint/ad_zetabc.F
+++ b/ROMS/Adjoint/ad_zetabc.F
@@ -1158,7 +1158,7 @@
 !
 !  Western edge, clamped boundary condition.
 !
-        ELSE IF (ad_LBC(iwest,isFsur,ng)%gradient) THEN
+        ELSE IF (ad_LBC(iwest,isFsur,ng)%clamped) THEN
           DO j=Jstr,Jend
             IF (LBC_apply(ng)%west(j)) THEN
 # ifdef MASKING

--- a/ROMS/Drivers/jedi_roms.h
+++ b/ROMS/Drivers/jedi_roms.h
@@ -1364,25 +1364,9 @@
         DO ng=1,Ngrids
           DO tile=first_tile(ng),last_tile(ng),+1
             CALL tl_set_data (ng, tile)
-# ifdef FORWARD_READ
-            CALL set_depth (ng, tile, iTLM)
-# endif
           END DO
         END DO
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
-# ifdef FORWARD_READ
-!
-!-----------------------------------------------------------------------
-!  Compute BASIC STATE horizontal mass fluxes (Hz*u/n and Hz*v/m).
-!-----------------------------------------------------------------------
-!
-        DO ng=1,Ngrids
-          DO tile=last_tile(ng),first_tile(ng),-1
-            CALL set_massflux (ng, tile, iTLM)
-          END DO
-        END DO
-# endif
 !
 !-----------------------------------------------------------------------
 !  Computes the initial depths and level thicknesses from the initial

--- a/ROMS/Nonlinear/ini_fields.F
+++ b/ROMS/Nonlinear/ini_fields.F
@@ -18,10 +18,10 @@
 !
       USE mod_param
       USE mod_grid
-      USE mod_ncparam
 # ifdef SOLVE3D
       USE mod_coupling
 # endif
+      USE mod_ncparam
       USE mod_ocean
       USE mod_scalars
 # if defined SOLVE3D && (defined SEDIMENT || defined BBL_MODEL)
@@ -293,7 +293,6 @@
               cff1=cff1*umask_wet(i,j)
 #  endif
               u(i,j,k,nstp)=cff1
-              u(i,j,k,nnew)=cff1
             END DO
           END DO
 !
@@ -308,7 +307,6 @@
                 cff2=cff2*vmask_wet(i,j)
 #  endif
                 v(i,j,k,nstp)=cff2
-                v(i,j,k,nnew)=cff2
               END DO
             END DO
           END IF
@@ -326,17 +324,6 @@
      &                   IminS, ImaxS, JminS, JmaxS,                    &
      &                   nstp, nstp,                                    &
      &                   v)
-
-        CALL u3dbc_tile (ng, tile,                                      &
-     &                   LBi, UBi, LBj, UBj, N(ng),                     &
-     &                   IminS, ImaxS, JminS, JmaxS,                    &
-     &                   nstp, nnew,                                    &
-     &                   u)
-        CALL v3dbc_tile (ng, tile,                                      &
-     &                   LBi, UBi, LBj, UBj, N(ng),                     &
-     &                   IminS, ImaxS, JminS, JmaxS,                    &
-     &                   nstp, nnew,                                    &
-     &                   v)
       END IF
 !
       IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
@@ -346,23 +333,15 @@
         CALL exchange_v3d_tile (ng, tile,                               &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          v(:,:,:,nstp))
-
-        CALL exchange_u3d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
-     &                          u(:,:,:,nnew))
-        CALL exchange_v3d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
-     &                          v(:,:,:,nnew))
       END IF
 
 #  ifdef DISTRIBUTE
 !
-      CALL mp_exchange3d (ng, tile, model, 4,                           &
+      CALL mp_exchange3d (ng, tile, model, 2,                           &
      &                    LBi, UBi, LBj, UBj, 1, N(ng),                 &
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    u(:,:,:,nstp), v(:,:,:,nstp),                 &
-     &                    u(:,:,:,nnew), v(:,:,:,nnew))
+     &                    u(:,:,:,nstp), v(:,:,:,nstp))
 #  endif
 # endif
 
@@ -398,12 +377,7 @@
 #  ifdef WET_DRY
             cff2=cff2*umask_wet(i,j)
 #  endif
-#  if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
             ubar(i,j,kstp)=cff2
-#  else
-            ubar(i,j,kstp)=cff2
-            ubar(i,j,knew)=cff2
-#  endif
           END DO
 !
           IF (j.ge.JstrM) THEN
@@ -427,12 +401,7 @@
 #  ifdef WET_DRY
               cff2=cff2*vmask_wet(i,j)
 #  endif
-#  if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
               vbar(i,j,kstp)=cff2
-#  else
-              vbar(i,j,kstp)=cff2
-              vbar(i,j,knew)=cff2
-#  endif
             END DO
           END IF
         END DO
@@ -453,19 +422,6 @@
      &                     IminS, ImaxS, JminS, JmaxS,                  &
      &                     krhs, kstp, kstp,                            &
      &                     ubar, vbar, zeta)
-
-#  if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-          CALL u2dbc_tile (ng, tile,                                    &
-     &                     LBi, UBi, LBj, UBj,                          &
-     &                     IminS, ImaxS, JminS, JmaxS,                  &
-     &                     krhs, kstp, knew,                            &
-     &                     ubar, vbar, zeta)
-          CALL v2dbc_tile (ng, tile,                                    &
-     &                     LBi, UBi, LBj, UBj,                          &
-     &                     IminS, ImaxS, JminS, JmaxS,                  &
-     &                     krhs, kstp, knew,                            &
-     &                     ubar, vbar, zeta)
-#  endif
         END IF
       END IF
 !
@@ -476,39 +432,22 @@
         CALL exchange_v2d_tile (ng, tile,                               &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          vbar(:,:,kstp))
-
-#  if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-        CALL exchange_u2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          ubar(:,:,knew))
-        CALL exchange_v2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          vbar(:,:,knew))
-#  endif
       END IF
 
 #  ifdef DISTRIBUTE
 !
-#   if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
       CALL mp_exchange2d (ng, tile, model, 2,                           &
      &                    LBi, UBi, LBj, UBj,                           &
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
      &                    ubar(:,:,kstp), vbar(:,:,kstp))
-#   else
-      CALL mp_exchange2d (ng, tile, model, 4,                           &
-     &                    LBi, UBi, LBj, UBj,                           &
-     &                    NghostPoints,                                 &
-     &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    ubar(:,:,kstp), vbar(:,:,kstp),               &
-     &                    ubar(:,:,knew), vbar(:,:,knew))
-#   endif
 #  endif
 
 # else
 !
 !-----------------------------------------------------------------------
-!  If not perfect restart, initialize other time levels for 2D momentum.
+!  If not perfect restart, initialize other time levels for 2D momentum
+!  (shallow-water model).
 !-----------------------------------------------------------------------
 !
       IF (.not.PerfectRST(ng)) THEN
@@ -522,8 +461,8 @@
             cff1=cff1*umask_wet(i,j)
 #  endif
             ubar(i,j,kstp)=cff1
-            ubar(i,j,krhs)=cff1
           END DO
+!
           IF (j.ge.JstrM) THEN
             DO i=IstrB,IendB
               cff2=vbar(i,j,kstp)
@@ -534,7 +473,6 @@
               cff2=cff2*vmask_wet(i,j)
 #  endif
               vbar(i,j,kstp)=cff2
-              vbar(i,j,krhs)=cff2
             END DO
           END IF
         END DO
@@ -555,17 +493,6 @@
      &                     IminS, ImaxS, JminS, JmaxS,                  &
      &                     krhs, kstp, kstp,                            &
      &                     ubar, vbar, zeta)
-
-          CALL u2dbc_tile (ng, tile,                                    &
-     &                     LBi, UBi, LBj, UBj,                          &
-     &                     IminS, ImaxS, JminS, JmaxS,                  &
-     &                     krhs, kstp, krhs,                            &
-     &                     ubar, vbar, zeta)
-          CALL v2dbc_tile (ng, tile,                                    &
-     &                     LBi, UBi, LBj, UBj,                          &
-     &                     IminS, ImaxS, JminS, JmaxS,                  &
-     &                     krhs, kstp, krhs,                            &
-     &                     ubar, vbar, zeta)
         END IF
       END IF
 !
@@ -576,14 +503,6 @@
         CALL exchange_v2d_tile (ng, tile,                               &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          vbar(:,:,kstp))
-
-        CALL exchange_u2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          ubar(:,:,krhs))
-        CALL exchange_v2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          vbar(:,:,krhs))
-
         IF (PerfectRST(ng)) THEN
           CALL exchange_u2d_tile (ng, tile,                             &
      &                            LBi, UBi, LBj, UBj,                   &
@@ -596,13 +515,11 @@
 
 #  ifdef DISTRIBUTE
 !
-      CALL mp_exchange2d (ng, tile, model, 4,                           &
+      CALL mp_exchange2d (ng, tile, model, 2,                           &
      &                    LBi, UBi, LBj, UBj,                           &
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    ubar(:,:,kstp), vbar(:,:,kstp),               &
-     &                    ubar(:,:,krhs), vbar(:,:,krhs))
-
+     &                    ubar(:,:,kstp), vbar(:,:,kstp))
       IF (PerfectRST(ng)) THEN
         CALL mp_exchange2d (ng, tile, model, 2,                         &
      &                      LBi, UBi, LBj, UBj,                         &
@@ -633,7 +550,6 @@
                 cff1=cff1*rmask(i,j)
 #  endif
                 t(i,j,k,nstp,itrc)=cff1
-                t(i,j,k,nnew,itrc)=cff1
               END DO
             END DO
           END DO
@@ -645,11 +561,6 @@
      &                     IminS, ImaxS, JminS, JmaxS,                  &
      &                     nstp, nstp,                                  &
      &                     t)
-          CALL t3dbc_tile (ng, tile, itrc, ic,                          &
-     &                     LBi, UBi, LBj, UBj, N(ng), NT(ng),           &
-     &                     IminS, ImaxS, JminS, JmaxS,                  &
-     &                     nstp, nnew,                                  &
-     &                     t)
         END DO
       END IF
 !
@@ -658,20 +569,16 @@
           CALL exchange_r3d_tile (ng, tile,                             &
      &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
      &                            t(:,:,:,nstp,itrc))
-          CALL exchange_r3d_tile (ng, tile,                             &
-     &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
-     &                            t(:,:,:,nnew,itrc))
         END DO
       END IF
 
 #  ifdef DISTRIBUTE
 !
-      CALL mp_exchange4d (ng, tile, model, 2,                           &
+      CALL mp_exchange4d (ng, tile, model, 1,                           &
      &                    LBi, UBi, LBj, UBj, 1, N(ng), 1, NT(ng),      &
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    t(:,:,:,nstp,:),                              &
-     &                    t(:,:,:,nnew,:))
+     &                    t(:,:,:,nstp,:))
 #  endif
 
 #  if defined BBL_MODEL || defined SEDIMENT
@@ -946,16 +853,7 @@
 !!            rmask_wet(i,j)=1.0_r8*rmask(i,j)
             END IF
 # endif
-# if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
             zeta(i,j,kstp)=cff1
-# else
-            zeta(i,j,kstp)=cff1
-#  ifdef SOLVE3D
-            zeta(i,j,knew)=cff1
-#  else
-            zeta(i,j,krhs)=cff1
-#  endif
-# endif
           END DO
         END DO
 !
@@ -969,22 +867,6 @@
      &                      IminS, ImaxS, JminS, JmaxS,                 &
      &                      krhs, kstp, kstp,                           &
      &                      zeta)
-
-# if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-#  ifdef SOLVE3D
-          CALL zetabc_tile (ng, tile,                                   &
-     &                      LBi, UBi, LBj, UBj,                         &
-     &                      IminS, ImaxS, JminS, JmaxS,                 &
-     &                      krhs, kstp, knew,                           &
-     &                      zeta)
-#  else
-          CALL zetabc_tile (ng, tile,                                   &
-     &                      LBi, UBi, LBj, UBj,                         &
-     &                      IminS, ImaxS, JminS, JmaxS,                 &
-     &                      krhs, kstp, krhs,                           &
-     &                      zeta)
-#  endif
-# endif
         END IF
       END IF
 !
@@ -992,18 +874,6 @@
         CALL exchange_r2d_tile (ng, tile,                               &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          zeta(:,:,kstp))
-# if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-#  ifdef SOLVE3D
-        CALL exchange_r2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          zeta(:,:,knew))
-#  else
-        CALL exchange_r2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          zeta(:,:,krhs))
-#  endif
-# endif
-
         IF (PerfectRST(ng)) THEN
 # ifdef SOLVE3D
           CALL exchange_r2d_tile (ng, tile,                             &
@@ -1024,30 +894,11 @@
       END IF
 
 # ifdef DISTRIBUTE
-#  if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
       CALL mp_exchange2d (ng, tile, model, 1,                           &
      &                    LBi, UBi, LBj, UBj,                           &
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
      &                    zeta(:,:,kstp))
-#  else
-#   ifdef SOLVE3D
-      CALL mp_exchange2d (ng, tile, model, 2,                           &
-     &                    LBi, UBi, LBj, UBj,                           &
-     &                    NghostPoints,                                 &
-     &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    zeta(:,:,kstp),                               &
-     &                    zeta(:,:,knew))
-#   else
-      CALL mp_exchange2d (ng, tile, model, 2,                           &
-     &                    LBi, UBi, LBj, UBj,                           &
-     &                    NghostPoints,                                 &
-     &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    zeta(:,:,kstp),                               &
-     &                    zeta(:,:,krhs))
-#   endif
-#  endif
-
       IF (PerfectRST(ng)) THEN
 #  ifdef SOLVE3D
         CALL mp_exchange2d (ng, tile, model, 1,                         &

--- a/ROMS/Representer/rp_ini_fields.F
+++ b/ROMS/Representer/rp_ini_fields.F
@@ -224,10 +224,8 @@
             tl_cff1=tl_cff1*umask(i,j)
 #  endif
 !^          u(i,j,k,nstp)=cff1
-!^          u(i,j,k,nnew)=cff1
 !^
             tl_u(i,j,k,nstp)=tl_cff1
-            tl_u(i,j,k,nnew)=tl_cff1
           END DO
         END DO
 !
@@ -243,10 +241,8 @@
               tl_cff2=tl_cff2*vmask(i,j)
 #  endif
 !^            v(i,j,k,nstp)=cff2
-!^            v(i,j,k,nnew)=cff2
 !^
               tl_v(i,j,k,nstp)=tl_cff2
-              tl_v(i,j,k,nnew)=tl_cff2
             END DO
           END DO
         END IF
@@ -276,29 +272,6 @@
      &                    IminS, ImaxS, JminS, JmaxS,                   &
      &                    nstp, nstp,                                   &
      &                    tl_v)
-
-!^    CALL u3dbc_tile (ng, tile,                                        &
-!^   &                 LBi, UBi, LBj, UBj, N(ng),                       &
-!^   &                 IminS, ImaxS, JminS, JmaxS,                      &
-!^   &                 nstp, nnew,                                      &
-!^   &                 u)
-!^
-      CALL rp_u3dbc_tile (ng, tile,                                     &
-     &                    LBi, UBi, LBj, UBj, N(ng),                    &
-     &                    IminS, ImaxS, JminS, JmaxS,                   &
-     &                    nstp, nnew,                                   &
-     &                    tl_u)
-!^    CALL v3dbc_tile (ng, tile,                                        &
-!^   &                 LBi, UBi, LBj, UBj, N(ng),                       &
-!^   &                 IminS, ImaxS, JminS, JmaxS,                      &
-!^   &                 nstp, nnew,                                      &
-!^   &                 v)
-!^
-      CALL rp_v3dbc_tile (ng, tile,                                     &
-     &                    LBi, UBi, LBj, UBj, N(ng),                    &
-     &                    IminS, ImaxS, JminS, JmaxS,                   &
-     &                    nstp, nnew,                                   &
-     &                    tl_v)
 !
       IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
 !^      CALL exchange_u3d_tile (ng, tile,                               &
@@ -316,30 +289,15 @@
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          tl_v(:,:,:,nstp))
 
-!^      CALL exchange_u3d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
-!^   &                          u(:,:,:,nnew))
-!^
-        CALL exchange_u3d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
-     &                          tl_u(:,:,:,nnew))
-!^      CALL exchange_v3d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
-!^   &                          v(:,:,:,nnew))
-!^
-        CALL exchange_v3d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
-     &                          tl_v(:,:,:,nnew))
       END IF
 
 #  ifdef DISTRIBUTE
 !
-!^    CALL mp_exchange3d (ng, tile, model, 4,                           &
+!^    CALL mp_exchange3d (ng, tile, model, 2,                           &
 !^   &                    LBi, UBi, LBj, UBj, 1, N(ng),                 &
 !^   &                    NghostPoints,                                 &
 !^   &                    EWperiodic(ng), NSperiodic(ng),               &
-!^   &                    u(:,:,:,nstp), v(:,:,:,nstp),                 &
-!^   &                    u(:,:,:,nnew), v(:,:,:,nnew))
+!^   &                    u(:,:,:,nstp), v(:,:,:,nstp))
 !^
       CALL mp_exchange3d (ng, tile, model, 4,                           &
      &                    LBi, UBi, LBj, UBj, 1, N(ng),                 &
@@ -398,17 +356,9 @@
 !^
           tl_cff2=tl_cff2*umask(i,j)
 #  endif
-#  if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
 !^        ubar(i,j,kstp)=cff2
 !^
           tl_ubar(i,j,kstp)=tl_cff2
-#  else
-!^        ubar(i,j,kstp)=cff2
-!^        ubar(i,j,knew)=cff2
-!^
-          tl_ubar(i,j,kstp)=tl_cff2
-          tl_ubar(i,j,knew)=tl_cff2
-#  endif
         END DO
 !
         IF (j.ge.JstrM) THEN
@@ -449,17 +399,9 @@
 !^
             tl_cff2=tl_cff2*vmask(i,j)
 #  endif
-#  if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
 !^          vbar(i,j,kstp)=cff2
 !^
             tl_vbar(i,j,kstp)=tl_cff2
-#  else
-!^          vbar(i,j,kstp)=cff2
-!^          vbar(i,j,knew)=cff2
-!^
-            tl_vbar(i,j,kstp)=tl_cff2
-            tl_vbar(i,j,knew)=tl_cff2
-#  endif
           END DO
         END IF
       END DO
@@ -494,33 +436,6 @@
      &                      krhs, kstp, kstp,                           &
      &                      ubar, vbar, zeta,                           &
      &                      tl_ubar, tl_vbar, tl_zeta)
-
-#  if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-!^      CALL u2dbc_tile (ng, tile,                                      &
-!^   &                   LBi, UBi, LBj, UBj,                            &
-!^   &                   IminS, ImaxS, JminS, JmaxS,                    &
-!^   &                   krhs, kstp, knew,                              &
-!^   &                   ubar, vbar, zeta)
-!^
-        CALL rp_u2dbc_tile (ng, tile,                                   &
-     &                      LBi, UBi, LBj, UBj,                         &
-     &                      IminS, ImaxS, JminS, JmaxS,                 &
-     &                      krhs, kstp, knew,                           &
-     &                      ubar, vbar, zeta,                           &
-     &                      tl_ubar, tl_vbar, tl_zeta)
-!^      CALL v2dbc_tile (ng, tile,                                      &
-!^   &                   LBi, UBi, LBj, UBj,                            &
-!^   &                   IminS, ImaxS, JminS, JmaxS,                    &
-!^   &                   krhs, kstp, knew,                              &
-!^   &                   ubar, vbar, zeta)
-!^
-        CALL rp_v2dbc_tile (ng, tile,                                   &
-     &                      LBi, UBi, LBj, UBj,                         &
-     &                      IminS, ImaxS, JminS, JmaxS,                 &
-     &                      krhs, kstp, knew,                           &
-     &                      ubar, vbar, zeta,                           &
-     &                      tl_ubar, tl_vbar, tl_zeta)
-#  endif
       END IF
 !
       IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
@@ -538,28 +453,10 @@
         CALL exchange_v2d_tile (ng, tile,                               &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          tl_vbar(:,:,kstp))
-
-#  if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-!^      CALL exchange_u2d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj,                     &
-!^   &                          ubar(:,:,knew))
-!^
-        CALL exchange_u2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          tl_ubar(:,:,knew))
-!^      CALL exchange_v2d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj,                     &
-!^   &                          vbar(:,:,knew))
-!^
-        CALL exchange_v2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          tl_vbar(:,:,knew))
-#  endif
       END IF
 
 #  ifdef DISTRIBUTE
 !
-#   if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
 !^    CALL mp_exchange2d (ng, tile, model, 2,                           &
 !^   &                    LBi, UBi, LBj, UBj,                           &
 !^   &                    NghostPoints,                                 &
@@ -571,21 +468,6 @@
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
      &                    tl_ubar(:,:,kstp), tl_vbar(:,:,kstp))
-#   else
-!^    CALL mp_exchange2d (ng, tile, model, 4,                           &
-!^   &                    LBi, UBi, LBj, UBj,                           &
-!^   &                    NghostPoints,                                 &
-!^   &                    EWperiodic(ng), NSperiodic(ng),               &
-!^   &                    ubar(:,:,kstp), vbar(:,:,kstp),               &
-!^   &                    ubar(:,:,knew), vbar(:,:,knew))
-!^
-      CALL mp_exchange2d (ng, tile, model, 4,                           &
-     &                    LBi, UBi, LBj, UBj,                           &
-     &                    NghostPoints,                                 &
-     &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    tl_ubar(:,:,kstp), tl_vbar(:,:,kstp),         &
-     &                    tl_ubar(:,:,knew), tl_vbar(:,:,knew))
-#   endif
 #  endif
 
 # else
@@ -605,10 +487,8 @@
           tl_cff1=tl_cff1*umask(i,j)
 #  endif
 !^        ubar(i,j,kstp)=cff1
-!^        ubar(i,j,krhs)=cff1
 !^
           tl_ubar(i,j,kstp)=tl_cff1
-          tl_ubar(i,j,krhs)=tl_cff1
         END DO
 !
         IF (j.ge.JstrM) THEN
@@ -622,10 +502,8 @@
             tl_cff2=tl_cff2*vmask(i,j)
 #  endif
 !^          vbar(i,j,kstp)=cff2
-!^          vbar(i,j,krhs)=cff2
 !^
             tl_vbar(i,j,kstp)=tl_cff2
-            tl_vbar(i,j,krhs)=tl_cff2
           END DO
         END IF
       END DO
@@ -660,33 +538,6 @@
      &                      krhs, kstp, kstp,                           &
      &                      ubar, vbar, zeta,                           &
      &                      tl_ubar, tl_vbar, tl_zeta)
-
-#  if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-!^      CALL u2dbc_tile (ng, tile,                                      &
-!^   &                   LBi, UBi, LBj, UBj,                            &
-!^   &                   IminS, ImaxS, JminS, JmaxS,                    &
-!^   &                   krhs, kstp, krhs,                              &
-!^   &                   ubar, vbar, zeta)
-!^
-        CALL rp_u2dbc_tile (ng, tile,                                   &
-     &                      LBi, UBi, LBj, UBj,                         &
-     &                      IminS, ImaxS, JminS, JmaxS,                 &
-     &                      krhs, kstp, krhs,                           &
-     &                      ubar, vbar, zeta,                           &
-     &                      tl_ubar, tl_vbar, tl_zeta)
-!^      CALL v2dbc_tile (ng, tile,                                      &
-!^   &                   LBi, UBi, LBj, UBj,                            &
-!^   &                   IminS, ImaxS, JminS, JmaxS,                    &
-!^   &                   krhs, kstp, krhs,                              &
-!^   &                   ubar, vbar, zeta)
-!^
-        CALL rp_v2dbc_tile (ng, tile,                                   &
-     &                      LBi, UBi, LBj, UBj,                         &
-     &                      IminS, ImaxS, JminS, JmaxS,                 &
-     &                      krhs, kstp, krhs,                           &
-     &                      ubar, vbar, zeta,                           &
-     &                      tl_ubar, tl_vbar, tl_zeta)
-#  endif
       END IF
 !
       IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
@@ -704,28 +555,10 @@
         CALL exchange_v2d_tile (ng, tile,                               &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          tl_vbar(:,:,kstp))
-
-#  if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-!^      CALL exchange_u2d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj,                     &
-!^   &                          ubar(:,:,krhs))
-!^
-        CALL exchange_u2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          tl_ubar(:,:,krhs))
-!^      CALL exchange_v2d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj,                     &
-!^   &                          vbar(:,:,krhs))
-!^
-        CALL exchange_v2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          tl_vbar(:,:,krhs))
-#  endif
       END IF
 
 #  ifdef DISTRIBUTE
 !
-#   if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
 !^    CALL mp_exchange2d (ng, tile, model, 2,                           &
 !^   &                    LBi, UBi, LBj, UBj,                           &
 !^   &                    NghostPoints,                                 &
@@ -737,21 +570,6 @@
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
      &                    tl_ubar(:,:,kstp), tl_vbar(:,:,kstp))
-#   else
-!^    CALL mp_exchange2d (ng, tile, model, 4,                           &
-!^   &                    LBi, UBi, LBj, UBj,                           &
-!^   &                    NghostPoints,                                 &
-!^   &                    EWperiodic(ng), NSperiodic(ng),               &
-!^   &                    ubar(:,:,kstp), vbar(:,:,kstp),               &
-!^   &                    ubar(:,:,krhs), vbar(:,:,krhs))
-!^
-      CALL mp_exchange2d (ng, tile, model, 4,                           &
-     &                    LBi, UBi, LBj, UBj,                           &
-     &                    NghostPoints,                                 &
-     &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    tl_ubar(:,:,kstp), tl_vbar(:,:,kstp),         &
-     &                    tl_ubar(:,:,krhs), tl_vbar(:,:,krhs))
-#   endif
 #  endif
 # endif
 
@@ -776,10 +594,8 @@
               tl_cff1=tl_cff1*rmask(i,j)
 #  endif
 !^            t(i,j,k,nstp,itrc)=cff1
-!^            t(i,j,k,nnew,itrc)=cff1
 !^
               tl_t(i,j,k,nstp,itrc)=tl_cff1
-              tl_t(i,j,k,nnew,itrc)=tl_cff1
             END DO
           END DO
         END DO
@@ -797,17 +613,6 @@
      &                      IminS, ImaxS, JminS, JmaxS,                 &
      &                      nstp, nstp,                                 &
      &                      tl_t)
-!^      CALL t3dbc_tile (ng, tile, itrc, ic,                            &
-!^   &                   LBi, UBi, LBj, UBj, N(ng), NT(ng),             &
-!^   &                   IminS, ImaxS, JminS, JmaxS,                    &
-!^   &                   nstp, nnew,                                    &
-!^   &                   t)
-!^
-        CALL rp_t3dbc_tile (ng, tile, itrc, ic,                         &
-     &                      LBi, UBi, LBj, UBj, N(ng), NT(ng),          &
-     &                      IminS, ImaxS, JminS, JmaxS,                 &
-     &                      nstp, nnew,                                 &
-     &                      tl_t)
 !
         IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
 !^        CALL exchange_r3d_tile (ng, tile,                             &
@@ -817,31 +622,23 @@
           CALL exchange_r3d_tile (ng, tile,                             &
      &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
      &                            tl_t(:,:,:,nstp,itrc))
-!^        CALL exchange_r3d_tile (ng, tile,                             &
-!^   &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
-!^   &                            t(:,:,:,nnew,itrc))
-!^
-          CALL exchange_r3d_tile (ng, tile,                             &
-     &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
-     &                            tl_t(:,:,:,nnew,itrc))
         END IF
       END DO
 
 #  ifdef DISTRIBUTE
 !
-!^    CALL mp_exchange4d (ng, tile, model, 2,                           &
+!^    CALL mp_exchange4d (ng, tile, model, 1,                           &
 !^   &                    LBi, UBi, LBj, UBj, 1, N(ng), 1, NT(ng),      &
 !^   &                    NghostPoints,                                 &
 !^   &                    EWperiodic(ng), NSperiodic(ng),               &
 !^   &                    t(:,:,:,nstp,:),                              &
 !^   &                    t(:,:,:,nnew,:))
 !^
-      CALL mp_exchange4d (ng, tile, model, 2,                           &
+      CALL mp_exchange4d (ng, tile, model, 1,                           &
      &                    LBi, UBi, LBj, UBj, 1, N(ng), 1, NT(ng),      &
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    tl_t(:,:,:,nstp,:),                           &
-     &                    tl_t(:,:,:,nnew,:))
+     &                    tl_t(:,:,:,nstp,:))
 #  endif
 # endif
 !
@@ -1021,24 +818,9 @@
 !^
           tl_cff1=tl_cff1*rmask(i,j)
 # endif
-# if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
 !^        zeta(i,j,kstp)=cff1
 !^
           tl_zeta(i,j,kstp)=tl_cff1
-# else
-!^        zeta(i,j,kstp)=cff1
-!^
-          tl_zeta(i,j,kstp)=tl_cff1
-#  ifdef SOLVE3D
-!^        zeta(i,j,knew)=cff1
-!^
-          tl_zeta(i,j,knew)=tl_cff1
-#  else
-!^        zeta(i,j,krhs)=cff1
-!^
-          tl_zeta(i,j,krhs)=tl_cff1
-#  endif
-# endif
         END DO
       END DO
 !
@@ -1060,35 +842,6 @@
      &                       zeta,                                      &
      &                       tl_zeta)
 
-# if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-#  ifdef SOLVE3D
-!^      CALL zetabc_tile (ng, tile,                                     &
-!^   &                    LBi, UBi, LBj, UBj,                           &
-!^   &                    IminS, ImaxS, JminS, JmaxS,                   &
-!^   &                    krhs, kstp, knew,                             &
-!^   &                    zeta)
-!^
-        CALL rp_zetabc_tile (ng, tile,                                  &
-     &                       LBi, UBi, LBj, UBj,                        &
-     &                       IminS, ImaxS, JminS, JmaxS,                &
-     &                       krhs, kstp, knew,                          &
-     &                       zeta,                                      &
-     &                       tl_zeta)
-#  else
-!^      CALL zetabc_tile (ng, tile,                                     &
-!^   &                    LBi, UBi, LBj, UBj,                           &
-!^   &                    IminS, ImaxS, JminS, JmaxS,                   &
-!^   &                    krhs, kstp, krhs,                             &
-!^   &                    zeta)
-!^
-        CALL rp_zetabc_tile (ng, tile,                                  &
-     &                       LBi, UBi, LBj, UBj,                        &
-     &                       IminS, ImaxS, JminS, JmaxS,                &
-     &                       krhs, kstp, krhs,                          &
-     &                       zeta,                                      &
-     &                       tl_zeta)
-#  endif
-# endif
       END IF
 !
       IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
@@ -1099,30 +852,10 @@
         CALL exchange_r2d_tile (ng, tile,                               &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          tl_zeta(:,:,kstp))
-
-# if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-#  ifdef SOLVE3D
-!^      CALL exchange_r2d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj,                     &
-!^   &                          zeta(:,:,knew))
-!^
-        CALL exchange_r2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          tl_zeta(:,:,knew))
-#  else
-!^      CALL exchange_r2d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj,                     &
-!^   &                          zeta(:,:,krhs))
-!^
-        CALL exchange_r2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          tl_zeta(:,:,krhs))
-#  endif
-# endif
       END IF
 
 # ifdef DISTRIBUTE
-#  if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
+!
 !^    CALL mp_exchange2d (ng, tile, model, 1,                           &
 !^   &                    LBi, UBi, LBj, UBj,                           &
 !^   &                    NghostPoints,                                 &
@@ -1134,37 +867,6 @@
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
      &                    tl_zeta(:,:,kstp))
-#  else
-#   ifdef SOLVE3D
-!^    CALL mp_exchange2d (ng, tile, model, 2,                           &
-!^   &                    LBi, UBi, LBj, UBj,                           &
-!^   &                    NghostPoints,                                 &
-!^   &                    EWperiodic(ng), NSperiodic(ng),               &
-!^   &                    zeta(:,:,kstp),                               &
-!^   &                    zeta(:,:,knew))
-!^
-      CALL mp_exchange2d (ng, tile, model, 2,                           &
-     &                    LBi, UBi, LBj, UBj,                           &
-     &                    NghostPoints,                                 &
-     &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    tl_zeta(:,:,kstp),                            &
-     &                    tl_zeta(:,:,knew))
-#   else
-!^    CALL mp_exchange2d (ng, tile, model, 2,                           &
-!^   &                    LBi, UBi, LBj, UBj,                           &
-!^   &                    NghostPoints,                                 &
-!^   &                    EWperiodic(ng), NSperiodic(ng),               &
-!^   &                    zeta(:,:,kstp),                               &
-!^   &                    zeta(:,:,krhs))
-!^
-      CALL mp_exchange2d (ng, tile, model, 2,                           &
-     &                    LBi, UBi, LBj, UBj,                           &
-     &                    NghostPoints,                                 &
-     &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    tl_zeta(:,:,kstp),                            &
-     &                    tl_zeta(:,:,krhs))
-#   endif
-#  endif
 # endif
 
 # ifdef SOLVE3D

--- a/ROMS/Tangent/tl_ini_fields.F
+++ b/ROMS/Tangent/tl_ini_fields.F
@@ -230,10 +230,8 @@
             tl_cff1=tl_cff1*umask(i,j)
 #  endif
 !^          u(i,j,k,nstp)=cff1
-!^          u(i,j,k,nnew)=cff1
 !^
             tl_u(i,j,k,nstp)=tl_cff1
-            tl_u(i,j,k,nnew)=tl_cff1
           END DO
         END DO
 !
@@ -249,10 +247,8 @@
               tl_cff2=tl_cff2*vmask(i,j)
 #  endif
 !^            v(i,j,k,nstp)=cff2
-!^            v(i,j,k,nnew)=cff2
 !^
               tl_v(i,j,k,nstp)=tl_cff2
-              tl_v(i,j,k,nnew)=tl_cff2
             END DO
           END DO
         END IF
@@ -282,29 +278,6 @@
      &                    IminS, ImaxS, JminS, JmaxS,                   &
      &                    nstp, nstp,                                   &
      &                    tl_v)
-
-!^    CALL u3dbc_tile (ng, tile,                                        &
-!^   &                 LBi, UBi, LBj, UBj, N(ng),                       &
-!^   &                 IminS, ImaxS, JminS, JmaxS,                      &
-!^   &                 nstp, nnew,                                      &
-!^   &                 u)
-!^
-      CALL tl_u3dbc_tile (ng, tile,                                     &
-     &                    LBi, UBi, LBj, UBj, N(ng),                    &
-     &                    IminS, ImaxS, JminS, JmaxS,                   &
-     &                    nstp, nnew,                                   &
-     &                    tl_u)
-!^    CALL v3dbc_tile (ng, tile,                                        &
-!^   &                 LBi, UBi, LBj, UBj, N(ng),                       &
-!^   &                 IminS, ImaxS, JminS, JmaxS,                      &
-!^   &                 nstp, nnew,                                      &
-!^   &                 v)
-!^
-      CALL tl_v3dbc_tile (ng, tile,                                     &
-     &                    LBi, UBi, LBj, UBj, N(ng),                    &
-     &                    IminS, ImaxS, JminS, JmaxS,                   &
-     &                    nstp, nnew,                                   &
-     &                    tl_v)
 !
       IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
 !^      CALL exchange_u3d_tile (ng, tile,                               &
@@ -321,38 +294,21 @@
         CALL exchange_v3d_tile (ng, tile,                               &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          tl_v(:,:,:,nstp))
-
-!^      CALL exchange_u3d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
-!^   &                          u(:,:,:,nnew))
-!^
-        CALL exchange_u3d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
-     &                          tl_u(:,:,:,nnew))
-!^      CALL exchange_v3d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
-!^   &                          v(:,:,:,nnew))
-!^
-        CALL exchange_v3d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
-     &                          tl_v(:,:,:,nnew))
       END IF
 
 #  ifdef DISTRIBUTE
 !
-!^    CALL mp_exchange3d (ng, tile, model, 4,                           &
+!^    CALL mp_exchange3d (ng, tile, model, 2,                           &
 !^   &                    LBi, UBi, LBj, UBj, 1, N(ng),                 &
 !^   &                    NghostPoints,                                 &
 !^   &                    EWperiodic(ng), NSperiodic(ng),               &
-!^   &                    u(:,:,:,nstp), v(:,:,:,nstp),                 &
-!^   &                    u(:,:,:,nnew), v(:,:,:,nnew))
+!^   &                    u(:,:,:,nstp), v(:,:,:,nstp))
 !^
-      CALL mp_exchange3d (ng, tile, model, 4,                           &
+      CALL mp_exchange3d (ng, tile, model, 2,                           &
      &                    LBi, UBi, LBj, UBj, 1, N(ng),                 &
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    tl_u(:,:,:,nstp), tl_v(:,:,:,nstp),           &
-     &                    tl_u(:,:,:,nnew), tl_v(:,:,:,nnew))
+     &                    tl_u(:,:,:,nstp), tl_v(:,:,:,nstp))
 #  endif
 # endif
 
@@ -398,17 +354,9 @@
 !^
           tl_cff2=tl_cff2*umask(i,j)
 #  endif
-#  if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
 !^        ubar(i,j,kstp)=cff2
 !^
           tl_ubar(i,j,kstp)=tl_cff2
-#  else
-!^        ubar(i,j,kstp)=cff2
-!^        ubar(i,j,knew)=cff2
-!^
-          tl_ubar(i,j,kstp)=tl_cff2
-          tl_ubar(i,j,knew)=tl_cff2
-#  endif
         END DO
 !
         IF (j.ge.JstrM) THEN
@@ -440,17 +388,9 @@
 !^
             tl_cff2=tl_cff2*vmask(i,j)
 #  endif
-#  if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
 !^          vbar(i,j,kstp)=cff2
 !^
             tl_vbar(i,j,kstp)=tl_cff2
-#  else
-!^          vbar(i,j,kstp)=cff2
-!^          vbar(i,j,knew)=cff2
-!^
-            tl_vbar(i,j,kstp)=tl_cff2
-            tl_vbar(i,j,knew)=tl_cff2
-#  endif
           END DO
         END IF
       END DO
@@ -485,33 +425,6 @@
      &                      krhs, kstp, kstp,                           &
      &                      ubar, vbar, zeta,                           &
      &                      tl_ubar, tl_vbar, tl_zeta)
-
-#  if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-!^      CALL u2dbc_tile (ng, tile,                                      &
-!^   &                   LBi, UBi, LBj, UBj,                            &
-!^   &                   IminS, ImaxS, JminS, JmaxS,                    &
-!^   &                   krhs, kstp, knew,                              &
-!^   &                   ubar, vbar, zeta)
-!^
-        CALL tl_u2dbc_tile (ng, tile,                                   &
-     &                      LBi, UBi, LBj, UBj,                         &
-     &                      IminS, ImaxS, JminS, JmaxS,                 &
-     &                      krhs, kstp, knew,                           &
-     &                      ubar, vbar, zeta,                           &
-     &                      tl_ubar, tl_vbar, tl_zeta)
-!^      CALL v2dbc_tile (ng, tile,                                      &
-!^   &                   LBi, UBi, LBj, UBj,                            &
-!^   &                   IminS, ImaxS, JminS, JmaxS,                    &
-!^   &                   krhs, kstp, knew,                              &
-!^   &                   ubar, vbar, zeta)
-!^
-        CALL tl_v2dbc_tile (ng, tile,                                   &
-     &                      LBi, UBi, LBj, UBj,                         &
-     &                      IminS, ImaxS, JminS, JmaxS,                 &
-     &                      krhs, kstp, knew,                           &
-     &                      ubar, vbar, zeta,                           &
-     &                      tl_ubar, tl_vbar, tl_zeta)
-#  endif
       END IF
 !
       IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
@@ -529,28 +442,10 @@
         CALL exchange_v2d_tile (ng, tile,                               &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          tl_vbar(:,:,kstp))
-
-#  if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-!^      CALL exchange_u2d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj,                     &
-!^   &                          ubar(:,:,knew))
-!^
-        CALL exchange_u2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          tl_ubar(:,:,knew))
-!^      CALL exchange_v2d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj,                     &
-!^   &                          vbar(:,:,knew))
-!^
-        CALL exchange_v2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          tl_vbar(:,:,knew))
-#  endif
       END IF
 
 #  ifdef DISTRIBUTE
 !
-#   if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
 !^    CALL mp_exchange2d (ng, tile, model, 2,                           &
 !^   &                    LBi, UBi, LBj, UBj,                           &
 !^   &                    NghostPoints,                                 &
@@ -562,21 +457,6 @@
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
      &                    tl_ubar(:,:,kstp), tl_vbar(:,:,kstp))
-#   else
-!^    CALL mp_exchange2d (ng, tile, model, 4,                           &
-!^   &                    LBi, UBi, LBj, UBj,                           &
-!^   &                    NghostPoints,                                 &
-!^   &                    EWperiodic(ng), NSperiodic(ng),               &
-!^   &                    ubar(:,:,kstp), vbar(:,:,kstp),               &
-!^   &                    ubar(:,:,knew), vbar(:,:,knew))
-!^
-      CALL mp_exchange2d (ng, tile, model, 4,                           &
-     &                    LBi, UBi, LBj, UBj,                           &
-     &                    NghostPoints,                                 &
-     &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    tl_ubar(:,:,kstp), tl_vbar(:,:,kstp),         &
-     &                    tl_ubar(:,:,knew), tl_vbar(:,:,knew))
-#   endif
 #  endif
 
 #  if defined STOCHASTIC_OPT && !defined STOCH_OPT_WHITE
@@ -586,7 +466,7 @@
 # else
 !
 !-----------------------------------------------------------------------
-!  Initialize other time levels for 2D momentum.
+!  Initialize other time levels for 2D momentum (shallow-water model).
 !-----------------------------------------------------------------------
 !
       DO j=JstrB,JendB
@@ -602,12 +482,6 @@
 !^        ubar(i,j,kstp)=cff1
 !^
           tl_ubar(i,j,kstp)=tl_cff1
-#  if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-
-!^        ubar(i,j,krhs)=cff1
-!^
-          tl_ubar(i,j,krhs)=tl_cff1
-#  endif
         END DO
 !
         IF (j.ge.JstrM) THEN
@@ -623,11 +497,6 @@
 !^          vbar(i,j,kstp)=cff2
 !^
             tl_vbar(i,j,kstp)=tl_cff2
-#  if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-!^          vbar(i,j,krhs)=cff2
-!^
-            tl_vbar(i,j,krhs)=tl_cff2
-#  endif
           END DO
         END IF
       END DO
@@ -662,33 +531,6 @@
      &                      krhs, kstp, kstp,                           &
      &                      ubar, vbar, zeta,                           &
      &                      tl_ubar, tl_vbar, tl_zeta)
-
-#  if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-!^      CALL u2dbc_tile (ng, tile,                                      &
-!^   &                   LBi, UBi, LBj, UBj,                            &
-!^   &                   IminS, ImaxS, JminS, JmaxS,                    &
-!^   &                   krhs, kstp, krhs,                              &
-!^   &                   ubar, vbar, zeta)
-!^
-        CALL tl_u2dbc_tile (ng, tile,                                   &
-     &                      LBi, UBi, LBj, UBj,                         &
-     &                      IminS, ImaxS, JminS, JmaxS,                 &
-     &                      krhs, kstp, krhs,                           &
-     &                      ubar, vbar, zeta,                           &
-     &                      tl_ubar, tl_vbar, tl_zeta)
-!^      CALL v2dbc_tile (ng, tile,                                      &
-!^   &                   LBi, UBi, LBj, UBj,                            &
-!^   &                   IminS, ImaxS, JminS, JmaxS,                    &
-!^   &                   krhs, kstp, krhs,                              &
-!^   &                   ubar, vbar, zeta)
-!^
-        CALL tl_v2dbc_tile (ng, tile,                                   &
-     &                      LBi, UBi, LBj, UBj,                         &
-     &                      IminS, ImaxS, JminS, JmaxS,                 &
-     &                      krhs, kstp, krhs,                           &
-     &                      ubar, vbar, zeta,                           &
-     &                      tl_ubar, tl_vbar, tl_zeta)
-#  endif
       END IF
 !
       IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
@@ -706,28 +548,10 @@
         CALL exchange_v2d_tile (ng, tile,                               &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          tl_vbar(:,:,kstp))
-
-#  if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-!^      CALL exchange_u2d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj,                     &
-!^   &                          ubar(:,:,krhs))
-!^
-        CALL exchange_u2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          tl_ubar(:,:,krhs))
-!^      CALL exchange_v2d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj,                     &
-!^   &                          vbar(:,:,krhs))
-!^
-        CALL exchange_v2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          tl_vbar(:,:,krhs))
-#  endif
       END IF
 
 #  ifdef DISTRIBUTE
 !
-#   if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
 !^    CALL mp_exchange2d (ng, tile, model, 2,                           &
 !^   &                    LBi, UBi, LBj, UBj,                           &
 !^   &                    NghostPoints,                                 &
@@ -739,21 +563,6 @@
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
      &                    tl_ubar(:,:,kstp), tl_vbar(:,:,kstp))
-#   else
-!^    CALL mp_exchange2d (ng, tile, model, 4,                           &
-!^   &                    LBi, UBi, LBj, UBj,                           &
-!^   &                    NghostPoints,                                 &
-!^   &                    EWperiodic(ng), NSperiodic(ng),               &
-!^   &                    ubar(:,:,kstp), vbar(:,:,kstp),               &
-!^   &                    ubar(:,:,krhs), vbar(:,:,krhs))
-!^
-      CALL mp_exchange2d (ng, tile, model, 4,                           &
-     &                    LBi, UBi, LBj, UBj,                           &
-     &                    NghostPoints,                                 &
-     &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    tl_ubar(:,:,kstp), tl_vbar(:,:,kstp),         &
-     &                    tl_ubar(:,:,krhs), tl_vbar(:,:,krhs))
-#   endif
 #  endif
 # endif
 
@@ -778,10 +587,8 @@
               tl_cff1=tl_cff1*rmask(i,j)
 #  endif
 !^            t(i,j,k,nstp,itrc)=cff1
-!^            t(i,j,k,nnew,itrc)=cff1
 !^
               tl_t(i,j,k,nstp,itrc)=tl_cff1
-              tl_t(i,j,k,nnew,itrc)=tl_cff1
             END DO
           END DO
         END DO
@@ -799,17 +606,6 @@
      &                      IminS, ImaxS, JminS, JmaxS,                 &
      &                      nstp, nstp,                                 &
      &                      tl_t)
-!^      CALL t3dbc_tile (ng, tile, itrc, ic,                            &
-!^   &                   LBi, UBi, LBj, UBj, N(ng), NT(ng),             &
-!^   &                   IminS, ImaxS, JminS, JmaxS,                    &
-!^   &                   nstp, nnew,                                    &
-!^   &                   t)
-!^
-        CALL tl_t3dbc_tile (ng, tile, itrc, ic,                         &
-     &                      LBi, UBi, LBj, UBj, N(ng), NT(ng),          &
-     &                      IminS, ImaxS, JminS, JmaxS,                 &
-     &                      nstp, nnew,                                 &
-     &                      tl_t)
 !
         IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
 !^        CALL exchange_r3d_tile (ng, tile,                             &
@@ -819,31 +615,22 @@
           CALL exchange_r3d_tile (ng, tile,                             &
      &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
      &                            tl_t(:,:,:,nstp,itrc))
-!^        CALL exchange_r3d_tile (ng, tile,                             &
-!^   &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
-!^   &                            t(:,:,:,nnew,itrc))
-!^
-          CALL exchange_r3d_tile (ng, tile,                             &
-     &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
-     &                            tl_t(:,:,:,nnew,itrc))
         END IF
       END DO
 
 #  ifdef DISTRIBUTE
 !
-!^    CALL mp_exchange4d (ng, tile, model, 2,                           &
+!^    CALL mp_exchange4d (ng, tile, model, 1,                           &
 !^   &                    LBi, UBi, LBj, UBj, 1, N(ng), 1, NT(ng),      &
 !^   &                    NghostPoints,                                 &
 !^   &                    EWperiodic(ng), NSperiodic(ng),               &
-!^   &                    t(:,:,:,nstp,:),                              &
-!^   &                    t(:,:,:,nnew,:))
+!^   &                    t(:,:,:,nstp,:))
 !^
-      CALL mp_exchange4d (ng, tile, model, 2,                           &
+      CALL mp_exchange4d (ng, tile, model, 1,                           &
      &                    LBi, UBi, LBj, UBj, 1, N(ng), 1, NT(ng),      &
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    tl_t(:,:,:,nstp,:),                           &
-     &                    tl_t(:,:,:,nnew,:))
+     &                    tl_t(:,:,:,nstp,:))
 #  endif
 # endif
 !
@@ -1001,24 +788,9 @@
 !^
           tl_cff1=tl_cff1*rmask(i,j)
 # endif
-# if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
 !^        zeta(i,j,kstp)=cff1
 !^
           tl_zeta(i,j,kstp)=tl_cff1
-# else
-!^        zeta(i,j,kstp)=cff1
-!^
-          tl_zeta(i,j,kstp)=tl_cff1
-#  ifdef SOLVE3D
-!^        zeta(i,j,knew)=cff1
-!^
-          tl_zeta(i,j,knew)=tl_cff1
-#  else
-!^        zeta(i,j,krhs)=cff1
-!^
-          tl_zeta(i,j,krhs)=tl_cff1
-#  endif
-# endif
         END DO
       END DO
 !
@@ -1039,36 +811,6 @@
      &                       krhs, kstp, kstp,                          &
      &                       zeta,                                      &
      &                       tl_zeta)
-
-# if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-#  ifdef SOLVE3D
-!^      CALL zetabc_tile (ng, tile,                                     &
-!^   &                    LBi, UBi, LBj, UBj,                           &
-!^   &                    IminS, ImaxS, JminS, JmaxS,                   &
-!^   &                    krhs, kstp, knew,                             &
-!^   &                    zeta)
-!^
-        CALL tl_zetabc_tile (ng, tile,                                  &
-     &                       LBi, UBi, LBj, UBj,                        &
-     &                       IminS, ImaxS, JminS, JmaxS,                &
-     &                       krhs, kstp, knew,                          &
-     &                       zeta,                                      &
-     &                       tl_zeta)
-#  else
-!^      CALL zetabc_tile (ng, tile,                                     &
-!^   &                    LBi, UBi, LBj, UBj,                           &
-!^   &                    IminS, ImaxS, JminS, JmaxS,                   &
-!^   &                    krhs, kstp, krhs,                             &
-!^   &                    zeta)
-!^
-        CALL tl_zetabc_tile (ng, tile,                                  &
-     &                       LBi, UBi, LBj, UBj,                        &
-     &                       IminS, ImaxS, JminS, JmaxS,                &
-     &                       krhs, kstp, krhs,                          &
-     &                       zeta,                                      &
-     &                       tl_zeta)
-#  endif
-# endif
       END IF
 !
       IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
@@ -1079,30 +821,10 @@
         CALL exchange_r2d_tile (ng, tile,                               &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          tl_zeta(:,:,kstp))
-
-# if !(defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3)
-#  ifdef SOLVE3D
-!^      CALL exchange_r2d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj,                     &
-!^   &                          zeta(:,:,knew))
-!^
-        CALL exchange_r2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          tl_zeta(:,:,knew))
-#  else
-!^      CALL exchange_r2d_tile (ng, tile,                               &
-!^   &                          LBi, UBi, LBj, UBj,                     &
-!^   &                          zeta(:,:,krhs))
-!^
-        CALL exchange_r2d_tile (ng, tile,                               &
-     &                          LBi, UBi, LBj, UBj,                     &
-     &                          tl_zeta(:,:,krhs))
-#  endif
-# endif
       END IF
 
 # ifdef DISTRIBUTE
-#  if defined STEP2D_FB_AB3_AM4 || defined STEP2D_FB_LF_AM3
+!
 !^    CALL mp_exchange2d (ng, tile, model, 1,                           &
 !^   &                    LBi, UBi, LBj, UBj,                           &
 !^   &                    NghostPoints,                                 &
@@ -1114,37 +836,6 @@
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
      &                    tl_zeta(:,:,kstp))
-#  else
-#   ifdef SOLVE3D
-!^    CALL mp_exchange2d (ng, tile, model, 2,                           &
-!^   &                    LBi, UBi, LBj, UBj,                           &
-!^   &                    NghostPoints,                                 &
-!^   &                    EWperiodic(ng), NSperiodic(ng),               &
-!^   &                    zeta(:,:,kstp),                               &
-!^   &                    zeta(:,:,knew))
-!^
-      CALL mp_exchange2d (ng, tile, model, 2,                           &
-     &                    LBi, UBi, LBj, UBj,                           &
-     &                    NghostPoints,                                 &
-     &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    tl_zeta(:,:,kstp),                            &
-     &                    tl_zeta(:,:,knew))
-#   else
-!^    CALL mp_exchange2d (ng, tile, model, 2,                           &
-!^   &                    LBi, UBi, LBj, UBj,                           &
-!^   &                    NghostPoints,                                 &
-!^   &                    EWperiodic(ng), NSperiodic(ng),               &
-!^   &                    zeta(:,:,kstp),                               &
-!^   &                    zeta(:,:,krhs))
-!^
-      CALL mp_exchange2d (ng, tile, model, 2,                           &
-     &                    LBi, UBi, LBj, UBj,                           &
-     &                    NghostPoints,                                 &
-     &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    tl_zeta(:,:,kstp),                            &
-     &                    tl_zeta(:,:,krhs))
-#   endif
-#  endif
 # endif
 
 # ifdef SOLVE3D

--- a/ROMS/Tangent/tl_main3d.F
+++ b/ROMS/Tangent/tl_main3d.F
@@ -45,7 +45,7 @@
 # if defined WAV_COUPLING_NOT_YET && defined MCT_LIB
       USE mct_coupler_mod,      ONLY : ocn2wav_coupling
 # endif
-# ifdef FORWARD_READ
+# if defined FORWARD_READ || defined JEDI
       USE omega_mod,            ONLY : omega
       USE set_depth_mod,        ONLY : set_depth
       USE set_massflux_mod,     ONLY : set_massflux
@@ -230,7 +230,7 @@
                 IF (ProcessInputData(ng)) THEN
                   CALL tl_set_data (ng, tile)
                 END IF
-# ifdef FORWARD_READ
+# if defined FORWARD_READ || defined JEDI
                 CALL set_depth (ng, tile, iTLM)
 # endif
               END DO
@@ -238,7 +238,7 @@
             END DO
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
-# ifdef FORWARD_READ
+# if defined FORWARD_READ || defined JEDI
 !
 !-----------------------------------------------------------------------
 !  Compute BASIC STATE horizontal mass fluxes (Hz*u/n and Hz*v/m).
@@ -328,7 +328,7 @@
                 CALL equilibrium_tide (ng, tile, iTLM)
 # endif
                 CALL tl_diag (ng, tile)
-# ifdef FORWARD_READ
+# if defined FORWARD_READ || defined JEDI
                 CALL omega (ng, tile, iTLM)
 # endif
 # ifdef TLM_CHECK

--- a/ROMS/Tangent/tl_zetabc.F
+++ b/ROMS/Tangent/tl_zetabc.F
@@ -241,7 +241,7 @@
 !
 !  Western edge, clamped boundary condition.
 !
-        ELSE IF (tl_LBC(iwest,isFsur,ng)%gradient) THEN
+        ELSE IF (tl_LBC(iwest,isFsur,ng)%clamped) THEN
           DO j=Jstr,Jend
             IF (LBC_apply(ng)%west(j)) THEN
 !^            zeta(Istr-1,j,kout)=BOUNDARY(ng)%zeta_west(j)


### PR DESCRIPTION
Updates to ROMS **NLM**, **TLM**, **RPM**, and **ADM** kernels:
 
* In **initial.F**, **tl_initial.F**, and **rp_initial.F**, we initialize **`kstp=krhs=knew=1`** and **`nstp=nrhs=nnew=1`** time levels for the 2D and 3D kernels., respectively. However, in **ad_initial.F** we initialize **`kstp=1`**, **`krhs=3`**, **knew=2** and **`nstp=nrhs=1`**, **`nnew=2`** because we need to take the adjoint of the rolling indices when time stepping backward.
* Then, in **ini_fields.F** and **tl_ini_fields.F**, we vertically integrate **`u(nstp)`** and **`v(nstp)`** to compute **`ubar(kstp)=ubar(knew)=cff2`**, **`vbar(kstp)=vbar(knew)=cff2`** and **`tl_ubar(kstp)=tl_ubar(knew)=tl_cff2`**, **`tl_vbar(kstp)=tl_vbar(knew)=tl_cff2`**.  Hence, we apply the boundary conditions for indices **`kstp=knew=1`** and parallel exchanges. In the **NLM**, **TLM**, and **RPM**, that assignment to the same time index **1**, twice is harmless, but when we take the discrete adjoint, we are in trouble. 
* Similarly, we initialize **`u(nstp)=u(nnew)`** and **`v(nstp)=v(nnew)`**.
* Now, in **step2d.F**, when **iif(ng)=1**, we have a Forward-Euler in the predictor step that only needs **`kstp=1`** and a Backward-Euler for the corrector step. Otherwise, for **`iif(ng)>1`**, we use a leapfrog for the predictor step and Adams-Moulton for the corrector step.
* Notice that in **`main3d.F`**, the 3D indices are rolled at the bottom of the routine and the 2D indices before calling **`step2d`**. The **`ini_fields`** routine is at the top of **`main3d`** before any timestep-level index rolling.

Corrected  CPP directives in **`tl_main3d.F`** and **`ad_main3d.F`**:

* We need to have **`if defined FORWARD_READ || defined JEDI`** instead.
* Now the sanity dot product in the **`LinearModel.h`** passes in the **`testLinearModelAdjoint`**  Unit Test case. We get the following values when comparing standalone ROMS and ROMS-JEDI cases, respectively:
``` d
>> [dot0,dot1] = tlad_dotproduct(TLname, ADname);
  
TL/AD date: 01-03 00:00:00 / 01-03 06:00:00, TLrec = 01, ADrec = 13, Dot Product = 112.84303514
TL/AD date: 01-03 00:30:00 / 01-03 05:30:00, TLrec = 02, ADrec = 12, Dot Product = 187.74224524
TL/AD date: 01-03 01:00:00 / 01-03 05:00:00, TLrec = 03, ADrec = 11, Dot Product = 112.04213911
TL/AD date: 01-03 01:30:00 / 01-03 04:30:00, TLrec = 04, ADrec = 10, Dot Product = 142.80619119
TL/AD date: 01-03 02:00:00 / 01-03 04:00:00, TLrec = 05, ADrec = 09, Dot Product = 132.49011272
TL/AD date: 01-03 02:30:00 / 01-03 03:30:00, TLrec = 06, ADrec = 08, Dot Product = 158.24016596
TL/AD date: 01-03 03:00:00 / 01-03 03:00:00, TLrec = 07, ADrec = 07, Dot Product = 177.18011365
TL/AD date: 01-03 03:30:00 / 01-03 02:30:00, TLrec = 08, ADrec = 06, Dot Product = 179.46528054
TL/AD date: 01-03 04:00:00 / 01-03 02:00:00, TLrec = 09, ADrec = 05, Dot Product = 192.82609918
TL/AD date: 01-03 04:30:00 / 01-03 01:30:00, TLrec = 10, ADrec = 04, Dot Product = 161.60554627
TL/AD date: 01-03 05:00:00 / 01-03 01:00:00, TLrec = 11, ADrec = 03, Dot Product = 108.95125745
TL/AD date: 01-03 05:30:00 / 01-03 00:30:00, TLrec = 12, ADrec = 02, Dot Product = 98.12076241
TL/AD date: 01-03 06:00:00 / 01-03 00:00:00, TLrec = 13, ADrec = 01, Dot Product = 112.84303514
  
Initial, dot0 = 112.84303514
Final,   dot1 = 112.84303514
    dot1-dot0 = 2.55795385e-13

>> [dot0,dot1] = tlad_dotproduct(TLjedi, ADjedi);
  
TL/AD date: 01-03 00:00:00 / 01-03 06:00:00, TLrec = 01, ADrec = 13, Dot Product = 112.84314694
TL/AD date: 01-03 00:30:00 / 01-03 05:30:00, TLrec = 02, ADrec = 12, Dot Product = 187.74240700
TL/AD date: 01-03 01:00:00 / 01-03 05:00:00, TLrec = 03, ADrec = 11, Dot Product = 112.04221197
TL/AD date: 01-03 01:30:00 / 01-03 04:30:00, TLrec = 04, ADrec = 10, Dot Product = 142.80631926
TL/AD date: 01-03 02:00:00 / 01-03 04:00:00, TLrec = 05, ADrec = 09, Dot Product = 132.49023204
TL/AD date: 01-03 02:30:00 / 01-03 03:30:00, TLrec = 06, ADrec = 08, Dot Product = 158.24031161
TL/AD date: 01-03 03:00:00 / 01-03 03:00:00, TLrec = 07, ADrec = 07, Dot Product = 177.18024401
TL/AD date: 01-03 03:30:00 / 01-03 02:30:00, TLrec = 08, ADrec = 06, Dot Product = 179.46541770
TL/AD date: 01-03 04:00:00 / 01-03 02:00:00, TLrec = 09, ADrec = 05, Dot Product = 192.82623867
TL/AD date: 01-03 04:30:00 / 01-03 01:30:00, TLrec = 10, ADrec = 04, Dot Product = 161.60567291
TL/AD date: 01-03 05:00:00 / 01-03 01:00:00, TLrec = 11, ADrec = 03, Dot Product = 108.95140191
TL/AD date: 01-03 05:30:00 / 01-03 00:30:00, TLrec = 12, ADrec = 02, Dot Product = 98.12088831
TL/AD date: 01-03 06:00:00 / 01-03 00:00:00, TLrec = 13, ADrec = 01, Dot Product = 112.84314694
  
Initial, dot0 = 112.84314694
Final,   dot1 = 112.84314694
    dot1-dot0 = 6.82121026e-13
```
* That is, the **TLM** and **ADM** operators are now discretely symmetric with roundoff.  It will facilitate running the 4D-Var algorithms without worrying about convergence in the minimization over the inner loops.