### PR TITLE
Added extra argument to stats routines and fixed LandFill switch

### DIFF
--- a/ROMS/Functionals/ana_biology.h
+++ b/ROMS/Functionals/ana_biology.h
@@ -102,6 +102,7 @@
       IF (first) THEN
         first=.FALSE.
         DO i=1,SIZE(Stats,1)
+          Stats(i) % checksum=0_i8b
           Stats(i) % count=0.0_r8
           Stats(i) % min=Large
           Stats(i) % max=-Large
@@ -397,7 +398,7 @@
 !
       DO itrc=1,NBT
         i=idbio(itrc)
-        CALL stats_3dfld (ng, tile, iNLM, u3dvar, Stats(itrc),          &
+        CALL stats_3dfld (ng, tile, iNLM, r3dvar, Stats(itrc), 0,       &
      &                    LBi, UBi, LBj, UBj, 1, N(ng), t(:,:,:,1,i))
         IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
           WRITE (stdout,10) TRIM(Vname(2,idTvar(i)))//': '//            &

--- a/ROMS/Functionals/ana_drag.h
+++ b/ROMS/Functionals/ana_drag.h
@@ -216,7 +216,7 @@
 !  Report statistics.
 !
 #if defined UV_LOGDRAG
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats,                  &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats, 0,               &
      &                  LBi, UBi, LBj, UBj, ZoBot)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'time invariant, bottom roughness '//         &
@@ -224,14 +224,14 @@
      &                    ng, Stats%min, Stats%max
       END IF
 #elif defined UV_LDRAG
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats,                  &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats, 0,               &
      &                  LBi, UBi, LBj, UBj, rdrag)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'linear bottom drag coefficient: rdrag',      &
      &                    ng, Stats%min, Stats%max
       END IF
 #elif defined UV_QDRAG
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats,                  &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats, 0,               &
      &                  LBi, UBi, LBj, UBj, rdrag2)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'quadratic bottom drag coefficient: rdrag2',  &

--- a/ROMS/Functionals/ana_grid.h
+++ b/ROMS/Functionals/ana_grid.h
@@ -536,104 +536,104 @@
 !  Report statistics.
 !
 #ifdef SPHERICAL
-      CALL stats_2dfld (ng, tile, iNLM, p2dvar, Stats(1),               &
+      CALL stats_2dfld (ng, tile, iNLM, p2dvar, Stats(1), 0,            &
      &                  LBi, UBi, LBj, UBj, lonp)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'longitude of PSI-points: lon_psi',           &
      &                     ng, Stats(1)%min, Stats(1)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, p2dvar, Stats(2),               &
+      CALL stats_2dfld (ng, tile, iNLM, p2dvar, Stats(2), 0,            &
      &                  LBi, UBi, LBj, UBj, latp)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'latitude of PSI-points: lat_psi',            &
      &                     ng, Stats(2)%min, Stats(2)%max
       END IF
 
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(3),               &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(3), 0,            &
      &                  LBi, UBi, LBj, UBj, lonr)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'longitude of RHO-points: lon_rho',           &
      &                     ng, Stats(3)%min, Stats(3)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(4),               &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(4), 0,            &
      &                  LBi, UBi, LBj, UBj, latr)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'latitude of RHO-points: lat_rho',            &
      &                     ng, Stats(4)%min, Stats(4)%max
       END IF
 
-      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(5),               &
+      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(5), 0,            &
      &                  LBi, UBi, LBj, UBj, lonu)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'longitude of U-points: lon_u',               &
      &                     ng, Stats(5)%min, Stats(5)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(6),               &
+      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(6), 0,            &
      &                  LBi, UBi, LBj, UBj, latu)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'latitude of U-points: lat_u',                &
      &                     ng, Stats(6)%min, Stats(6)%max
       END IF
 
-      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(7),               &
+      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(7), 0,            &
      &                  LBi, UBi, LBj, UBj, lonv)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'longitude of V-points: lon_v',               &
      &                     ng, Stats(7)%min, Stats(7)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(8),               &
+      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(8), 0,            &
      &                  LBi, UBi, LBj, UBj, latv)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'latitude of V-points: lat_v',                &
      &                     ng, Stats(8)%min, Stats(8)%max
       END IF
 #else
-      CALL stats_2dfld (ng, tile, iNLM, p2dvar, Stats(1),               &
+      CALL stats_2dfld (ng, tile, iNLM, p2dvar, Stats(1), 0,            &
      &                  LBi, UBi, LBj, UBj, xp)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'x-location of PSI-points: x_psi',            &
      &                     ng, Stats(1)%min, Stats(1)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, p2dvar, Stats(2),               &
+      CALL stats_2dfld (ng, tile, iNLM, p2dvar, Stats(2), 0,            &
      &                  LBi, UBi, LBj, UBj, yp)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'y-location of PSI-points: y_psi',            &
      &                     ng, Stats(2)%min, Stats(2)%max
       END IF
 
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(3),               &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(3), 0,            &
      &                  LBi, UBi, LBj, UBj, xr)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'x-location of RHO-points: x_rho',            &
      &                     ng, Stats(3)%min, Stats(3)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(4),               &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(4), 0,            &
      &                  LBi, UBi, LBj, UBj, yr)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'y-location of RHO-points: y_rho',            &
      &                     ng, Stats(4)%min, Stats(4)%max
       END IF
 
-      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(5),               &
+      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(5), 0,            &
      &                  LBi, UBi, LBj, UBj, xu)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'x-location of U-points: x_u',                &
      &                     ng, Stats(5)%min, Stats(5)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(6),               &
+      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(6), 0,            &
      &                  LBi, UBi, LBj, UBj, yu)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'y-location of U-points: y_u',                &
      &                     ng, Stats(6)%min, Stats(6)%max
       END IF
 
-      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(7),               &
+      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(7), 0,            &
      &                  LBi, UBi, LBj, UBj, xv)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'x-location of V-points: x_v',                &
      &                     ng, Stats(7)%min, Stats(7)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(8),               &
+      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(8), 0,            &
      &                  LBi, UBi, LBj, UBj, yv)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'y-location of V-points: y_v',                &
@@ -724,13 +724,13 @@
 !
 !  Report statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(9),               &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(9), 0,            &
      &                  LBi, UBi, LBj, UBj, pm)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'reciprocal XI-grid spacing: pm',             &
      &                     ng, Stats(9)%min, Stats(9)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(10),              &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(10), 0,           &
      &                  LBi, UBi, LBj, UBj, pn)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'reciprocal ETA-grid spacing: pn',            &
@@ -773,14 +773,14 @@
 !
 !  Report statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(11),              &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(11), 0,           &
      &                  LBi, UBi, LBj, UBj, dmde)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'ETA-derivative of inverse metric '//         &
      &                    'factor pm: dmde',                            &
      &                     ng, Stats(11)%min, Stats(11)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(12),              &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(12), 0,           &
      &                  LBi, UBi, LBj, UBj, dndx)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'XI-derivative of inverse metric '//          &
@@ -840,7 +840,7 @@
 !
 !  Report Statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(13),              &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(13), 0,           &
      &                  LBi, UBi, LBj, UBj, angler)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'angle between XI-axis and EAST: '//          &
@@ -902,7 +902,7 @@
 !
 !  Report Statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(14),              &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(14), 0,           &
      &                  LBi, UBi, LBj, UBj, f)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'Coriolis parameter at RHO-points: f',        &
@@ -1136,7 +1136,7 @@
 !
 !  Report Statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(15),              &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(15), 0,           &
      &                  LBi, UBi, LBj, UBj, h)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'bathymetry at RHO-points: h',                &
@@ -1190,7 +1190,7 @@
 !
 !  Report Statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(16),              &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(16), 0,           &
      &                  LBi, UBi, LBj, UBj, zice)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'ice shelf thickness: zice',                  &

--- a/ROMS/Functionals/ana_initial.h
+++ b/ROMS/Functionals/ana_initial.h
@@ -328,14 +328,14 @@
 !
 !  Report statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(1),               &
+      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(1), 0,            &
      &                  LBi, UBi, LBj, UBj, ubar(:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idUbar))//': '//                 &
      &                    TRIM(Vname(1,idUbar)),                        &
      &                     ng, Stats(1)%min, Stats(1)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(2),               &
+      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(2), 0,            &
      &                  LBi, UBi, LBj, UBj, vbar(:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idVbar))//': '//                 &
@@ -428,7 +428,7 @@
 !
 !  Report statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(3),               &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(3), 0,            &
      &                  LBi, UBi, LBj, UBj, zeta(:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idFsur))//': '//                 &
@@ -521,14 +521,14 @@
 !
 !  Report statistics.
 !
-      CALL stats_3dfld (ng, tile, iNLM, u3dvar, Stats(4),               &
+      CALL stats_3dfld (ng, tile, iNLM, u3dvar, Stats(4), 0,            &
      &                  LBi, UBi, LBj, UBj, 1, N(ng), u(:,:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idUvel))//': '//                 &
      &                    TRIM(Vname(1,idUvel)),                        &
      &                    ng, Stats(4)%min, Stats(4)%max
       END IF
-      CALL stats_3dfld (ng, tile, iNLM, v3dvar, Stats(5),               &
+      CALL stats_3dfld (ng, tile, iNLM, v3dvar, Stats(5), 0,            &
      &                  LBi, UBi, LBj, UBj, 1, N(ng), v(:,:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idVvel))//': '//                 &
@@ -874,7 +874,7 @@
 !  Report statistics.
 !
       DO itrc=1,NAT
-        CALL stats_3dfld (ng, tile, iNLM, u3dvar, Stats(itrc+5),        &
+        CALL stats_3dfld (ng, tile, iNLM, r3dvar, Stats(itrc+5), 0,     &
      &                    LBi, UBi, LBj, UBj, 1, N(ng), t(:,:,:,1,itrc))
         IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
           WRITE (stdout,10) TRIM(Vname(2,idTvar(itrc)))//': '//         &

--- a/ROMS/Functionals/ana_mask.h
+++ b/ROMS/Functionals/ana_mask.h
@@ -248,25 +248,25 @@
 !  Report statitics.
 !-----------------------------------------------------------------------
 !
-      CALL stats_2dfld (ng, tile, iNLM, p2dvar, Stats(1),               &
+      CALL stats_2dfld (ng, tile, iNLM, p2dvar, Stats(1), 0,            &
      &                  LBi, UBi, LBj, UBj, pmask)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'mask on PSI-points: mask_psi',               &
      &                    ng, Stats(1)%min, Stats(1)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(2),               &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(2), 0,            &
      &                  LBi, UBi, LBj, UBj, rmask)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'mask on RHO-points: mask_rho',               &
      &                    ng, Stats(2)%min, Stats(2)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(3),               &
+      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(3), 0,            &
      &                  LBi, UBi, LBj, UBj, umask)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'mask on U-points: mask_u',                   &
      &                    ng, Stats(3)%min, Stats(3)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(4),               &
+      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(4), 0,            &
      &                  LBi, UBi, LBj, UBj, vmask)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'mask on V-points: mask_v',                   &

--- a/ROMS/Functionals/ana_wtype.h
+++ b/ROMS/Functionals/ana_wtype.h
@@ -154,7 +154,7 @@
 !
 !  Report statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats,                  &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats, 0,               &
      &                  LBi, UBi, LBj, UBj, Jwtype)
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) 'Jerlov water type: wtype_grid',              &

--- a/ROMS/Utility/nf_fwrite2d.F
+++ b/ROMS/Utility/nf_fwrite2d.F
@@ -135,10 +135,8 @@
 !
 !  Local variable declarations.
 !
-# ifdef MASKING
       logical :: LandFill
 !
-# endif
       integer :: Extract_Flag
       integer :: i, ic, j, jc, Npts
       integer :: Imin, Imax, Jmin, Jmax
@@ -206,16 +204,17 @@
       Ilen=Imax-Imin+1
       Jlen=Jmax-Jmin+1
       IJlen=Ilen*Jlen
-
-# ifdef MASKING
 !
 !  Set switch to replace land areas with fill value, spval.
 !
+# ifdef MASKING
       IF (PRESENT(SetFillVal)) THEN
         LandFill=SetFillVal
       ELSE
         LandFill=tindex.gt.0
       END IF
+# else
+      LandFill=.FALSE.
 # endif
 !
 !  If appropriate, set the field extraction flag to the provided grid
@@ -447,10 +446,8 @@
 !
 !  Local variable declarations.
 !
-# ifdef MASKING
       logical :: LandFill
 !
-# endif
       integer :: Extract_Flag
       integer :: Npts, i, tile
       integer :: status
@@ -477,15 +474,17 @@
 # else
       tile=-1
 # endif
-# ifdef MASKING
 !
 !  Set switch to replace land areas with fill value, spval.
 !
+# ifdef MASKING
       IF (PRESENT(SetFillVal)) THEN
         LandFill=SetFillVal
       ELSE
         LandFill=tindex.gt.0
       END IF
+# else
+      LandFill=.FALSE.
 # endif
 !
 !  If appropriate, set the field extraction flag to the provided grid
@@ -707,16 +706,17 @@
       ELSE
         Lminmax=.FALSE.
       END IF
-
-# ifdef MASKING
 !
 !  Set switch to replace land areas with fill value, spval.
 !
+# ifdef MASKING
       IF (PRESENT(SetFillVal)) THEN
         LandFill=SetFillVal
       ELSE
         LandFill=tindex.gt.0
       END IF
+# else
+      LandFill=.FALSE.
 # endif
 !
 !  If appropriate, set the field extraction flag to the provided grid

--- a/ROMS/Utility/nf_fwrite3d.F
+++ b/ROMS/Utility/nf_fwrite3d.F
@@ -136,10 +136,8 @@
 !
 !  Local variable declarations.
 !
-# ifdef MASKING
       logical :: LandFill
 !
-# endif
       integer :: Extract_Flag
       integer :: i, ic, j, jc, k, kc, Npts
       integer :: Imin, Imax, Jmin, Jmax
@@ -207,16 +205,17 @@
       Ilen=Imax-Imin+1
       Jlen=Jmax-Jmin+1
       Klen=UBk-LBk+1
-
-# ifdef MASKING
 !
 !  Set switch to replace land areas with fill value, spval.
 !
+# ifdef MASKING
       IF (PRESENT(SetFillVal)) THEN
         LandFill=SetFillVal
       ELSE
         LandFill=tindex.gt.0
       END IF
+# else
+      LandFill=.FALSE.
 # endif
 !
 !  If appropriate, set the field extraction flag to the provided grid
@@ -476,9 +475,8 @@
 !
 !  Local variable declarations.
 !
-# ifdef MASKING
       logical :: LandFill
-# endif
+!
       integer :: Extract_Flag
       integer :: i, Npts, tile
       integer :: Imin, Imax, Jmin, Jmax, Koff
@@ -507,15 +505,17 @@
 # else
       tile=-1
 # endif
-# ifdef MASKING
 !
 !  Set switch to replace land areas with fill value, spval.
 !
+# ifdef MASKING
       IF (PRESENT(SetFillVal)) THEN
         LandFill=SetFillVal
       ELSE
         LandFill=tindex.gt.0
       END IF
+# else
+      LandFill=.FALSE.
 # endif
 !
 !  If appropriate, set the field extraction flag to the provided grid
@@ -738,16 +738,17 @@
       ELSE
         Lminmax=.FALSE.
       END IF
-
-# ifdef MASKING
 !
 !  Set switch to replace land areas with fill value, spval.
 !
+# ifdef MASKING
       IF (PRESENT(SetFillVal)) THEN
         LandFill=SetFillVal
       ELSE
         LandFill=tindex.gt.0
       END IF
+# else
+      LandFill=.FALSE.
 # endif
 !
 !  If appropriate, set the field extraction flag to the provided grid

--- a/ROMS/Utility/nf_fwrite4d.F
+++ b/ROMS/Utility/nf_fwrite4d.F
@@ -138,10 +138,8 @@
 !
 !  Local variable declarations.
 !
-# ifdef MASKING
       logical :: LandFill
 !
-# endif
       integer :: Extract_Flag
       integer :: i, ic, j, jc, k, kc, l, lc, Npts
       integer :: Imin, Imax, Jmin, Jmax, Kmin, Kmax
@@ -210,16 +208,17 @@
       Jlen=Jmax-Jmin+1
       Klen=UBk-LBk+1
       Llen=UBt-LBt+1
-
-# ifdef MASKING
 !
 !  Set switch to replace land areas with fill value, spval.
 !
+# ifdef MASKING
       IF (PRESENT(SetFillVal)) THEN
         LandFill=SetFillVal
       ELSE
         LandFill=tindex.gt.0
       END IF
+# else
+      LandFill=.FALSE.
 # endif
 !
 !  If appropriate, set the field extraction flag to the provided grid
@@ -501,10 +500,8 @@
 !
 !  Local variable declarations.
 !
-# ifdef MASKING
       logical :: LandFill
 !
-# endif
       integer :: Extract_Flag
       integer :: i, fourth, Npts, tile
       integer :: status
@@ -531,15 +528,17 @@
 # else
       tile=-1
 # endif
-# ifdef MASKING
 !
 !  Set switch to replace land areas with fill value, spval.
 !
+# ifdef MASKING
       IF (PRESENT(SetFillVal)) THEN
         LandFill=SetFillVal
       ELSE
         LandFill=tindex.gt.0
       END IF
+# else
+      LandFill=.FALSE.
 # endif
 !
 !  If appropriate, set the field extraction flag to the provided grid
@@ -769,16 +768,17 @@
       ELSE
         Lminmax=.FALSE.
       END IF
-
-# ifdef MASKING
 !
 !  Set switch to replace land areas with fill value, spval.
 !
+# ifdef MASKING
       IF (PRESENT(SetFillVal)) THEN
         LandFill=SetFillVal
       ELSE
         LandFill=tindex.gt.0
       END IF
+# else
+      LandFill=.FALSE.
 # endif
 !
 !  If appropriate, set the field extraction flag to the provided grid


### PR DESCRIPTION
- The derived type **`T_STATS`** structure includes an additional member checksum that must be initialized when computing the statistics. For example, in **`ana_initial.h`**, we must have:
``` f90
      IF (first) THEN
        first=.FALSE.
        DO i=1,SIZE(Stats,1)
          Stats(i) % checksum=0_i8b
          Stats(i) % count=0
          Stats(i) % min=Large
          Stats(i) % max=-Large
          Stats(i) % avg=0.0_r8
          Stats(i) % rms=0.0_r8
        END DO
      END IF
```
- The analytical routines needed an additional argument **Extract_Flag** when calling **`stats_2dfield,`** **`stats_3dfield`**, and **`stats_4dfield`** . For example, in **`ana_initial.h`**, we now have:
``` f90
      CALL stats_3dfld (ng, tile, iNLM, u3dvar, Stats(4), 0,            &
     &                  LBi, UBi, LBj, UBj, 1, N(ng), u(:,:,:,1))
```
- Fixed an issue in the generic NetCDF writing modules **`nf_fwrite2d.F`**, **`nf_fwrite3d.F`**, and **`nf_fwrite4d.F`** that needs the initialization of local variable **LandFilL** regardless if **MASKING** is activated or not.  For example, in **`nf_fwrite2d`**, we must have:
``` f90
!
!  Set switch to replace land areas with fill value, spval.
!
# ifdef MASKING
      IF (PRESENT(SetFillVal)) THEN
        LandFill=SetFillVal
      ELSE
        LandFill=tindex.gt.0
      END IF
# else
      LandFill=.FALSE.
# endif
```
  Many thanks to Jangggeun Choi for reporting this issue.

---

### Warning:

You need to update all your customized analytical header files **`ana_*.h`**.