### PR TITLE
4D-VAR Incremental Analysis Update (IAU)

### DIFF
--- a/Compilers/CYGWIN-df.mk
+++ b/Compilers/CYGWIN-df.mk
@@ -230,11 +230,11 @@ endif
 ifdef SHARED
  ifdef EXEC
   ifndef STATIC
-	CYG_DLL_CP := cyg_dll_cp
+       CYG_DLL_CP := cyg_dll_cp
 
 .PHONY: cyg_dll_cp
 cyg_dll_cp: $(BIN)
-	$(CP) $(BUILD_DIR)/$(SH_LIB_NAME) $(BINDIR)
+            $(CP) $(BUILD_DIR)/$(SH_LIB_NAME) $(BINDIR)
 
   endif
  endif
@@ -323,4 +323,4 @@ endif
 #
 
 %.o: %.f90
-	cd $(BUILD_DIR); $(FC) $(FFLAGS) /compile (notdir $<) /object:$(notdir $@)
+        cd $(BUILD_DIR); $(FC) $(FFLAGS) /compile (notdir $<) /object:$(notdir $@)

--- a/Compilers/CYGWIN-g95.mk
+++ b/Compilers/CYGWIN-g95.mk
@@ -232,11 +232,11 @@ endif
 ifdef SHARED
  ifdef EXEC
   ifndef STATIC
-	CYG_DLL_CP := cyg_dll_cp
+       CYG_DLL_CP := cyg_dll_cp
 
 .PHONY: cyg_dll_cp
 cyg_dll_cp: $(BIN)
-	$(CP) $(BUILD_DIR)/$(SH_LIB_NAME) $(BINDIR)
+            $(CP) $(BUILD_DIR)/$(SH_LIB_NAME) $(BINDIR)
 
   endif
  endif

--- a/Compilers/CYGWIN-gfortran.mk
+++ b/Compilers/CYGWIN-gfortran.mk
@@ -258,11 +258,11 @@ endif
 ifdef SHARED
  ifdef EXEC
   ifndef STATIC
-	CYG_DLL_CP := cyg_dll_cp
+       CYG_DLL_CP := cyg_dll_cp
 
 .PHONY: cyg_dll_cp
 cyg_dll_cp: $(BIN)
-	$(CP) $(BUILD_DIR)/$(SH_LIB_NAME) $(BINDIR)
+            $(CP) $(BUILD_DIR)/$(SH_LIB_NAME) $(BINDIR)
 
   endif
  endif

--- a/Compilers/CYGWIN-ifort.mk
+++ b/Compilers/CYGWIN-ifort.mk
@@ -260,11 +260,11 @@ endif
 ifdef SHARED
  ifdef EXEC
   ifndef STATIC
-	CYG_DLL_CP := cyg_dll_cp
+       CYG_DLL_CP := cyg_dll_cp
 
 .PHONY: cyg_dll_cp
 cyg_dll_cp: $(BIN)
-	$(CP) $(BUILD_DIR)/$(SH_LIB_NAME) $(BINDIR)
+            $(CP) $(BUILD_DIR)/$(SH_LIB_NAME) $(BINDIR)
 
   endif
  endif

--- a/Compilers/Linux-g95.mk
+++ b/Compilers/Linux-g95.mk
@@ -251,11 +251,11 @@ endif
 ifdef SHARED
  ifdef EXEC
   ifndef STATIC
-	CYG_DLL_CP := cyg_dll_cp
+       CYG_DLL_CP := cyg_dll_cp
 
 .PHONY: cyg_dll_cp
 cyg_dll_cp: $(BIN)
-	$(CP) $(BUILD_DIR)/$(SH_LIB_NAME) $(BINDIR)
+            $(CP) $(BUILD_DIR)/$(SH_LIB_NAME) $(BINDIR)
 
   endif
  endif

--- a/Compilers/Makefile.cice
+++ b/Compilers/Makefile.cice
@@ -20,7 +20,7 @@
 
 ifneq (3.80,$(firstword $(sort $(MAKE_VERSION) 3.80)))
  $(error This makefile requires GNU make version 3.80 or higher. \
-		Your current version is: $(MAKE_VERSION))
+         Your current version is: $(MAKE_VERSION))
 endif
 
 #--------------------------------------------------------------------------

--- a/Compilers/compiler_flags_GNU_Fortran.cmake
+++ b/Compilers/compiler_flags_GNU_Fortran.cmake
@@ -14,11 +14,11 @@
 if( MPI )
   execute_process( COMMAND which mpif90
                    OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
-                   OUTPUT_STRIP_TRAILING_WHITESPACE ) 
+                   OUTPUT_STRIP_TRAILING_WHITESPACE )
 else()
   execute_process( COMMAND which gfortran
                    OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
-                   OUTPUT_STRIP_TRAILING_WHITESPACE ) 
+                   OUTPUT_STRIP_TRAILING_WHITESPACE )
 endif()
 
 ###########################################################################

--- a/Compilers/compiler_flags_Intel_Fortran.cmake
+++ b/Compilers/compiler_flags_Intel_Fortran.cmake
@@ -15,16 +15,16 @@ if( MPI )
   if( ${COMM} MATCHES "intel")
     execute_process( COMMAND which mpiifort
                      OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
-                     OUTPUT_STRIP_TRAILING_WHITESPACE ) 
+                     OUTPUT_STRIP_TRAILING_WHITESPACE )
   else()
     execute_process( COMMAND which mpif90
                      OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
-                     OUTPUT_STRIP_TRAILING_WHITESPACE ) 
+                     OUTPUT_STRIP_TRAILING_WHITESPACE )
   endif()
 else()
   execute_process( COMMAND which ifort
                    OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
-                   OUTPUT_STRIP_TRAILING_WHITESPACE ) 
+                   OUTPUT_STRIP_TRAILING_WHITESPACE )
 endif()
 
 ###########################################################################

--- a/Compilers/my_build_paths.sh
+++ b/Compilers/my_build_paths.sh
@@ -178,7 +178,7 @@ case "$FORT" in
           export      NF_CONFIG=${NETCDF}/bin/nf-config
           export  NETCDF_INCDIR=${NETCDF}/include
           export        NETCDF4=1
-	fi
+        fi
       else
         export         ESMF_DIR=${MPI_SOFT}/esmf_nc3
         export           NETCDF=/opt/intelsoft/serial/netcdf3

--- a/Master/mod_esmf_esm.F
+++ b/Master/mod_esmf_esm.F
@@ -1406,7 +1406,7 @@
 # ifdef DISTRIBUTE
       USE distribute_mod, ONLY : mp_bcasts
 # endif
-      USE stdout_mod,     ONLY : Set_StdOutUnit, stdout_unit  
+      USE stdout_mod,     ONLY : Set_StdOutUnit, stdout_unit
       USE strings_mod,    ONLY : lowercase
 !
       implicit none

--- a/ROMS/Adjoint/ad_main3d.F
+++ b/ROMS/Adjoint/ad_main3d.F
@@ -1055,7 +1055,7 @@
 !  On the last timestep, it computes the adjoint of initial depths and
 !  level thicknesses from the initial free-surface field. Additionally,
 !  it initializes the adjoint state variables for all time levels and
-!  and applies lateral boundary conditions. 
+!  and applies lateral boundary conditions.
 !-----------------------------------------------------------------------
 !
             DO ig=1,GridsInLayer(nl)

--- a/ROMS/Adjoint/ad_post_initial.F
+++ b/ROMS/Adjoint/ad_post_initial.F
@@ -45,7 +45,7 @@
 !
 !  Local variable declarations.
 !
-      integer :: tile      
+      integer :: tile
 
 # ifdef NESTING
 !

--- a/ROMS/Adjoint/ad_step2d_FB.h
+++ b/ROMS/Adjoint/ad_step2d_FB.h
@@ -594,7 +594,7 @@
       real(r8) :: adfac, adfac1, adfac2, adfac3, adfac4, adfac5
 !
       real(r8), parameter :: IniVal = 0.0_r8
-! 
+!
 #if defined UV_C4ADVECTION && !defined SOLVE3D
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: Dgrad
 #endif
@@ -676,7 +676,7 @@
       real(r8), allocatable :: ad_zeta_new(:,:)
 
 #include "set_bounds.h"
-! 
+!
 !-----------------------------------------------------------------------
 !  Initialize adjoint private variables.
 !-----------------------------------------------------------------------
@@ -929,11 +929,11 @@
       ad_zeta_new = 0.0_r8
 !
 !  Compute "zeta_new" at new time step and interpolate it half-step
-!  backward, "zwrk" for the subsequent computation of the adjoint 
+!  backward, "zwrk" for the subsequent computation of the adjoint
 !  barotropic pressure gradient. Here, we use the BASIC STATE values.
 !  Thus, the nonlinear correction to the pressure-gradient term from
 !  "kstp" to "knew" is not needed for Forward-Euler to Forward-Backward
-!  steps (PGF_FB_CORRECTION method). 
+!  steps (PGF_FB_CORRECTION method).
 !
 !  Get background zeta_new from BASIC state. Notice the I- and J-range
 !  used to avoid calling nonlinear 'zetabc_local' routine.
@@ -1045,7 +1045,7 @@
      &                       ad_vbar(:,:,knew))
 #endif
 
-      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN 
+      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
 !^      CALL exchange_v2d_tile (ng, tile,                               &
 !^   &                          LBi, UBi, LBj, UBj,                     &
 !^   &                          tl_vbar(:,:,knew))
@@ -1463,7 +1463,7 @@
             adfac1=adfac*ubar(i,Jstr-1,knew)
             ad_ubar(i,Jstr-1,knew)=ad_ubar(i,Jstr-1,knew)+              &
      &                             (Dnew(i  ,Jstr-1)+                   &
-     &                              Dnew(i-1,Jstr-1))*adfac 
+     &                              Dnew(i-1,Jstr-1))*adfac
             ad_Dnew(i-1,Jstr-1)=ad_Dnew(i-1,Jstr-1)+adfac1
             ad_Dnew(i  ,Jstr-1)=ad_Dnew(i  ,Jstr-1)+adfac1
             ad_DU_flux(i,Jstr-1)=0.0_r8
@@ -1652,7 +1652,7 @@
           DO i=Istr-1,IendR
 !^          tl_Dnew(i,Jend+1)=tl_h(i,Jend+1)+tl_zeta_new(i,Jend+1)
 !^
-            ad_h(i,Jend+1)=ad_h(i,Jend+1)+                              & 
+            ad_h(i,Jend+1)=ad_h(i,Jend+1)+                              &
      &                     ad_Dnew(i,Jend+1)
             ad_zeta_new(i,Jend+1)=ad_zeta_new(i,Jend+1)+                &
      &                            ad_Dnew(i,Jend+1)
@@ -2079,8 +2079,8 @@
 !  subtracting the fast-time "rubar" and "rvbar" from them.
 !
 !  In the predictor-coupled mode, the resultant forcing terms "rufrc"
-!  and "rvfrc" are extrapolated forward in time, so they become 
-!  centered effectively at time n+1/2. This is done using optimized 
+!  and "rvfrc" are extrapolated forward in time, so they become
+!  centered effectively at time n+1/2. This is done using optimized
 !  Adams-Bashforth weights. In the code below, rufrc_bak(:,:,nstp) is
 !  at (n-1)time step, while rufrc_bak(:,:,3-nstp) is at (n-2). After
 !  its use as input, the latter is overwritten by the value at time
@@ -2104,9 +2104,9 @@
           cfwd0=1.5_r8
           cfwd1=-0.5_r8
           cfwd2=0.0_r8
-        ELSE                                
-          cfwd2=0.281105_r8                     
-          cfwd1=-0.5_r8-2.0_r8*cfwd2                 
+        ELSE
+          cfwd2=0.281105_r8
+          cfwd1=-0.5_r8-2.0_r8*cfwd2
           cfwd0=1.5_r8+cfwd2
         END IF
 !
@@ -2405,7 +2405,7 @@
 #ifdef SOLVE3D
 !
 !  Notice that we are suppressing the computation of momentum advection,
-!  Coriolis, and lateral viscosity terms in 3D Applications because 
+!  Coriolis, and lateral viscosity terms in 3D Applications because
 !  these terms are already included in the baroclinic-to-barotropic
 !  forcing arrays "rufrc" and "rvfrc". It does not mean we are entirely
 !  omitting them, but it is a choice between recomputing them at every
@@ -2777,7 +2777,7 @@
 !^
             adfac=0.5_r8*ad_fac2
             ad_VFe(i,j-1)=ad_VFe(i,j-1)+adfac
-            ad_VFe(i,j  )=ad_VFe(i,j  )+adfac          
+            ad_VFe(i,j  )=ad_VFe(i,j  )+adfac
             ad_fac2=0.0_r8
           END IF
 !
@@ -2955,7 +2955,7 @@
 #  endif
 !^   &                    tl_urhs(i,j  )))
 !^
-          adfac=0.25_r8*ad_UFe(i,j+1)       
+          adfac=0.25_r8*ad_UFe(i,j+1)
           adfac1=adfac*(urhs(i,j+1)+                                    &
 #  ifdef WEC_MELLOR
      &                  ubar_stokes(i,j+1)+                             &
@@ -3045,7 +3045,7 @@
      &                  vrhs(i  ,j))
           adfac2=adfac*(DUon(i+1,j)+DUon(i+1,j-1))
           ad_DUon(i+1,j-1)=ad_DUon(i+1,j-1)+adfac1
-          ad_DUon(i+1,j  )=ad_DUon(i+1,j  )+adfac1            
+          ad_DUon(i+1,j  )=ad_DUon(i+1,j  )+adfac1
           ad_vrhs(i  ,j)=ad_vrhs(i  ,j)+adfac2
           ad_vrhs(i+1,j)=ad_vrhs(i+1,j)+adfac2
 #  ifdef WEC_MELLOR
@@ -3877,7 +3877,7 @@
 !
       IF (FIRST_2D_STEP) THEN
         DO j=JstrR,JendR
-          DO i=IstrR,IendR 
+          DO i=IstrR,IendR
             IF (j.ge.Jstr) THEN
 !^            tl_DV_avg2(i,j)=cff2*tl_DVom(i,j)
 !^
@@ -4240,7 +4240,7 @@
       END DO
 !
       DO j=JR_RANGE
-        DO i=IR_RANGE 
+        DO i=IR_RANGE
 !^        tl_Drhs(i,j)=tl_h(i,j)+fwd0*tl_zeta(i,j,kstp)+                &
 !^   &                           fwd1*tl_zeta(i,j,kbak)+                &
 !^   &                           fwd2*tl_zeta(i,j,kold)

--- a/ROMS/Adjoint/ad_step2d_FB_LF_AM3.h
+++ b/ROMS/Adjoint/ad_step2d_FB_LF_AM3.h
@@ -677,8 +677,8 @@
       IF (FIRST_2D_STEP) THEN
         kbak=kstp                      ! "kbak" is used as "from"
       ELSE                             ! time index for LF timestep
-        kbak=3-kstp                    
-      END IF                            
+        kbak=3-kstp
+      END IF
 
 #ifdef DEBUG
 !
@@ -688,7 +688,7 @@
      &          ' kbak = ',i1,' krhs = ',i1,' kstp = ',i1,' knew = ',i1)
       END IF
 #endif
-! 
+!
 !-----------------------------------------------------------------------
 !  Initialize adjoint private variables.
 !-----------------------------------------------------------------------
@@ -1013,7 +1013,7 @@
      &                       ad_vbar(:,:,knew))
 
 #endif
-      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN 
+      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
 !^      CALL exchange_v2d_tile (ng, tile,                               &
 !^   &                          LBi, UBi, LBj, UBj,                     &
 !^   &                          tl_vbar(:,:,knew))
@@ -1107,7 +1107,7 @@
 #ifdef SOLVE3D
 !
 !-----------------------------------------------------------------------
-!  Adjoint of finalize computation of barotropic mode averages. 
+!  Adjoint of finalize computation of barotropic mode averages.
 !-----------------------------------------------------------------------
 !
 !  This procedure starts with filling in boundary rows of total depths
@@ -1464,7 +1464,7 @@
             adfac1=adfac*ubar(i,Jstr-1,knew)
             ad_ubar(i,Jstr-1,knew)=ad_ubar(i,Jstr-1,knew)+              &
      &                             (Dnew(i  ,Jstr-1)+                   &
-     &                              Dnew(i-1,Jstr-1))*adfac 
+     &                              Dnew(i-1,Jstr-1))*adfac
             ad_Dnew(i-1,Jstr-1)=ad_Dnew(i-1,Jstr-1)+adfac1
             ad_Dnew(i  ,Jstr-1)=ad_Dnew(i  ,Jstr-1)+adfac1
             ad_DU_flux(i,Jstr-1)=0.0_r8
@@ -2293,7 +2293,7 @@
             tl_zeta(i,j,kstp)=tl_zeta(i,j,kstp)+cff3*adfac
             ad_rzeta2(i,j)=0.0_r8
 !^          tl_rzeta(i,j)=(1.0_r8+rhoS(i,j))*tl_zwrk(i,j)+              &
-!^   &                    tl_rhoS(i,j)*zwrk(i,j) 
+!^   &                    tl_rhoS(i,j)*zwrk(i,j)
 !^
             ad_zwrk(i,j)=ad_zwrk(i,j)+(1.0_r8+rhoS(i,j))*ad_rzeta(i,j)
             ad_rhoS(i,j)=ad_rhoS(i,j)+zwrk(i,j)*ad_rzeta(i,j)
@@ -2383,7 +2383,7 @@
 #ifdef SOLVE3D
 !
 !  Notice that we are suppressing the computation of momentum advection,
-!  Coriolis, and lateral viscosity terms in 3D Applications because 
+!  Coriolis, and lateral viscosity terms in 3D Applications because
 !  these terms are already included in the baroclinic-to-barotropic
 !  forcing arrays "rufrc" and "rvfrc". It does not mean we are entirely
 !  omitting them, but it is a choice between recomputing them at every
@@ -2790,7 +2790,7 @@
       END DO
 #endif
 
-#if (defined UV_COR & !defined SOLVE3D) || defined STEP2D_CORIOLIS 
+#if (defined UV_COR & !defined SOLVE3D) || defined STEP2D_CORIOLIS
 !
 !-----------------------------------------------------------------------
 !  Add in Coriolis term.
@@ -2809,7 +2809,7 @@
 !^
             adfac=0.5_r8*ad_fac2
             ad_VFe(i,j-1)=ad_VFe(i,j-1)+adfac
-            ad_VFe(i,j  )=ad_VFe(i,j  )+adfac          
+            ad_VFe(i,j  )=ad_VFe(i,j  )+adfac
             ad_fac2=0.0_r8
           END IF
 !
@@ -3984,7 +3984,7 @@
 !  "rufrc, rvfrc" are finalized, a correction term based on the
 !  difference zeta_new(:,:)-zeta(:,:,kstp) to "rubar, rvbar" to make
 !  them consistent with generalized RK2 stepping for pressure gradient
-!  terms. 
+!  terms.
 !
       IF (PREDICTOR_2D_STEP) THEN
         IF (FIRST_2D_STEP) THEN     ! Modified RK2 time step (with
@@ -4284,7 +4284,7 @@
 !^   &                    IminS, ImaxS, JminS, JmaxS,                   &
 !^   &                    NghostPoints,                                 &
 !^   &                    EWperiodic(ng), NSperiodic(ng),               &
-!^   &                    DUon, DVom,                                   & 
+!^   &                    DUon, DVom,                                   &
 !^   &                    tl_DUon, tl_DVom)
 !^
       CALL ad_mp_exchange2d (ng, tile, iTLM, 2,                         &

--- a/ROMS/Bin/submit_split_i4dvar.sh
+++ b/ROMS/Bin/submit_split_i4dvar.sh
@@ -529,7 +529,7 @@ while [ $SDAY -le $L_DN ]; do
         echo
         echo "Error while running 4D-Var System:  Cycle = ${Cycle}" \
                                                "  Outer = ${OuterLoop}" \
-			                       "  Phase = ${Phase4DVAR}"
+                                               "  Phase = ${Phase4DVAR}"
         echo "Check ${RunDir}/log.roms for details ..."
         exit 1
       fi
@@ -542,7 +542,7 @@ while [ $SDAY -le $L_DN ]; do
     echo
     echo "Running 4D-Var System:  Cycle = ${Cycle}" \
                                "  Outer = ${OuterLoop}" \
-			       "  Phase = ${Phase4DVAR}"
+                               "  Phase = ${Phase4DVAR}"
 
     My4DVarScript ${DataDir} ${SUBSTITUTE} ${OuterLoop} ${Phase4DVAR} \
                   ${OBSname} ${Fprefix} ${Fsuffix} ${Inp4DVAR}
@@ -561,7 +561,7 @@ while [ $SDAY -le $L_DN ]; do
         echo
         echo "Error while running 4D-Var System:  Cycle = ${Cycle}" \
                                                "  Outer = ${OuterLoop}" \
-			                       "  Phase = ${Phase4DVAR}"
+                                               "  Phase = ${Phase4DVAR}"
         echo "Check ${RunDir}/log.roms for details ..."
         exit 1
       fi
@@ -599,7 +599,7 @@ while [ $SDAY -le $L_DN ]; do
     if [ $? -ne 0 ] ; then
       echo
       echo "Error while running 4D-Var System:  Cycle = ${Cycle}" \
-		                             "  Phase = ${Phase4DVAR}"
+                                             "  Phase = ${Phase4DVAR}"
       echo "Check ${RunDir}/log.roms for details ..."
       exit 1
     fi

--- a/ROMS/Bin/submit_split_r4dvar.sh
+++ b/ROMS/Bin/submit_split_r4dvar.sh
@@ -546,7 +546,7 @@ while [ $SDAY -le $L_DN ]; do
         echo
         echo "Error while running 4D-Var System:  Cycle = ${Cycle}" \
                                                "  Outer = ${OuterLoop}" \
-			                       "  Phase = ${Phase4DVAR}"
+                                               "  Phase = ${Phase4DVAR}"
         echo "Check ${RunDir}/log.roms for details ..."
         exit 1
       fi
@@ -559,7 +559,7 @@ while [ $SDAY -le $L_DN ]; do
     echo
     echo "Running 4D-Var System:  Cycle = ${Cycle}" \
                                "  Outer = ${OuterLoop}" \
-			       "  Phase = ${Phase4DVAR}"
+                               "  Phase = ${Phase4DVAR}"
 
     My4DVarScript ${DataDir} ${SUBSTITUTE} ${OuterLoop} ${Phase4DVAR} \
                   ${OBSname} ${Fprefix} ${Fsuffix} ${Inp4DVAR}
@@ -578,7 +578,7 @@ while [ $SDAY -le $L_DN ]; do
         echo
         echo "Error while running 4D-Var System:  Cycle = ${Cycle}" \
                                                "  Outer = ${OuterLoop}" \
-			                       "  Phase = ${Phase4DVAR}"
+                                               "  Phase = ${Phase4DVAR}"
         echo "Check ${RunDir}/log.roms for details ..."
         exit 1
       fi
@@ -620,7 +620,7 @@ while [ $SDAY -le $L_DN ]; do
       if [ $? -ne 0 ] ; then
         echo
         echo "Error while running 4D-Var System:  Cycle = ${Cycle}" \
-			                       "  Phase = ${Phase4DVAR}"
+                                               "  Phase = ${Phase4DVAR}"
         echo "Check ${RunDir}/log.roms for details ..."
         exit 1
       fi

--- a/ROMS/Bin/submit_split_rbl4dvar.sh
+++ b/ROMS/Bin/submit_split_rbl4dvar.sh
@@ -532,7 +532,7 @@ while [ $SDAY -le $L_DN ]; do
         echo
         echo "Error while running 4D-Var System:  Cycle = ${Cycle}" \
                                                "  Outer = ${OuterLoop}" \
-			                       "  Phase = ${Phase4DVAR}"
+                                               "  Phase = ${Phase4DVAR}"
         echo "Check ${RunDir}/log.roms for details ..."
         exit 1
       fi
@@ -545,7 +545,7 @@ while [ $SDAY -le $L_DN ]; do
     echo
     echo "Running 4D-Var System:  Cycle = ${Cycle}" \
                                "  Outer = ${OuterLoop}" \
-			       "  Phase = ${Phase4DVAR}"
+                               "  Phase = ${Phase4DVAR}"
 
     My4DVarScript ${DataDir} ${SUBSTITUTE} ${OuterLoop} ${Phase4DVAR} \
                   ${OBSname} ${Fprefix} ${Fsuffix} ${Inp4DVAR}
@@ -564,7 +564,7 @@ while [ $SDAY -le $L_DN ]; do
         echo
         echo "Error while running 4D-Var System:  Cycle = ${Cycle}" \
                                                "  Outer = ${OuterLoop}" \
-			                       "  Phase = ${Phase4DVAR}"
+                                               "  Phase = ${Phase4DVAR}"
         echo "Check ${RunDir}/log.roms for details ..."
         exit 1
       fi
@@ -606,7 +606,7 @@ while [ $SDAY -le $L_DN ]; do
       if [ $? -ne 0 ] ; then
         echo
         echo "Error while running 4D-Var System:  Cycle = ${Cycle}" \
-			                       "  Phase = ${Phase4DVAR}"
+                                               "  Phase = ${Phase4DVAR}"
         echo "Check ${RunDir}/log.roms for details ..."
         exit 1
       fi

--- a/ROMS/Drivers/rbl4dvar.F
+++ b/ROMS/Drivers/rbl4dvar.F
@@ -130,6 +130,9 @@
 # ifdef STD_MODEL
       USE def_std_mod,        ONLY : def_std
 # endif
+# ifdef RPCG
+      USE frc_iau_mod,        ONLY : frc_iau_ini
+# endif
       USE get_state_mod,      ONLY : get_state
 # ifdef POSTERIOR_ERROR_F
       USE ini_adjust_mod,     ONLY : load_TLtoAD
@@ -1748,12 +1751,16 @@
       LiNL=my_outer+1
       DO ng=1,Ngrids
         CALL get_state (ng, iNLM, 9, INI(ng), LiNL, Lnew(ng))
-        CALL get_state (ng, iADM, 4, ITL(ng), Rec2, LTLM1)
+        IF (time_IAU(ng).eq.0.0_r8) THEN
+          CALL get_state (ng, iADM, 4, ITL(ng), Rec2, LTLM1)
+        END IF
       END DO
       DO ng=1,Ngrids
-        DO tile=first_tile(ng),last_tile(ng),+1
-          CALL ini_adjust (ng, tile, LTLM1, Lnew(ng))
-        END DO
+        IF (time_IAU(ng).eq.0.0_r8) THEN
+          DO tile=first_tile(ng),last_tile(ng),+1
+            CALL ini_adjust (ng, tile, LTLM1, Lnew(ng))
+          END DO
+        END IF
       END DO
 !
 !  Write out nonlinear model initial conditions into INIname, record
@@ -2315,6 +2322,31 @@
         Fcount=RST(ng)%load
         RST(ng)%Nrec(Fcount)=0
       END DO
+
+# ifdef RPCG
+!
+! Compute the incremental analysis update forcing for the NLM.
+!
+!    Read the accumulated increment from Rec3 of the ITL file.
+!
+        DO ng=1,Ngrids
+          IF (time_IAU(ng).gt.0.0_r8) THEN
+            IAUswitch(ng)=.TRUE.
+            CALL get_state (ng, iADM, 4, ITL(ng), Rec3, LTLM1)
+          END IF
+        END DO
+!
+!    Set up the NL model forcing contribution for the incremental
+!    analysis update.
+!
+        DO ng=1,Ngrids
+          IF (time_IAU(ng).gt.0.0_r8) THEN
+            DO tile=first_tile(ng),last_tile(ng),+1
+              CALL frc_iau_ini (ng, tile, LTLM1)
+            END DO
+          END IF
+        END DO
+# endif
 !
       CALL initial
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -2494,6 +2526,15 @@
           wrtNLmod(ng)=.FALSE.
           wrtTLmod(ng)=.FALSE.
         END DO
+
+# ifdef RPCG
+!
+!  Deactivate the NL forcing term for iau.
+!
+        DO ng=1,Ngrids
+          IAUswitch(ng)=.FALSE.
+        END DO
+# endif
 !
 !  Set structure for the nonlinear forward trajectory to be processed
 !  by the tangent linear and adjoint models. Also, set switches to

--- a/ROMS/Drivers/rbl4dvar.F
+++ b/ROMS/Drivers/rbl4dvar.F
@@ -1751,12 +1751,12 @@
       LiNL=my_outer+1
       DO ng=1,Ngrids
         CALL get_state (ng, iNLM, 9, INI(ng), LiNL, Lnew(ng))
-        IF (time_IAU(ng).eq.0.0_r8) THEN
+        IF (timeIAU(ng).eq.0.0_dp) THEN
           CALL get_state (ng, iADM, 4, ITL(ng), Rec2, LTLM1)
         END IF
       END DO
       DO ng=1,Ngrids
-        IF (time_IAU(ng).eq.0.0_r8) THEN
+        IF (timeIAU(ng).eq.0.0_dp) THEN
           DO tile=first_tile(ng),last_tile(ng),+1
             CALL ini_adjust (ng, tile, LTLM1, Lnew(ng))
           END DO
@@ -2330,7 +2330,7 @@
 !    Read the accumulated increment from Rec3 of the ITL file.
 !
         DO ng=1,Ngrids
-          IF (time_IAU(ng).gt.0.0_r8) THEN
+          IF (timeIAU(ng).gt.0.0_dp) THEN
             IAUswitch(ng)=.TRUE.
             CALL get_state (ng, iADM, 4, ITL(ng), Rec3, LTLM1)
           END IF
@@ -2340,7 +2340,7 @@
 !    analysis update.
 !
         DO ng=1,Ngrids
-          IF (time_IAU(ng).gt.0.0_r8) THEN
+          IF (timeIAU(ng).gt.0.0_dp) THEN
             DO tile=first_tile(ng),last_tile(ng),+1
               CALL frc_iau_ini (ng, tile, LTLM1)
             END DO

--- a/ROMS/External/s4dvar.in
+++ b/ROMS/External/s4dvar.in
@@ -165,6 +165,11 @@ balance(isVvel) =  T                      ! 3D momentum (u, v)
 
        tl_Tdiff ==  50.0d0  50.0d0        ! NT tracers
 
+! Duration of the Incremental Analysis Update (days) [1:Ngrids].
+! NOTE: This option is only available for RBL4DVAR and when using RPCG.
+
+       time_IAU == 0.0d0
+
 ! Switches (T/F) to create and write error covariance normalization
 ! factors for model, initial conditions, boundary conditions, and
 ! surface forcing. If TRUE, these factors are computed and written
@@ -709,6 +714,25 @@ Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
 !
 !  tl_Tdiff       Tracers type variables diffusion relaxation coefficients
 !                 (m2/s).  NT values are expected.
+!
+!------------------------------------------------------------------------------
+! Incremental Analysis Update (IAU)
+!------------------------------------------------------------------------------
+!
+!  time_IAU       Duration of the Incremental Analysis Update (days),
+!                 [1:Ngrids]. It controls the time interval over which
+!                 the IAU is applied.
+!
+!                 This option is only available for RBL4DVAR and when using
+!                 RPCG minimizer.
+!
+!                 In SPLIT_RBL4DVAR, you can the analysis phase multiple 
+!                 times experimenting with different values of time_IAU
+!                 to see which works best, without having to rerun the
+!                 inner-loops again (increment phase). You can only do
+!                 this if SPLIT_RBL4DVAR is first run with a non-zero
+!                 value of time_IAU, otherwise the initial condition will
+!                 get overwritten in the initial NetCDF file.
 !
 !------------------------------------------------------------------------------
 ! Background/model correlation parameters.

--- a/ROMS/External/s4dvar.in
+++ b/ROMS/External/s4dvar.in
@@ -168,7 +168,7 @@ balance(isVvel) =  T                      ! 3D momentum (u, v)
 ! Duration of the Incremental Analysis Update (days) [1:Ngrids].
 ! NOTE: This option is only available for RBL4DVAR and when using RPCG.
 
-       time_IAU == 0.0d0
+        timeIAU == 0.0d0
 
 ! Switches (T/F) to create and write error covariance normalization
 ! factors for model, initial conditions, boundary conditions, and
@@ -719,7 +719,7 @@ Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
 ! Incremental Analysis Update (IAU)
 !------------------------------------------------------------------------------
 !
-!  time_IAU       Duration of the Incremental Analysis Update (days),
+!  timeIAU        Duration of the Incremental Analysis Update (days),
 !                 [1:Ngrids]. It controls the time interval over which
 !                 the IAU is applied.
 !
@@ -727,11 +727,11 @@ Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
 !                 RPCG minimizer.
 !
 !                 In SPLIT_RBL4DVAR, you can the analysis phase multiple 
-!                 times experimenting with different values of time_IAU
+!                 times experimenting with different values of timeIAU
 !                 to see which works best, without having to rerun the
 !                 inner-loops again (increment phase). You can only do
 !                 this if SPLIT_RBL4DVAR is first run with a non-zero
-!                 value of time_IAU, otherwise the initial condition will
+!                 value of timeIAU, otherwise the initial condition will
 !                 get overwritten in the initial NetCDF file.
 !
 !------------------------------------------------------------------------------

--- a/ROMS/Functionals/ana_respiration.h
+++ b/ROMS/Functionals/ana_respiration.h
@@ -101,7 +101,7 @@
       DO k=1,N(ng)
         DO j=JstrT,JendT
           DO i=IstrT,IendT
-	    respiration(i,j,k)=ResRate(ng)
+            respiration(i,j,k)=ResRate(ng)
           END DO
         END DO
       END DO

--- a/ROMS/Include/globaldefs.h
+++ b/ROMS/Include/globaldefs.h
@@ -877,7 +877,7 @@
 ** Define internal option to process wave data.
 */
 
-#if (defined ROLLER_SVENDSEN || defined ROLLER_MONO ||	\
+#if (defined ROLLER_SVENDSEN || defined ROLLER_MONO || \
      defined ROLLER_RENIERS) && defined WEC
 # define WEC_ROLLER
 #endif

--- a/ROMS/Modules/mod_grid.F
+++ b/ROMS/Modules/mod_grid.F
@@ -339,7 +339,7 @@
 !
 ! Set global geometry 1D arrays, packed in column-major order, needed
 ! for field extraction by interpolation during writing to the proper
-! output NetCDF file. 
+! output NetCDF file.
 !
          real(r8), pointer :: Gangle_psi(:)
          real(r8), pointer :: Gangle_rho(:)

--- a/ROMS/Modules/mod_scalars.F
+++ b/ROMS/Modules/mod_scalars.F
@@ -408,7 +408,7 @@
         logical, allocatable :: SetGridConfig(:)
 !
 !  Switch to procces (Get/Set) all input data in an application. It is
-!  set to .TRUE. by default. It is manipulated by the ROMS-JEDI 
+!  set to .TRUE. by default. It is manipulated by the ROMS-JEDI
 !  interface during ROMS Phase 3 initialization that applies lateral
 !  boundary condition to the initial state vector passed by OOPS. Some
 !  applications requited input data for lateral boundary conditons.
@@ -1269,6 +1269,17 @@
 !
         logical, allocatable :: SporadicImpulse(:)     ! intermittent
         logical, allocatable :: FrequentImpulse(:)     ! continuous
+
+# ifdef RPCG
+!
+!  Logical switch to control incremental analysis update forcing.
+!
+        logical, allocatable :: IAUswitch(:)
+!
+!  Duration of the incremental inalysis update
+!
+        real(r8), allocatable :: time_IAU(:)
+# endif
 !
 !  Stability and accuracy factor used to scale the time-step of the
 !  horizontal and vertical convolution operator below its theoretical
@@ -3193,6 +3204,18 @@
         allocate ( FrequentImpulse(Ngrids) )
         Dmem(1)=Dmem(1)+REAL(Ngrids,r8)
       END IF
+
+# ifdef RPCG
+      IF (.not.allocated(IAUswitch)) THEN
+        allocate ( IAUswitch(Ngrids) )
+        Dmem(1)=Dmem(1)+REAL(Ngrids,r8)
+      END IF
+
+      IF (.not.allocated(time_IAU)) THEN
+        allocate ( time_IAU(Ngrids) )
+        Dmem(1)=Dmem(1)+REAL(Ngrids,r8)
+      END IF
+# endif
 
       IF (.not.allocated(dTdz_min)) THEN
         allocate ( dTdz_min(Ngrids) )

--- a/ROMS/Modules/mod_scalars.F
+++ b/ROMS/Modules/mod_scalars.F
@@ -1269,17 +1269,14 @@
 !
         logical, allocatable :: SporadicImpulse(:)     ! intermittent
         logical, allocatable :: FrequentImpulse(:)     ! continuous
-
-# ifdef RPCG
 !
-!  Logical switch to control incremental analysis update forcing.
+!  Logical switch to control 4D-Var incremental analysis update forcing.
 !
         logical, allocatable :: IAUswitch(:)
 !
-!  Duration of the incremental inalysis update
+!  Duration of the 4D-Var incremental inalysis update (seconds).
 !
-        real(r8), allocatable :: time_IAU(:)
-# endif
+        real(dp), allocatable :: timeIAU(:)
 !
 !  Stability and accuracy factor used to scale the time-step of the
 !  horizontal and vertical convolution operator below its theoretical
@@ -3205,17 +3202,16 @@
         Dmem(1)=Dmem(1)+REAL(Ngrids,r8)
       END IF
 
-# ifdef RPCG
       IF (.not.allocated(IAUswitch)) THEN
         allocate ( IAUswitch(Ngrids) )
         Dmem(1)=Dmem(1)+REAL(Ngrids,r8)
       END IF
 
-      IF (.not.allocated(time_IAU)) THEN
-        allocate ( time_IAU(Ngrids) )
+      IF (.not.allocated(timeIAU)) THEN
+        allocate ( timeIAU(Ngrids) )
+        timeIAU=0.0_dp
         Dmem(1)=Dmem(1)+REAL(Ngrids,r8)
       END IF
-# endif
 
       IF (.not.allocated(dTdz_min)) THEN
         allocate ( dTdz_min(Ngrids) )

--- a/ROMS/Nonlinear/bulk_flux.F
+++ b/ROMS/Nonlinear/bulk_flux.F
@@ -43,7 +43,7 @@
 !    Drennan, W. M., Graber, H. C., Hauser, D., & Quentin, C., 2003:   !
 !      On the wave age dependence of wind stress over pure wind seas.  !
 !      J. Geophys. Res: Oceans, 108(C3).                               !
-!                                                                      !                
+!                                                                      !
 !    Edson, J.B., Jampana, V., Weller, R.A., Bigorre, S.P.,            !
 !      Plueddemann, A.J., Fairall, C.W., Miller, S.D., Mahrt, L.,      !
 !      Vickers, D. and Hersbach, H., 2013. On the exchange of          !
@@ -75,7 +75,7 @@
 !  Modified by Jim Edson to correct specific humidities.               !
 !  Modified by John Wilkin to introduce WIND_MINUS_CURRENT (02/2018)   !
 !  Modified by Fernando Pareja-Roman and John Wilkin to introduce      !
-!      COARE 3.5 and correct the partition of vector stress (02/2024)  !     
+!      COARE 3.5 and correct the partition of vector stress (02/2024)  !
 !      To recover older COAREv3.0 #define COARE_30                     !
 !                                                                      !
 !=======================================================================
@@ -778,7 +778,7 @@
 # if defined COARE_30
 !
 !  Momentum roughness length based on COARE 3.0 (Fairall et al 2003, JPO)
-!  
+!
           IF (delW(i).gt.18.0_r8) THEN
             charn(i)=0.018_r8
           ELSE IF ((10.0_r8.lt.delW(i)).and.(delW(i).le.18.0_r8)) THEN
@@ -788,7 +788,7 @@
             charn(i)=0.011_r8
           END IF
 
-# else  
+# else
 !
 ! Momentum roughness length based on COARE 3.5 (Edson et al 2013, JPO)
 !
@@ -839,16 +839,16 @@
 !
 #if defined COARE_30
 !
-! Moisture and thermal roughness lengths, COARE 3.0      
-!           
-            ZoQ(i)=MIN(1.15e-4_r8,5.5e-5_r8/Rr(i)**0.6_r8)
-#else 
+! Moisture and thermal roughness lengths, COARE 3.0
 !
-! In COARE 3.5, moisture and thermal roughness lengths are adjusted 
+            ZoQ(i)=MIN(1.15e-4_r8,5.5e-5_r8/Rr(i)**0.6_r8)
+#else
+!
+! In COARE 3.5, moisture and thermal roughness lengths are adjusted
 ! to reflect COARE 3.0 fluxes (J. Edson, pers. comm, 11/2023)
 !
             ZoQ(i)=MIN(1.6e-4_r8,5.8e-5_r8/(Rr(i)**0.72_r8))
-# endif            
+# endif
             ZoT(i)=ZoQ(i)
 !
 !  Compute Monin-Obukhov stability parameter, Z/L.
@@ -949,7 +949,7 @@
 !  sensible heat (Ch), and latent heat (Ce).
 !
           Wspeed=SQRT(Wmag(i)*Wmag(i)+Wgus(i)*Wgus(i))
-!         Cd=Wstar(i)*Wstar(i)/(Wspeed*Wspeed+eps) ! used prior to 02/2024   
+!         Cd=Wstar(i)*Wstar(i)/(Wspeed*Wspeed+eps) ! used prior to 02/2024
 # if defined ICE_MODEL && defined ICE_BULK_FLUXES && defined ICE_THERMO
           Ch=Wstar(i)*Tstar(i)/(-Wspeed*delT(i)+0.0098_r8*blk_ZT(ng))
           Ce=Wstar(i)*Qstar(i)/(-Wspeed*delQ(i)+eps)
@@ -1009,16 +1009,16 @@
           LHeat(i,j)=LHeat(i,j)*rmask_wet(i,j)
 # endif
 !
-!  Horizontal momentum flux (N/m2) due to rain (kg/m2/s) impact 
+!  Horizontal momentum flux (N/m2) due to rain (kg/m2/s) impact
 !  traveling at 85% of air velocity
 !
           Taur=0.85_r8*ABS(rain(i,j))*Wmag(i)
 !
-!  Sum of stresses (N/m2) expressed as friction velocities.  
+!  Sum of stresses (N/m2) expressed as friction velocities.
 !  Normalization by Wmag (m/s) so that stress components (Taux,
 !  Tauy in N/m2) are cff times the respective wind components
-!  (Uair,Vair in m/s). 
-!    
+!  (Uair,Vair in m/s).
+!
           cff=rhoAir(i)*(Wstar(i)*Wstar(i)+Taur/rhoAir(i))/(Wmag(i)+eps)
 !
 !  In prior versions incorrect normalization included gustiness in

--- a/ROMS/Nonlinear/forcing.F
+++ b/ROMS/Nonlinear/forcing.F
@@ -159,7 +159,14 @@
 !-----------------------------------------------------------------------
 !
       IF (DOMAIN(ng)%SouthWest_Corner(tile)) THEN
-        IF (Master) WRITE (stdout,10) time_code(ng)
+        IF (FrequentImpulse(ng)) THEN
+          IF (Master) WRITE (stdout,10) time_code(ng)
+        END IF
+# ifdef RPCG
+        IF (IAUswitch(ng)) THEN
+          IF (Master) WRITE (stdout,20) time_code(ng)
+        END IF
+# endif
       END IF
 !
 !  Free-surface.
@@ -235,6 +242,10 @@
 !
  10   FORMAT (2x,'NL_FORCING       - added convolved adjoint impulse,', &
      &        t71,'t = ', a)
+# ifdef RPCG
+ 20   FORMAT (2x,'NL_FORCING       - incremental analysis update,    ', &
+     &        t71,'t = ', a)
+# endif
 !
       RETURN
       END SUBROUTINE forcing_tile

--- a/ROMS/Nonlinear/main3d.F
+++ b/ROMS/Nonlinear/main3d.F
@@ -278,8 +278,8 @@
             DO ig=1,GridsInLayer(nl)
               ng=GridNumber(ig,nl)
 #  ifdef RPCG
-              IF ((iic(ng).gt.INT(time_IAU(ng)*day2sec/dt(ng))).or.     &
-     &            time_IAU(ng).eq.0.0_r8) THEN
+              IF ((iic(ng).gt.INT(timeIAU(ng)/dt(ng))).or.              &
+     &            timeIAU(ng).eq.0.0_dp) THEN
                 IAUswitch(ng)=.FALSE.
               END IF
               IF (FrequentImpulse(ng).or.IAUswitch(ng)) THEN

--- a/ROMS/Nonlinear/main3d.F
+++ b/ROMS/Nonlinear/main3d.F
@@ -73,6 +73,10 @@
       USE gls_corstep_mod,      ONLY : gls_corstep
       USE gls_prestep_mod,      ONLY : gls_prestep
 # endif
+# if defined NLM_OUTER             || defined RBL4DVAR                 || \
+  defined RBL4DVAR_ANA_SENSITIVITY || defined RBL4DVAR_FCT_SENSITIVITY
+      USE frc_iau_mod,          ONLY : frc_iau
+# endif
 # if defined DIFF_3DCOEF || defined VISC_3DCOEF
       USE hmixing_mod,          ONLY : hmixing
 # endif
@@ -273,13 +277,32 @@
 !
             DO ig=1,GridsInLayer(nl)
               ng=GridNumber(ig,nl)
-#  if defined WEAK_NOINTERP
-              IF ((iic(ng).gt.1).and.(iic(ng).ne.ntend(ng)+1).and.      &
-     &            (MOD(iic(ng)-1,nadj(ng)).eq.0)) THEN
-                IF (Master) THEN
-                  WRITE (stdout,*) ' FORCING NLM at iic = ',iic(ng)
-                END IF
+#  ifdef RPCG
+              IF ((iic(ng).gt.INT(time_IAU(ng)*day2sec/dt(ng))).or.     &
+     &            time_IAU(ng).eq.0.0_r8) THEN
+                IAUswitch(ng)=.FALSE.
+              END IF
+              IF (FrequentImpulse(ng).or.IAUswitch(ng)) THEN
 #  endif
+#  if defined WEAK_NOINTERP
+                IF ((iic(ng).gt.1).and.(iic(ng).ne.ntend(ng)+1).and.    &
+     &              (MOD(iic(ng)-1,nadj(ng)).eq.0)) THEN
+                  IF (Master) THEN
+                    WRITE (stdout,*) ' FORCING NLM at iic = ',iic(ng)
+                  END IF
+#  endif
+#  ifdef RPCG
+                  IF (FrequentImpulse(ng).and.IAUswitch(ng)) THEN
+                    DO tile=first_tile(ng),last_tile(ng),+1
+                    CALL frc_iau (ng, tile, 1)
+                    END DO
+                  END IF
+                  DO tile=first_tile(ng),last_tile(ng),+1
+                    CALL forcing (ng, tile, kstp(ng), nstp(ng))
+                    CALL set_depth (ng, tile, iNLM)
+                  END DO
+!$OMP BARRIER
+#  else
                 IF (FrequentImpulse(ng)) THEN
                   DO tile=first_tile(ng),last_tile(ng),+1
                     CALL forcing (ng, tile, kstp(ng), nstp(ng))
@@ -287,7 +310,11 @@
                   END DO
 !$OMP BARRIER
                 END IF
+#  endif
 #  if defined WEAK_NOINTERP
+                END IF
+#  endif
+#  ifdef RPCG
               END IF
 #  endif
             END DO

--- a/ROMS/Nonlinear/post_initial.F
+++ b/ROMS/Nonlinear/post_initial.F
@@ -43,7 +43,7 @@
 !
 !  Local variable declarations.
 !
-      integer :: tile      
+      integer :: tile
 !
 !-----------------------------------------------------------------------
 !  Initialize free-surface and compute initial level thicknesses and

--- a/ROMS/Representer/rp_main3d.F
+++ b/ROMS/Representer/rp_main3d.F
@@ -222,7 +222,7 @@
 !  On the first timestep, it computes the initial depths and level
 !  thicknesses from the initial free-surface field. Additionally, it
 !  initializes the tangent linear state variables for all time levels
-!  and applies lateral boundary conditions. 
+!  and applies lateral boundary conditions.
 !-----------------------------------------------------------------------
 !
         DO ng=1,Ngrids

--- a/ROMS/Representer/rp_post_initial.F
+++ b/ROMS/Representer/rp_post_initial.F
@@ -43,7 +43,7 @@
 !
 !  Local variable declarations.
 !
-      integer :: tile      
+      integer :: tile
 !
 !-----------------------------------------------------------------------
 !  Initialize free-surface and compute initial level thicknesses and

--- a/ROMS/Representer/rp_step2d_FB.h
+++ b/ROMS/Representer/rp_step2d_FB.h
@@ -588,7 +588,7 @@
 #ifdef DEBUG
       real(r8), parameter :: IniVal = 0.0_r8
 #endif
-! 
+!
 #if defined UV_C4ADVECTION && !defined SOLVE3D
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: Dgrad
 #endif
@@ -680,7 +680,7 @@
 #include "set_bounds.h"
 
 #ifdef DEBUG
-! 
+!
 !-----------------------------------------------------------------------
 !  Initialize private arrays for debugging.
 !-----------------------------------------------------------------------
@@ -826,7 +826,7 @@
 #endif
 
       DO j=JR_RANGE
-        DO i=IR_RANGE 
+        DO i=IR_RANGE
 !^        Drhs(i,j)=h(i,j)+fwd0*zeta(i,j,kstp)+                         &
 !^   &                     fwd1*zeta(i,j,kbak)+                         &
 !^   &                     fwd2*zeta(i,j,kold)
@@ -846,7 +846,7 @@
 !^        urhs(i,j)=fwd0*ubar(i,j,kstp)+                                &
 !^   &              fwd1*ubar(i,j,kbak)+                                &
 !^   &              fwd2*ubar(i,j,kold)
-!^                                            
+!^
           urhs(i,j)=ubar(i,j,kstp)              ! using background value
           tl_urhs(i,j)=fwd0*tl_ubar(i,j,kstp)+                          &
      &                 fwd1*tl_ubar(i,j,kbak)+                          &
@@ -917,7 +917,7 @@
      &                    IminS, ImaxS, JminS, JmaxS,                   &
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    DUon, DVom,                                   & 
+     &                    DUon, DVom,                                   &
      &                    tl_DUon, tl_DVom)
 #endif
 !
@@ -980,7 +980,7 @@
 !
 !  Notice that the new local free-surface is allocated so it can be
 !  passed as an argumment to "zetabc_local". An automatic array cannot
-!  be used here because of weird memory problems. 
+!  be used here because of weird memory problems.
 !
       allocate ( tl_zeta_new(IminS:ImaxS,JminS:JmaxS) )
       tl_zeta_new = 0.0_r8
@@ -1005,11 +1005,11 @@
       END DO
 !
 !  Compute "zeta_new" at new time step and interpolate it half-step
-!  backward, "zwrk" for the subsequent computation of the tangent 
+!  backward, "zwrk" for the subsequent computation of the tangent
 !  linear barotropic pressure gradient. Here, we use the BASIC STATE
 !  values. Thus, the nonlinear correction to the pressure-gradient
 !  term from "kstp" to "knew" is not needed for Forward-Euler to
-!  Forward-Backward steps (PGF_FB_CORRECTION method). 
+!  Forward-Backward steps (PGF_FB_CORRECTION method).
 !
       DO j=JstrV-1,Jend
         DO i=IstrU-1,Iend
@@ -1140,7 +1140,7 @@
 !
       IF (FIRST_2D_STEP) THEN
         DO j=JstrR,JendR
-          DO i=IstrR,IendR 
+          DO i=IstrR,IendR
 !^          Zt_avg1(i,j)=cff1*zeta(i,j,knew)
 !^
             tl_Zt_avg1(i,j)=cff1*tl_zeta(i,j,knew)
@@ -1189,7 +1189,7 @@
 #ifdef SOLVE3D
 !
 !  Notice that we are suppressing the computation of momentum advection,
-!  Coriolis, and lateral viscosity terms in 3D Applications because 
+!  Coriolis, and lateral viscosity terms in 3D Applications because
 !  these terms are already included in the baroclinic-to-barotropic
 !  forcing arrays "rufrc" and "rvfrc". It does not mean we are entirely
 !  omitting them, but it is a choice between recomputing them at every
@@ -2177,7 +2177,7 @@
      &         pnom_r(i,j)*                                             &
      &         ((pm(i,j  )+pm(i,j+1))*vbar(i,j+1,kstp)-                 &
      &          (pm(i,j-1)+pm(i,j  ))*vbar(i,j  ,kstp)))
-!        
+!
           tl_cff=visc2_r(i,j)*0.5_r8*                                   &
      &           (tl_Drhs(i,j)*                                         &
      &            (pmon_r(i,j)*                                         &
@@ -2383,8 +2383,8 @@
 !  subtracting the fast-time "rubar" and "rvbar" from them.
 !
 !  In the predictor-coupled mode, the resultant forcing terms "rufrc"
-!  and "rvfrc" are extrapolated forward in time, so they become 
-!  centered effectively at time n+1/2. This is done using optimized 
+!  and "rvfrc" are extrapolated forward in time, so they become
+!  centered effectively at time n+1/2. This is done using optimized
 !  Adams-Bashforth weights. In the code below, rufrc_bak(:,:,nstp) is
 !  at (n-1)time step, while rufrc_bak(:,:,3-nstp) is at (n-2). After
 !  its use as input, the latter is overwritten by the value at time
@@ -2408,9 +2408,9 @@
           cfwd0=1.5_r8
           cfwd1=-0.5_r8
           cfwd2=0.0_r8
-        ELSE                                
-          cfwd2=0.281105_r8                     
-          cfwd1=-0.5_r8-2.0_r8*cfwd2                 
+        ELSE
+          cfwd2=0.281105_r8
+          cfwd1=-0.5_r8-2.0_r8*cfwd2
           cfwd0=1.5_r8+cfwd2
         END IF
 !
@@ -3667,7 +3667,7 @@
 !  Exchange halo tile information.
 !-----------------------------------------------------------------------
 !
-      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN 
+      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
 !^      CALL exchange_r2d_tile (ng, tile,                               &
 !^   &                          LBi, UBi, LBj, UBj,                     &
 !^   &                          zeta(:,:,knew))

--- a/ROMS/Representer/rp_step2d_FB_LF_AM3.h
+++ b/ROMS/Representer/rp_step2d_FB_LF_AM3.h
@@ -660,8 +660,8 @@
       IF (FIRST_2D_STEP) THEN
         kbak=kstp                      ! "kbak" is used as "from"
       ELSE                             ! time index for LF timestep
-        kbak=3-kstp                    
-      END IF                            
+        kbak=3-kstp
+      END IF
 
 #ifdef DEBUG
 !
@@ -766,7 +766,7 @@
      &                    IminS, ImaxS, JminS, JmaxS,                   &
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    DUon, DVom,                                   & 
+     &                    DUon, DVom,                                   &
      &                    tl_DUon, tl_DVom)
 #endif
 !
@@ -930,7 +930,7 @@
 !  "rufrc, rvfrc" are finalized, a correction term based on the
 !  difference zeta_new(:,:)-zeta(:,:,kstp) to "rubar, rvbar" to make
 !  them consistent with generalized RK2 stepping for pressure gradient
-!  terms. 
+!  terms.
 !
       IF (PREDICTOR_2D_STEP) THEN
         IF (FIRST_2D_STEP) THEN     ! Modified RK2 time step (with
@@ -1169,7 +1169,7 @@
 #ifdef SOLVE3D
 !
 !  Notice that we are suppressing the computation of momentum advection,
-!  Coriolis, and lateral viscosity terms in 3D Applications because 
+!  Coriolis, and lateral viscosity terms in 3D Applications because
 !  these terms are already included in the baroclinic-to-barotropic
 !  forcing arrays "rufrc" and "rvfrc". It does not mean we are entirely
 !  omitting them, but it is a choice between recomputing them at every
@@ -1939,7 +1939,7 @@
       END DO
 #endif
 
-#if (defined UV_COR & !defined SOLVE3D) || defined STEP2D_CORIOLIS 
+#if (defined UV_COR & !defined SOLVE3D) || defined STEP2D_CORIOLIS
 !
 !-----------------------------------------------------------------------
 !  Add in Coriolis term.
@@ -2487,7 +2487,7 @@
 !^          rzeta(i,j)=(1.0_r8+rhoS(i,j))*zwrk(i,j)
 !^
             tl_rzeta(i,j)=(1.0_r8+rhoS(i,j))*tl_zwrk(i,j)+              &
-     &                    tl_rhoS(i,j)+zwrk(i,j)-                       & 
+     &                    tl_rhoS(i,j)+zwrk(i,j)-                       &
 #  ifdef TL_IOMS
      &                    rhoS(i,j)*zwrk(i,j)
 #  endif
@@ -3403,7 +3403,7 @@
 #ifdef SOLVE3D
 !
 !-----------------------------------------------------------------------
-!  Finalize computation of barotropic mode averages. 
+!  Finalize computation of barotropic mode averages.
 !-----------------------------------------------------------------------
 !
 !  This procedure starts with filling in boundary rows of total depths
@@ -3658,7 +3658,7 @@
 !  Exchange boundary information.
 !-----------------------------------------------------------------------
 !
-      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN 
+      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
 !^      CALL exchange_r2d_tile (ng, tile,                               &
 !^   &                          LBi, UBi, LBj, UBj,                     &
 !^   &                          zeta(:,:,knew))

--- a/ROMS/Tangent/tl_main3d.F
+++ b/ROMS/Tangent/tl_main3d.F
@@ -299,7 +299,7 @@
 !  On the first timestep, it computes the initial depths and level
 !  thicknesses from the initial free-surface field. Additionally, it
 !  initializes the tangent linear state variables for all time levels
-!  and applies lateral boundary conditions. 
+!  and applies lateral boundary conditions.
 !-----------------------------------------------------------------------
 !
             DO ig=1,GridsInLayer(nl)

--- a/ROMS/Tangent/tl_post_initial.F
+++ b/ROMS/Tangent/tl_post_initial.F
@@ -45,7 +45,7 @@
 !
 !  Local variable declarations.
 !
-      integer :: tile      
+      integer :: tile
 !
 !-----------------------------------------------------------------------
 !  Initialize free-surface and compute initial level thicknesses and

--- a/ROMS/Tangent/tl_step2d_FB.h
+++ b/ROMS/Tangent/tl_step2d_FB.h
@@ -591,7 +591,7 @@
 #ifdef DEBUG
       real(r8), parameter :: IniVal = 0.0_r8
 #endif
-! 
+!
 #if defined UV_C4ADVECTION && !defined SOLVE3D
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: Dgrad
 #endif
@@ -683,7 +683,7 @@
 #include "set_bounds.h"
 
 #ifdef DEBUG
-! 
+!
 !-----------------------------------------------------------------------
 !  Initialize private arrays for debugging.
 !-----------------------------------------------------------------------
@@ -829,7 +829,7 @@
 #endif
 
       DO j=JR_RANGE
-        DO i=IR_RANGE 
+        DO i=IR_RANGE
 !^        Drhs(i,j)=h(i,j)+fwd0*zeta(i,j,kstp)+                         &
 !^   &                     fwd1*zeta(i,j,kbak)+                         &
 !^   &                     fwd2*zeta(i,j,kold)
@@ -849,7 +849,7 @@
 !^        urhs(i,j)=fwd0*ubar(i,j,kstp)+                                &
 !^   &              fwd1*ubar(i,j,kbak)+                                &
 !^   &              fwd2*ubar(i,j,kold)
-!^                                            
+!^
           urhs(i,j)=ubar(i,j,kstp)              ! using background value
           tl_urhs(i,j)=fwd0*tl_ubar(i,j,kstp)+                          &
      &                 fwd1*tl_ubar(i,j,kbak)+                          &
@@ -912,7 +912,7 @@
      &                    IminS, ImaxS, JminS, JmaxS,                   &
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    DUon, DVom,                                   & 
+     &                    DUon, DVom,                                   &
      &                    tl_DUon, tl_DVom)
 #endif
 !
@@ -975,7 +975,7 @@
 !
 !  Notice that the new local free-surface is allocated so it can be
 !  passed as an argumment to "zetabc_local". An automatic array cannot
-!  be used here because of weird memory problems. 
+!  be used here because of weird memory problems.
 !
       allocate ( tl_zeta_new(IminS:ImaxS,JminS:JmaxS) )
       tl_zeta_new = 0.0_r8
@@ -1003,11 +1003,11 @@
 #undef JR_RANGE
 !
 !  Compute "zeta_new" at new time step and interpolate it half-step
-!  backward, "zwrk" for the subsequent computation of the tangent 
+!  backward, "zwrk" for the subsequent computation of the tangent
 !  linear barotropic pressure gradient. Here, we use the BASIC STATE
 !  values. Thus, the nonlinear correction to the pressure-gradient
 !  term from "kstp" to "knew" is not needed for Forward-Euler to
-!  Forward-Backward steps (PGF_FB_CORRECTION method). 
+!  Forward-Backward steps (PGF_FB_CORRECTION method).
 !
       DO j=JstrV-1,Jend
         DO i=IstrU-1,Iend
@@ -1126,7 +1126,7 @@
 !
       IF (FIRST_2D_STEP) THEN
         DO j=JstrR,JendR
-          DO i=IstrR,IendR 
+          DO i=IstrR,IendR
 !^          Zt_avg1(i,j)=cff1*zeta(i,j,knew)
 !^
             tl_Zt_avg1(i,j)=cff1*tl_zeta(i,j,knew)
@@ -1175,7 +1175,7 @@
 #ifdef SOLVE3D
 !
 !  Notice that we are suppressing the computation of momentum advection,
-!  Coriolis, and lateral viscosity terms in 3D Applications because 
+!  Coriolis, and lateral viscosity terms in 3D Applications because
 !  these terms are already included in the baroclinic-to-barotropic
 !  forcing arrays "rufrc" and "rvfrc". It does not mean we are entirely
 !  omitting them, but it is a choice between recomputing them at every
@@ -2197,8 +2197,8 @@
 !  subtracting the fast-time "rubar" and "rvbar" from them.
 !
 !  In the predictor-coupled mode, the resultant forcing terms "rufrc"
-!  and "rvfrc" are extrapolated forward in time, so they become 
-!  centered effectively at time n+1/2. This is done using optimized 
+!  and "rvfrc" are extrapolated forward in time, so they become
+!  centered effectively at time n+1/2. This is done using optimized
 !  Adams-Bashforth weights. In the code below, rufrc_bak(:,:,nstp) is
 !  at (n-1)time step, while rufrc_bak(:,:,3-nstp) is at (n-2). After
 !  its use as input, the latter is overwritten by the value at time
@@ -2222,9 +2222,9 @@
           cfwd0=1.5_r8
           cfwd1=-0.5_r8
           cfwd2=0.0_r8
-        ELSE                                
-          cfwd2=0.281105_r8                     
-          cfwd1=-0.5_r8-2.0_r8*cfwd2                 
+        ELSE
+          cfwd2=0.281105_r8
+          cfwd1=-0.5_r8-2.0_r8*cfwd2
           cfwd0=1.5_r8+cfwd2
         END IF
 !
@@ -2309,7 +2309,7 @@
 !^          rzeta(i,j)=(1.0_r8+rhoS(i,j))*zwrk(i,j)
 !^
             tl_rzeta(i,j)=(1.0_r8+rhoS(i,j))*tl_zwrk(i,j)+              &
-     &                    tl_rhoS(i,j)*zwrk(i,j) 
+     &                    tl_rhoS(i,j)*zwrk(i,j)
 !^          rzeta2(i,j)=rzeta(i,j)*(zeta_new(i,j)+zeta(i,j,kstp))
 !^
             tl_rzeta2(i,j)=tl_rzeta(i,j)*                               &
@@ -3274,7 +3274,7 @@
 !  Exchange halo tile information.
 !-----------------------------------------------------------------------
 !
-      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN 
+      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
 !^      CALL exchange_r2d_tile (ng, tile,                               &
 !^   &                          LBi, UBi, LBj, UBj,                     &
 !^   &                          zeta(:,:,knew))

--- a/ROMS/Tangent/tl_step2d_FB_LF_AM3.h
+++ b/ROMS/Tangent/tl_step2d_FB_LF_AM3.h
@@ -660,8 +660,8 @@
       IF (FIRST_2D_STEP) THEN
         kbak=kstp                      ! "kbak" is used as "from"
       ELSE                             ! time index for LF timestep
-        kbak=3-kstp                    
-      END IF                            
+        kbak=3-kstp
+      END IF
 
 #ifdef DEBUG
 !
@@ -760,7 +760,7 @@
      &                    IminS, ImaxS, JminS, JmaxS,                   &
      &                    NghostPoints,                                 &
      &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    DUon, DVom,                                   & 
+     &                    DUon, DVom,                                   &
      &                    tl_DUon, tl_DVom)
 #endif
 !
@@ -924,7 +924,7 @@
 !  "rufrc, rvfrc" are finalized, a correction term based on the
 !  difference zeta_new(:,:)-zeta(:,:,kstp) to "rubar, rvbar" to make
 !  them consistent with generalized RK2 stepping for pressure gradient
-!  terms. 
+!  terms.
 !
       IF (PREDICTOR_2D_STEP) THEN
         IF (FIRST_2D_STEP) THEN     ! Modified RK2 time step (with
@@ -1139,7 +1139,7 @@
 #ifdef SOLVE3D
 !
 !  Notice that we are suppressing the computation of momentum advection,
-!  Coriolis, and lateral viscosity terms in 3D Applications because 
+!  Coriolis, and lateral viscosity terms in 3D Applications because
 !  these terms are already included in the baroclinic-to-barotropic
 !  forcing arrays "rufrc" and "rvfrc". It does not mean we are entirely
 !  omitting them, but it is a choice between recomputing them at every
@@ -1823,7 +1823,7 @@
       END DO
 #endif
 
-#if (defined UV_COR & !defined SOLVE3D) || defined STEP2D_CORIOLIS 
+#if (defined UV_COR & !defined SOLVE3D) || defined STEP2D_CORIOLIS
 !
 !-----------------------------------------------------------------------
 !  Add in Coriolis term.
@@ -2286,7 +2286,7 @@
 !^          rzeta(i,j)=(1.0_r8+rhoS(i,j))*zwrk(i,j)
 !^
             tl_rzeta(i,j)=(1.0_r8+rhoS(i,j))*tl_zwrk(i,j)+              &
-     &                    tl_rhoS(i,j)*zwrk(i,j) 
+     &                    tl_rhoS(i,j)*zwrk(i,j)
 !^          rzeta2(i,j)=rzeta(i,j)*                                     &
 !^   &                  (cff2*zeta_new(i,j)+                            &
 !^   &                   cff3*zeta(i,j,kstp))
@@ -3020,7 +3020,7 @@
 #ifdef SOLVE3D
 !
 !-----------------------------------------------------------------------
-!  Finalize computation of barotropic mode averages. 
+!  Finalize computation of barotropic mode averages.
 !-----------------------------------------------------------------------
 !
 !  This procedure starts with filling in boundary rows of total depths
@@ -3265,7 +3265,7 @@
 !  Exchange boundary information.
 !-----------------------------------------------------------------------
 !
-      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN 
+      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
 !^      CALL exchange_r2d_tile (ng, tile,                               &
 !^   &                          LBi, UBi, LBj, UBj,                     &
 !^   &                          zeta(:,:,knew))

--- a/ROMS/Utility/congrad.F
+++ b/ROMS/Utility/congrad.F
@@ -136,7 +136,7 @@
       INTERFACE rprecond
 # ifdef SINGLE_PRECISION
         MODULE PROCEDURE rprecond_dp
-# endif 
+# endif
         MODULE PROCEDURE rprecond_r8
       END INTERFACE rprecond
 !

--- a/ROMS/Utility/def_extract.F
+++ b/ROMS/Utility/def_extract.F
@@ -16,7 +16,7 @@
 !                                                                      !
 !  If ExtractFlag > 1:   Decimation                                    !
 !                                                                      !
-!  It decimates the field solution at the prescribed integer factor,   !    
+!  It decimates the field solution at the prescribed integer factor,   !
 !  ExtractFlag . For example, if ExtractFlag=2 (recommended), the      !
 !  output fieldsare written at every other point, resulting in coarser !
 !  data resolution. This strategy is advantageous in mixed resolution, !

--- a/ROMS/Utility/extract_field.F
+++ b/ROMS/Utility/extract_field.F
@@ -16,7 +16,7 @@
 !                                                                      !
 !  If Extract_Flag > 1:   Decimation                                   !
 !                                                                      !
-!  It decimates the field solution at the prescribed integer factor,   !    
+!  It decimates the field solution at the prescribed integer factor,   !
 !  Extract_Flag . For example, if Extract_Flag=2 (recommended), the    !
 !  output fieldsare written at every other point, resulting in coarser !
 !  data resolution. This strategy is advantageous in mixed resolution, !
@@ -288,7 +288,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)    :: ng, model, tile 
+      integer,  intent(in)    :: ng, model, tile
       integer,  intent(in)    :: gtype, ifield, tindex, Extract_Flag
       integer,  intent(in)    :: Imin, Imax, Jmin, Jmax
       integer,  intent(in)    :: Npts
@@ -306,7 +306,7 @@
 !------------------------------------------------------------------------
 !  Decimate or interpolate 2D field.
 !------------------------------------------------------------------------
-! 
+!
       IF (Extract_Flag.ge.2) THEN
         CALL decimate_field2d (ng, model, tile,                         &
      &                         gtype, ifield, tindex, Extract_Flag,     &
@@ -372,7 +372,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)    :: ng, model, tile 
+      integer,  intent(in)    :: ng, model, tile
       integer,  intent(in)    :: gtype, ifield, tindex, Extract_Flag
       integer,  intent(in)    :: Imin, Imax, Jmin, Jmax, Kmin, Kmax
       integer,  intent(in)    :: Npts
@@ -465,7 +465,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)    :: ng, model, tile 
+      integer,  intent(in)    :: ng, model, tile
       integer,  intent(in)    :: gtype, ifield, tindex, Extract_Flag
       integer,  intent(in)    :: Imin, Imax, Jmin, Jmax, Kmin, Kmax
       integer,  intent(in)    :: fourth, Loff
@@ -548,7 +548,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)  :: ng, model, tile 
+      integer,  intent(in)  :: ng, model, tile
       integer,  intent(in)  :: gtype, Extract_Flag
       integer,  intent(in)  :: Imin, Imax, Jmin, Jmax, Nrec
       integer,  intent(in)  :: Npts
@@ -597,7 +597,7 @@
             DO ir=1,Nrec
               rc=(ir-1)*IorJ*4
               DO ib=1,4
-                bc=(ib-1)*IorJ+rc            
+                bc=(ib-1)*IorJ+rc
                 IF (bounded(ib).and.                                    &
      &              ((ib.eq.isouth).or.(ib.eq.inorth))) THEN
                   DO i=Imin,Imax-1
@@ -616,7 +616,7 @@
             DO ir=1,Nrec
               rc=(ir-1)*IorJ*4
               DO ib=1,4
-                bc=(ib-1)*IorJ+rc            
+                bc=(ib-1)*IorJ+rc
                 IF (bounded(ib).and.                                    &
      &              ((ib.eq.iwest).or.(ib.eq.ieast))) THEN
                   DO j=Jmin,Jmax-1
@@ -669,7 +669,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)  :: ng, model, tile 
+      integer,  intent(in)  :: ng, model, tile
       integer,  intent(in)  :: gtype, Extract_Flag
       integer,  intent(in)  :: Imin, Imax, Jmin, Jmax, LBk, UBk, Nrec
       integer,  intent(in)  :: Npts
@@ -708,7 +708,7 @@
 !
       IF (Extract_Flag.ge.2) THEN
         Klen=UBk-LBk+1
-        IJKlen=IorJ*Klen      
+        IJKlen=IorJ*Klen
 !
         SELECT CASE (gtype)
 !
@@ -795,7 +795,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)  :: ng, model, tile 
+      integer,  intent(in)  :: ng, model, tile
       integer,  intent(in)  :: gtype, ifield, Extract_Flag
       integer,  intent(in)  :: Imin, Imax, Jmin, Jmax
       integer,  intent(in)  :: Npts
@@ -889,7 +889,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)  :: ng, model, tile 
+      integer,  intent(in)  :: ng, model, tile
       integer,  intent(in)  :: gtype, ifield, Extract_Flag
       integer,  intent(in)  :: Imin, Imax, Jmin, Jmax, Kmin, Kmax
       integer,  intent(in)  :: Npts
@@ -928,8 +928,8 @@
             Koff=0
             DO k=Kmin,Kmax                  ! Average data at RHO points
               DO j=Jmin,Jmax
-                DO i=Imin,Imax-1 
-                  ij=i+Ioff+(j-1+Joff)*Isize          
+                DO i=Imin,Imax-1
+                  ij=i+Ioff+(j-1+Joff)*Isize
                   ijk=ij+(k-1+Koff)*IJsize
                   Favg(ijk)=0.5_r8*(Fdat(ijk)+Fdat(ijk+1))
                 END DO
@@ -947,7 +947,7 @@
             DO k=Kmin,Kmax                  ! Average data at RHO points
               DO j=Jmin,Jmax-1
                 DO i=Imin,Imax
-                  ij=i+Ioff+(j-1+Joff)*Isize          
+                  ij=i+Ioff+(j-1+Joff)*Isize
                   ijk=ij+(k-1+Koff)*IJsize
                   Favg(ijk)=0.5_r8*(Fdat(ijk)+Fdat(ijk+Isize))
                 END DO
@@ -1003,7 +1003,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)    :: ng, model, tile 
+      integer,  intent(in)    :: ng, model, tile
       integer,  intent(in)    :: gtype, tindex, Extract_Flag
       integer,  intent(in)    :: Imin, Imax, Jmin, Jmax
       integer,  intent(in)    :: Nrec, Npts
@@ -1028,7 +1028,7 @@
 !------------------------------------------------------------------------
 !  Decimate input packed 2D boundary by requested factor.
 !------------------------------------------------------------------------
-! 
+!
       ifactor=ABS(Extract_Flag)
       IorJ=IOBOUNDS(ng)%IorJ
 !
@@ -1044,12 +1044,12 @@
           DO ir=1,Nrec
             rc=(ir-1)*IorJ*4
             DO ib=1,4
-              bc=(ib-1)*IorJ+rc            
+              bc=(ib-1)*IorJ+rc
               DO ij=1,IorJ,ifactor
                 ic=ic+1
                 Bdat(ic)=Bwrk(ij)
               END DO
-              IF ((ir.eq.1).and.(ib.eq.1)) IJdim=ic         
+              IF ((ir.eq.1).and.(ib.eq.1)) IJdim=ic
             END DO
           END DO
           Mpts=ic
@@ -1068,12 +1068,12 @@
           DO ir=1,Nrec
             rc=(ir-1)*IorJ*4
             DO ib=1,4
-              bc=(ib-1)*IorJ+rc            
+              bc=(ib-1)*IorJ+rc
               DO ij=1,IorJ,ifactor
                 ic=ic+1
                 Bdat(ic)=Bwrk(ij)
               END DO
-              IF ((ir.eq.1).and.(ib.eq.1)) IJdim=ic         
+              IF ((ir.eq.1).and.(ib.eq.1)) IJdim=ic
             END DO
           END DO
           Mpts=ic
@@ -1092,12 +1092,12 @@
           DO ir=1,Nrec
             rc=(ir-1)*IorJ*4
             DO ib=1,4
-              bc=(ib-1)*IorJ+rc            
+              bc=(ib-1)*IorJ+rc
               DO ij=1,IorJ,ifactor
                 ic=ic+1
                 Bdat(ic)=Bwrk(ij)
               END DO
-              IF ((ir.eq.1).and.(ib.eq.1)) IJdim=ic         
+              IF ((ir.eq.1).and.(ib.eq.1)) IJdim=ic
             END DO
           END DO
           Mpts=ic
@@ -1176,7 +1176,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)    :: ng, model, tile 
+      integer,  intent(in)    :: ng, model, tile
       integer,  intent(in)    :: gtype, tindex, Extract_Flag
       integer,  intent(in)    :: Imin, Imax, Jmin, Jmax, LBk, UBk
       integer,  intent(in)    :: Nrec, Npts
@@ -1201,11 +1201,11 @@
 !------------------------------------------------------------------------
 !  Decimate input packed 3D boundary by requested factor.
 !------------------------------------------------------------------------
-! 
+!
       ifactor=ABS(Extract_Flag)
       IorJ=IOBOUNDS(ng)%IorJ
       Klen=UBk-LBk+1
-      IJKlen=IorJ*Klen      
+      IJKlen=IorJ*Klen
 !
       SELECT CASE (gtype)
 !
@@ -1225,7 +1225,7 @@
                   ic=ic+1
                   Bwrk(ic)=Bdat(ij)
                 END DO
-                IF ((ir.eq.1).and.(ib.eq.1).and.(k.eq.LBk)) IJdim=ic         
+                IF ((ir.eq.1).and.(ib.eq.1).and.(k.eq.LBk)) IJdim=ic
               END DO
             END DO
           END DO
@@ -1252,7 +1252,7 @@
                   ic=ic+1
                   Bwrk(ic)=Bdat(ij)
                 END DO
-                IF ((ir.eq.1).and.(ib.eq.1).and.(k.eq.LBk)) IJdim=ic         
+                IF ((ir.eq.1).and.(ib.eq.1).and.(k.eq.LBk)) IJdim=ic
               END DO
             END DO
           END DO
@@ -1279,7 +1279,7 @@
                   ic=ic+1
                   Bwrk(ic)=Bdat(ij)
                 END DO
-                IF ((ir.eq.1).and.(ib.eq.1).and.(k.eq.LBk)) IJdim=ic         
+                IF ((ir.eq.1).and.(ib.eq.1).and.(k.eq.LBk)) IJdim=ic
               END DO
             END DO
           END DO
@@ -1356,7 +1356,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)    :: ng, model, tile 
+      integer,  intent(in)    :: ng, model, tile
       integer,  intent(in)    :: gtype, ifield, tindex, Extract_Flag
       integer,  intent(in)    :: Imin, Imax, Jmin, Jmax
       integer,  intent(in)    :: Npts
@@ -1379,7 +1379,7 @@
 !------------------------------------------------------------------------
 !  Decimate input packed 2D field by requested factor.
 !------------------------------------------------------------------------
-! 
+!
       ifactor=ABS(Extract_Flag)
       Isize=Imax-Imin+1
       Jsize=Jmax-Jmin+1
@@ -1545,7 +1545,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)    :: ng, model, tile 
+      integer,  intent(in)    :: ng, model, tile
       integer,  intent(in)    :: gtype, ifield, tindex, Extract_Flag
       integer,  intent(in)    :: Imin, Imax, Jmin, Jmax, Kmin, Kmax
       integer,  intent(in)    :: Npts
@@ -1790,7 +1790,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)    :: ng, model, tile 
+      integer,  intent(in)    :: ng, model, tile
       integer,  intent(in)    :: gtype, ifield, tindex, Extract_Flag
       integer,  intent(in)    :: Imin, Imax, Jmin, Jmax, Kmin, Kmax
       integer,  intent(in)    :: fourth, Loff
@@ -2255,28 +2255,28 @@
      &                          GRID(ng)%angler(i  ,j-1)+               &
      &                          GRID(ng)%angler(i  ,j  ))
           END DO
-        END DO                
+        END DO
       ELSE IF (Cgrid.eq.2) THEN                           ! RHO-points
         DO j=JstrT,JendT
           DO i=IstrT,IendT
             angle(i,j)=GRID(ng)%angler(i,j)
           END DO
-        END DO                
+        END DO
       ELSE IF (Cgrid.eq.3) THEN                           ! U-points
         DO j=JstrT,JendT
           DO i=IstrP,IendT
             angle(i,j)=0.5_r8*(GRID(ng)%angler(i-1,j)+                  &
      &                         GRID(ng)%angler(i  ,j))
           END DO
-        END DO                
+        END DO
       ELSE IF (Cgrid.eq.4) THEN                           ! V-points
         DO j=JstrP,JendT
           DO i=IstrT,IendT
             angle(i,j)=0.5_r8*(GRID(ng)%angler(i,j-1)+                  &
      &                         GRID(ng)%angler(i,j  ))
           END DO
-        END DO                
-      END IF      
+        END DO
+      END IF
 
 # ifdef DISTRIBUTE
 !
@@ -2456,7 +2456,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)    :: ng, model, tile 
+      integer,  intent(in)    :: ng, model, tile
       integer,  intent(in)    :: gtype, ifield, tindex
       integer,  intent(in)    :: Imin, Imax, Jmin, Jmax
       integer,  intent(in)    :: Npts
@@ -2485,7 +2485,7 @@
 !------------------------------------------------------------------------
 !  Interpolate
 !------------------------------------------------------------------------
-! 
+!
       LandFill=.TRUE.
       ghost=0
       method=Bilinear
@@ -2744,7 +2744,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)  :: ng, model, tile 
+      integer,  intent(in)  :: ng, model, tile
       integer,  intent(in)  :: gtype, ifield, tindex
       integer,  intent(in)  :: Imin, Imax, Jmin, Jmax, Kmin, Kmax
       integer,  intent(in)  :: Npts
@@ -3035,7 +3035,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)    :: ng, model, tile 
+      integer,  intent(in)    :: ng, model, tile
       integer,  intent(in)    :: gtype, ifield, tindex
       integer,  intent(in)    :: Imin, Imax, Jmin, Jmax, Kmin, Kmax
       integer,  intent(in)    :: fourth, Loff
@@ -3322,7 +3322,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)    :: ng, model, tile 
+      integer,  intent(in)    :: ng, model, tile
       integer,  intent(in)    :: gtype, ifield, tindex
       integer,  intent(in)    :: Imin, Imax, Jmin, Jmax
       integer,  intent(in)    :: Npts
@@ -3351,7 +3351,7 @@
 !------------------------------------------------------------------------
 !  Interpolate
 !------------------------------------------------------------------------
-! 
+!
       LandFill=.TRUE.
       ghost=0
       method=Bilinear
@@ -3544,7 +3544,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)  :: ng, model, tile 
+      integer,  intent(in)  :: ng, model, tile
       integer,  intent(in)  :: gtype, ifield, tindex
       integer,  intent(in)  :: Imin, Imax, Jmin, Jmax, Kmin, Kmax
       integer,  intent(in)  :: Npts
@@ -3769,7 +3769,7 @@
 !
 !  Imported variable declarations.
 !
-      integer,  intent(in)    :: ng, model, tile 
+      integer,  intent(in)    :: ng, model, tile
       integer,  intent(in)    :: gtype, ifield, tindex
       integer,  intent(in)    :: Imin, Imax, Jmin, Jmax, Kmin, Kmax
       integer,  intent(in)    :: fourth, Loff
@@ -4091,7 +4091,7 @@
         DO i=Istr,Iend
           ic=ic+1
 # ifdef MASKING
-          IF ((maskOut(i,j).lt.1.0_r8).and.LandFill) THEN    
+          IF ((maskOut(i,j).lt.1.0_r8).and.LandFill) THEN
             Fout(i,j)=spval
           ELSE
             Fmin=MIN(Fmin,Fout(i,j))
@@ -4256,7 +4256,7 @@
           DO i=Istr,Iend
             ic=ic+1
 # ifdef MASKING
-            IF ((maskOut(i,j).lt.1.0_r8).and.LandFill) THEN    
+            IF ((maskOut(i,j).lt.1.0_r8).and.LandFill) THEN
               Fout(i,j,k)=spval
             ELSE
               Fmin=MIN(Fmin,Fout(i,j,k))

--- a/ROMS/Utility/frc_iau.F
+++ b/ROMS/Utility/frc_iau.F
@@ -40,7 +40,7 @@
 !                                                                      !
 !  This subroutine computes the incremental analysis update (IAU)      !
 !  that is applied as a forcing term in the non-linear model during    !
-!  the first time_IAU days of the assimilation window.                 !
+!  the first timeIAU seconds of the assimilation window.               !
 !                                                                      !
 !  The adjoint arrays ad_var(irec) are used as temporary storage for   !
 !  the IAU.                                                            !
@@ -171,7 +171,7 @@
 !
 !  Set uniform weights in time.
 !
-      fac1=REAL(time_IAU(ng)*day2sec/dt(ng),r8)
+      fac1=REAL(timeIAU(ng)/dt(ng),r8)
       fac1=1.0_r8/fac1
 !
       DO j=JstrR,JendR

--- a/ROMS/Utility/frc_iau.F
+++ b/ROMS/Utility/frc_iau.F
@@ -1,0 +1,425 @@
+#include "cppdefs.h"
+      MODULE frc_iau_mod
+
+#if defined RBL4DVAR && defined RPCG
+!
+!================================================== Hernan G. Arango ===
+!  Copyright (c) 2002-2019 The ROMS/TOMS Group       Andrew M. Moore   !
+!    Licensed under a MIT/X style license                              !
+!    See License_ROMS.txt                                              !
+!=======================================================================
+!                                                                      !
+!  This routine is used to compute the IAU forcing for the NLM.        !
+!                                                                      !
+!  The method is described in:                                         !
+!  Bloom et al., 1996: Data Assimilation Using Incremental Analysis    !
+!                      Update. Mon. Wea. Rev., 124, 1256-1271.         !
+!                                                                      !
+!=======================================================================
+!
+      USE mod_param
+      USE mod_forces
+      USE mod_fourdvar
+      USE mod_ocean
+      USE mod_scalars
+      USE mod_stepping
+
+
+!
+      implicit none
+!
+      PRIVATE
+      PUBLIC :: frc_iau
+      PUBLIC :: frc_iau_ini
+!
+      CONTAINS
+!
+      SUBROUTINE frc_iau_ini (ng, tile, irec)
+!
+!=======================================================================
+!                                                                      !
+!  This subroutine computes the incremental analysis update (IAU)      !
+!  that is applied as a forcing term in the non-linear model during    !
+!  the first time_IAU days of the assimilation window.                 !
+!                                                                      !
+!  The adjoint arrays ad_var(irec) are used as temporary storage for   !
+!  the IAU.                                                            !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     ng        Nested grid number.                                    !
+!     tile      Domain partition.                                      !
+!     irec      ad_var record containing the fields on input.          !
+!                                                                      !
+!=======================================================================
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, tile, irec
+!
+!  Local variable declarations.
+!
+# include "tile.h"
+!
+# ifdef PROFILE
+      CALL wclock_on (ng, iADM, 7, __LINE__, __FILE__)
+# endif
+      CALL frc_iau_ini_tile (ng, tile,                                  &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       IminS, ImaxS, JminS, JmaxS,                &
+     &                       irec,                                      &
+     &                       OCEAN(ng) % ad_zeta,                       &
+# ifdef SOLVE3D
+     &                       OCEAN(ng) % ad_u,                          &
+     &                       OCEAN(ng) % ad_v,                          &
+     &                       OCEAN(ng) % ad_t,                          &
+# else
+     &                       OCEAN(ng) % ad_ubar,                       &
+     &                       OCEAN(ng) % ad_vbar,                       &
+# endif
+     &                       OCEAN(ng) % f_zeta,                        &
+# ifdef SOLVE3D
+     &                       OCEAN(ng) % f_u,                           &
+     &                       OCEAN(ng) % f_v,                           &
+     &                       OCEAN(ng) % f_t)
+# else
+     &                       OCEAN(ng) % f_ubar,                        &
+     &                       OCEAN(ng) % f_vbar)
+# endif
+# ifdef PROFILE
+      CALL wclock_off (ng, iADM, 7, __LINE__, __FILE__)
+# endif
+!
+      RETURN
+      END SUBROUTINE frc_iau_ini
+!
+!***********************************************************************
+      SUBROUTINE frc_iau_ini_tile (ng, tile,                            &
+     &                             LBi, UBi, LBj, UBj,                  &
+     &                             IminS, ImaxS, JminS, JmaxS,          &
+     &                             irec,                                &
+     &                             ad_zeta,                             &
+# ifdef SOLVE3D
+     &                             ad_u, ad_v, ad_t,                    &
+# else
+     &                             ad_ubar, ad_vbar,                    &
+# endif
+     &                             f_zeta,                              &
+# ifdef SOLVE3D
+     &                             f_u, f_v, f_t)
+# else
+     &                             f_ubar, f_vbar)
+# endif
+!***********************************************************************
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, tile, irec
+      integer, intent(in) :: LBi, UBi, LBj, UBj
+      integer, intent(in) :: IminS, ImaxS, JminS, JmaxS
+!
+# ifdef ASSUMED_SHAPE
+      real(r8), intent(inout) :: ad_zeta(LBi:,LBj:,:)
+      real(r8), intent(inout) :: f_zeta(LBi:,LBj:)
+#  ifdef SOLVE3D
+      real(r8), intent(inout) :: ad_u(LBi:,LBj:,:,:)
+      real(r8), intent(inout) :: ad_v(LBi:,LBj:,:,:)
+      real(r8), intent(inout) :: ad_t(LBi:,LBj:,:,:,:)
+      real(r8), intent(inout) :: f_u(LBi:,LBj:,:)
+      real(r8), intent(inout) :: f_v(LBi:,LBj:,:)
+      real(r8), intent(inout) :: f_t(LBi:,LBj:,:,:)
+#  else
+      real(r8), intent(inout) :: ad_ubar(LBi:,LBj:,:)
+      real(r8), intent(inout) :: ad_vbar(LBi:,LBj:,:)
+      real(r8), intent(inout) :: f_ubar(LBi:,LBj:)
+      real(r8), intent(inout) :: f_vbar(LBi:,LBj:)
+#  endif
+# else
+      real(r8), intent(inout) :: ad_zeta(LBi:UBi,LBj:UBj,3)
+      real(r8), intent(inout) :: f_zeta(LBi:UBi,LBj:UBj)
+#  ifdef SOLVE3D
+      real(r8), intent(inout) :: ad_u(LBi:UBi,LBj:UBj,N(ng),2)
+      real(r8), intent(inout) :: ad_v(LBi:UBi,LBj:UBj,N(ng),2)
+      real(r8), intent(inout) :: ad_t(LBi:UBi,LBj:UBj,N(ng),2,NT(ng))
+      real(r8), intent(inout) :: f_u(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(inout) :: f_v(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(inout) :: f_t(LBi:UBi,LBj:UBj,N(ng),NT(ng))
+#  else
+      real(r8), intent(inout) :: ad_ubar(LBi:UBi,LBj:UBj,3)
+      real(r8), intent(inout) :: ad_vbar(LBi:UBi,LBj:UBj,3)
+      real(r8), intent(inout) :: f_ubar(LBi:UBi,LBj:UBj)
+      real(r8), intent(inout) :: f_vbar(LBi:UBi,LBj:UBj)
+#  endif
+# endif
+!
+!  Local variable declarations.
+!
+      integer :: i, it1, it2, j, k
+# ifdef SOLVE3D
+      integer :: itrc
+# endif
+      real(r8) :: fac1
+
+# include "set_bounds.h"
+!
+!-----------------------------------------------------------------------
+!  Compute IAU forcing terms used in the nonlinear model.
+!  Use ad_var arrays as temporary storage for incremental analysis
+!  update forcing - needed when weak constraing is also activated
+!  and used in in the routine frc_iau.
+!-----------------------------------------------------------------------
+!
+!  Set uniform weights in time.
+!
+      fac1=REAL(time_IAU(ng)*day2sec/dt(ng),r8)
+      fac1=1.0_r8/fac1
+!
+      DO j=JstrR,JendR
+        DO i=IstrR,IendR
+         f_zeta(i,j)=fac1*ad_zeta(i,j,irec)
+         ad_zeta(i,j,irec)=f_zeta(i,j)
+        END DO
+      END DO
+
+# ifndef SOLVE3D
+!
+!  Compute 2D-momentum iau forcing terms.
+!
+      DO j=JstrR,JendR
+        DO i=Istr,IendR
+           f_ubar(i,j)=fac1*ad_ubar(i,j,irec)
+           ad_ubar(i,j,irec)=f_ubar(i,j)
+        END DO
+      END DO
+      DO j=Jstr,JendR
+        DO i=IstrR,IendR
+           f_vbar(i,j)=fac1*ad_vbar(i,j,irec)
+           ad_vbar(i,j,irec)=f_vbar(i,j)
+        END DO
+      END DO
+# endif
+# ifdef SOLVE3D
+!
+!  Compute 3D-momentum iau forcing terms.
+!
+      DO k=1,N(ng)
+        DO j=JstrR,JendR
+          DO i=Istr,IendR
+           f_u(i,j,k)=fac1*ad_u(i,j,k,irec)
+           ad_u(i,j,k,irec)=f_u(i,j,k)
+          END DO
+        END DO
+      END DO
+      DO k=1,N(ng)
+        DO j=Jstr,JendR
+          DO i=IstrR,IendR
+           f_v(i,j,k)=fac1*ad_v(i,j,k,irec)
+           ad_v(i,j,k,irec)=f_v(i,j,k)
+          END DO
+        END DO
+      END DO
+!
+!  Compute tracer iau forcing terms.
+!
+      DO itrc=1,NT(ng)
+        DO k=1,N(ng)
+          DO j=JstrR,JendR
+            DO i=IstrR,IendR
+             f_t(i,j,k,itrc)=fac1*ad_t(i,j,k,irec,itrc)
+             ad_t(i,j,k,irec,itrc)=f_t(i,j,k,itrc)
+            END DO
+          END DO
+        END DO
+      END DO
+# endif
+!
+      RETURN
+      END SUBROUTINE frc_iau_ini_tile
+!
+      SUBROUTINE frc_iau (ng, tile, irec)
+!
+!=======================================================================
+!                                                                      !
+!  This subroutine computes the combined weak constraint forcing       !
+!  and the incremental analysis update (IAU) when both weak constraint !
+!  data assimilation and the IAU are activated.                        !
+!  The input adjoint arrays ad_var(irec) hold the IAU forcing.         !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     ng        Nested grid number.                                    !
+!     tile      Domain partition.                                      !
+!     irec      ad_var record containing the fields on input.          !
+!                                                                      !
+!=======================================================================
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, tile, irec
+!
+!  Local variable declarations.
+!
+# include "tile.h"
+!
+# ifdef PROFILE
+      CALL wclock_on (ng, iADM, 7, __LINE__, __FILE__)
+# endif
+      CALL frc_iau_tile (ng, tile,                                      &
+     &                   LBi, UBi, LBj, UBj,                            &
+     &                   IminS, ImaxS, JminS, JmaxS,                    &
+     &                   irec,                                          &
+     &                   OCEAN(ng) % ad_zeta,                           &
+# ifdef SOLVE3D
+     &                   OCEAN(ng) % ad_u,                              &
+     &                   OCEAN(ng) % ad_v,                              &
+     &                   OCEAN(ng) % ad_t,                              &
+# else
+     &                   OCEAN(ng) % ad_ubar,                           &
+     &                   OCEAN(ng) % ad_vbar,                           &
+# endif
+     &                   OCEAN(ng) % f_zeta,                            &
+# ifdef SOLVE3D
+     &                   OCEAN(ng) % f_u,                               &
+     &                   OCEAN(ng) % f_v,                               &
+     &                   OCEAN(ng) % f_t)
+# else
+     &                   OCEAN(ng) % f_ubar,                            &
+     &                   OCEAN(ng) % f_vbar)
+# endif
+# ifdef PROFILE
+      CALL wclock_off (ng, iADM, 7, __LINE__, __FILE__)
+# endif
+!
+      RETURN
+      END SUBROUTINE frc_iau
+!
+!***********************************************************************
+      SUBROUTINE frc_iau_tile (ng, tile,                                &
+     &                         LBi, UBi, LBj, UBj,                      &
+     &                         IminS, ImaxS, JminS, JmaxS,              &
+     &                         irec,                                    &
+     &                         ad_zeta,                                 &
+# ifdef SOLVE3D
+     &                         ad_u, ad_v, ad_t,                        &
+# else
+     &                         ad_ubar, ad_vbar,                        &
+# endif
+     &                         f_zeta,                                  &
+# ifdef SOLVE3D
+     &                         f_u, f_v, f_t)
+# else
+     &                         f_ubar, f_vbar)
+# endif
+!***********************************************************************
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, tile, irec
+      integer, intent(in) :: LBi, UBi, LBj, UBj
+      integer, intent(in) :: IminS, ImaxS, JminS, JmaxS
+!
+# ifdef ASSUMED_SHAPE
+      real(r8), intent(in) :: ad_zeta(LBi:,LBj:,:)
+      real(r8), intent(inout) :: f_zeta(LBi:,LBj:)
+#  ifdef SOLVE3D
+      real(r8), intent(in) :: ad_u(LBi:,LBj:,:,:)
+      real(r8), intent(in) :: ad_v(LBi:,LBj:,:,:)
+      real(r8), intent(in) :: ad_t(LBi:,LBj:,:,:,:)
+      real(r8), intent(inout) :: f_u(LBi:,LBj:,:)
+      real(r8), intent(inout) :: f_v(LBi:,LBj:,:)
+      real(r8), intent(inout) :: f_t(LBi:,LBj:,:,:)
+#  else
+      real(r8), intent(in) :: ad_ubar(LBi:,LBj:,:)
+      real(r8), intent(in) :: ad_vbar(LBi:,LBj:,:)
+      real(r8), intent(inout) :: f_ubar(LBi:,LBj:)
+      real(r8), intent(inout) :: f_vbar(LBi:,LBj:)
+#  endif
+# else
+      real(r8), intent(in) :: ad_zeta(LBi:UBi,LBj:UBj,3)
+      real(r8), intent(inout) :: f_zeta(LBi:UBi,LBj:UBj)
+#  ifdef SOLVE3D
+      real(r8), intent(in) :: ad_u(LBi:UBi,LBj:UBj,N(ng),2)
+      real(r8), intent(in) :: ad_v(LBi:UBi,LBj:UBj,N(ng),2)
+      real(r8), intent(in) :: ad_t(LBi:UBi,LBj:UBj,N(ng),2,NT(ng))
+      real(r8), intent(inout) :: f_u(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(inout) :: f_v(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(inout) :: f_t(LBi:UBi,LBj:UBj,N(ng),NT(ng))
+#  else
+      real(r8), intent(in) :: ad_ubar(LBi:UBi,LBj:UBj,3)
+      real(r8), intent(in) :: ad_vbar(LBi:UBi,LBj:UBj,3)
+      real(r8), intent(inout) :: f_ubar(LBi:UBi,LBj:UBj)
+      real(r8), intent(inout) :: f_vbar(LBi:UBi,LBj:UBj)
+#  endif
+# endif
+!
+!  Local variable declarations.
+!
+      integer :: i, it1, it2, j, k
+# ifdef SOLVE3D
+      integer :: itrc
+# endif
+
+# include "set_bounds.h"
+!
+!-----------------------------------------------------------------------
+!  Update the weak constraint forcing arrays with the IAU forcing
+!  which is stored in the ad_var(irec) arrays.
+!-----------------------------------------------------------------------
+!
+      DO j=JstrR,JendR
+        DO i=IstrR,IendR
+         f_zeta(i,j)=f_zeta(i,j)+ad_zeta(i,j,irec)
+        END DO
+      END DO
+
+# ifndef SOLVE3D
+!
+!  Add 2D-momentum iau forcing terms.
+!
+      DO j=JstrR,JendR
+        DO i=Istr,IendR
+           f_ubar(i,j)=f_ubar(i,j)+ad_ubar(i,j,irec)
+        END DO
+      END DO
+      DO j=Jstr,JendR
+        DO i=IstrR,IendR
+           f_vbar(i,j)=f_vbar(i,j)+ad_vbar(i,j,irec)
+        END DO
+      END DO
+# endif
+# ifdef SOLVE3D
+!
+!  Add 3D-momentum iau forcing terms.
+!
+      DO k=1,N(ng)
+        DO j=JstrR,JendR
+          DO i=Istr,IendR
+           f_u(i,j,k)=f_u(i,j,k)+ad_u(i,j,k,irec)
+          END DO
+        END DO
+      END DO
+      DO k=1,N(ng)
+        DO j=Jstr,JendR
+          DO i=IstrR,IendR
+           f_v(i,j,k)=f_v(i,j,k)+ad_v(i,j,k,irec)
+          END DO
+        END DO
+      END DO
+!
+!  Add tracer iau forcing terms.
+!
+      DO itrc=1,NT(ng)
+        DO k=1,N(ng)
+          DO j=JstrR,JendR
+            DO i=IstrR,IendR
+             f_t(i,j,k,itrc)=f_t(i,j,k,itrc)+ad_t(i,j,k,irec,itrc)
+            END DO
+          END DO
+        END DO
+      END DO
+# endif
+!
+      RETURN
+      END SUBROUTINE frc_iau_tile
+#endif
+      END MODULE frc_iau_mod

--- a/ROMS/Utility/get_bounds.F
+++ b/ROMS/Utility/get_bounds.F
@@ -858,7 +858,7 @@
 !  Imported variable declarations.
 !
       integer, intent(in)  :: ng, tile
-      integer, intent(in)  :: my_Lm, my_Mm      
+      integer, intent(in)  :: my_Lm, my_Mm
       integer, intent(out) :: Itile, Jtile
       integer, intent(out) :: Iend, Istr, Jend, Jstr
       integer, intent(out) :: IstrM, IstrR, IstrU, IendR

--- a/ROMS/Utility/pack_field.F
+++ b/ROMS/Utility/pack_field.F
@@ -525,7 +525,7 @@
 !     ifield       Field metadata index (integer)                      !
 !     tindex       Time record index to process (integer)              !
 !     LandFill     Switch to set fill value in land areas (logical)    !                                         !
-!     Extract_Flag Extraction flag interpolation/decimation (integer)  ! 
+!     Extract_Flag Extraction flag interpolation/decimation (integer)  !
 !     LBi          Donor field I-dimension Lower bound (integer)       !
 !     UBi          Donor field I-dimension Upper bound (integer)       !
 !     LBj          Donor field J-dimension Lower bound (integer)       !
@@ -836,7 +836,7 @@
 !     ifield       Field metadata index (integer)                      !
 !     tindex       Time record index to process (integer)              !
 !     LandFill     Switch to set fill value in land areas (logical)    !
-!     Extract_Flag Extraction flag interpolation/decimation (integer)  ! 
+!     Extract_Flag Extraction flag interpolation/decimation (integer)  !
 !     LBi          Field I-dimension Lower bound (integer)             !
 !     UBi          Field I-dimension Upper bound (integer)             !
 !     LBj          Field J-dimension Lower bound (integer)             !
@@ -1116,7 +1116,7 @@
 !     ifield       Field metadata index (integer)                      !
 !     tindex       Time record index to process (integer)              !
 !     LandFill     Switch to set fill value in land areas (logical)    !
-!     Extract_Flag Extraction flag interpolation/decimation (integer)  ! 
+!     Extract_Flag Extraction flag interpolation/decimation (integer)  !
 !     LBi          Field I-dimension Lower bound (integer)             !
 !     UBi          Field I-dimension Upper bound (integer)             !
 !     LBj          Field J-dimension Lower bound (integer)             !

--- a/ROMS/Utility/read_asspar.F
+++ b/ROMS/Utility/read_asspar.F
@@ -200,8 +200,8 @@
                   tl_Tdiff(itrc,ng)=Rtracer(itrc,ng)
                 END DO
               END DO
-            CASE ('time_IAU')
-              Npts=load_r(Nval, Rval, Ngrids, time_IAU)
+            CASE ('timeIAU')
+              Npts=load_r(Nval, Rval, Ngrids, timeIAU)
             CASE ('LdefNRM')
               Npts=load_l(Nval, Cval, 4, Ngrids, LdefNRM)
             CASE ('LwrtNRM')
@@ -857,8 +857,8 @@
 #     endif
 #    endif
 #   endif
-          WRITE (out,100) time_IAU(ng), 'time_IAU',                     &
-     &            'Duration of the incremental analysis update.'
+          WRITE (out,100) timeIAU(ng), 'timeIAU',                       &
+     &            'Duration of the incremental analysis update (days).'
 #   ifndef I4DVAR_ANA_SENSITIVITY
 #    ifdef I4DVAR
           WRITE (out,100) GradErr, 'GradErr',                           &
@@ -1602,19 +1602,21 @@
         END IF
       END DO
 #  endif
-
-#  if defined WEAK_CONSTRAINT && defined TIME_CONV
 !
 !-----------------------------------------------------------------------
-!  Convert time decorrelation scales to seconds.
+!  Convert time scales to seconds.
 !-----------------------------------------------------------------------
 !
       DO ng=1,Ngrids
+#  ifdef FOUR_DVAR
+         timeIAU(ng)=timeIAU(ng)*86400.0_dp
+#  endif
+#  if defined WEAK_CONSTRAINT && defined TIME_CONV
         DO i=1,MstateVar
           Tdecay(i,ng)=Tdecay(i,ng)*86400.0_r8
         END DO
-      END DO
 #  endif
+      END DO
 !
   50  FORMAT (/,' READ_AssPar - Error while processing line: ',/,a)
   55  FORMAT (/,' READ_AssPar - ',a,i4,2x,i4,/,15x,a)

--- a/ROMS/Utility/read_asspar.F
+++ b/ROMS/Utility/read_asspar.F
@@ -200,6 +200,8 @@
                   tl_Tdiff(itrc,ng)=Rtracer(itrc,ng)
                 END DO
               END DO
+            CASE ('time_IAU')
+              Npts=load_r(Nval, Rval, Ngrids, time_IAU)
             CASE ('LdefNRM')
               Npts=load_l(Nval, Cval, 4, Ngrids, LdefNRM)
             CASE ('LwrtNRM')
@@ -855,6 +857,8 @@
 #     endif
 #    endif
 #   endif
+          WRITE (out,100) time_IAU(ng), 'time_IAU',                     &
+     &            'Duration of the incremental analysis update.'
 #   ifndef I4DVAR_ANA_SENSITIVITY
 #    ifdef I4DVAR
           WRITE (out,100) GradErr, 'GradErr',                           &

--- a/ROMS/Utility/read_phypar.F
+++ b/ROMS/Utility/read_phypar.F
@@ -4074,7 +4074,7 @@
             CASE ('GRDNAME')
               label='GRD - application grid'
               Npts=load_s1d(Nval, Cval, Cdim, line, label, igrid,       &
-     &                      Ngrids, Nfiles, inp_lib, GRD) 
+     &                      Ngrids, Nfiles, inp_lib, GRD)
             CASE ('GRXNAME')
               label='GRX - I/O histrory extract grid'
               Npts=load_s1d(Nval, Cval, Cdim, line, label, igrid,       &

--- a/ROMS/Utility/wrt_extract.F
+++ b/ROMS/Utility/wrt_extract.F
@@ -16,7 +16,7 @@
 !                                                                      !
 !  If ExtractFlag > 1:   Decimation                                    !
 !                                                                      !
-!  It decimates the field solution at the prescribed integer factor,   !    
+!  It decimates the field solution at the prescribed integer factor,   !
 !  ExtractFlag . For example, if ExtractFlag=2 (recommended), the      !
 !  output fieldsare written at every other point, resulting in coarser !
 !  data resolution. This strategy is advantageous in mixed resolution, !

--- a/User/External/s4dvar.in
+++ b/User/External/s4dvar.in
@@ -165,6 +165,11 @@ balance(isVvel) =  T                      ! 3D momentum (u, v)
 
        tl_Tdiff ==  50.0d0  50.0d0        ! NT tracers
 
+! Duration of the Incremental Analysis Update (days) [1:Ngrids].
+! NOTE: This option is only available for RBL4DVAR and when using RPCG.
+
+       time_IAU == 0.0d0
+
 ! Switches (T/F) to create and write error covariance normalization
 ! factors for model, initial conditions, boundary conditions, and
 ! surface forcing. If TRUE, these factors are computed and written
@@ -709,6 +714,25 @@ Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
 !
 !  tl_Tdiff       Tracers type variables diffusion relaxation coefficients
 !                 (m2/s).  NT values are expected.
+!
+!------------------------------------------------------------------------------
+! Incremental Analysis Update (IAU)
+!------------------------------------------------------------------------------
+!
+!  time_IAU       Duration of the Incremental Analysis Update (days),
+!                 [1:Ngrids]. It controls the time interval over which
+!                 the IAU is applied.
+!
+!                 This option is only available for RBL4DVAR and when using
+!                 RPCG minimizer.
+!
+!                 In SPLIT_RBL4DVAR, you can the analysis phase multiple 
+!                 times experimenting with different values of time_IAU
+!                 to see which works best, without having to rerun the
+!                 inner-loops again (increment phase). You can only do
+!                 this if SPLIT_RBL4DVAR is first run with a non-zero
+!                 value of time_IAU, otherwise the initial condition will
+!                 get overwritten in the initial NetCDF file.
 !
 !------------------------------------------------------------------------------
 ! Background/model correlation parameters.

--- a/User/External/s4dvar.in
+++ b/User/External/s4dvar.in
@@ -168,7 +168,7 @@ balance(isVvel) =  T                      ! 3D momentum (u, v)
 ! Duration of the Incremental Analysis Update (days) [1:Ngrids].
 ! NOTE: This option is only available for RBL4DVAR and when using RPCG.
 
-       time_IAU == 0.0d0
+        timeIAU == 0.0d0
 
 ! Switches (T/F) to create and write error covariance normalization
 ! factors for model, initial conditions, boundary conditions, and
@@ -719,7 +719,7 @@ Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
 ! Incremental Analysis Update (IAU)
 !------------------------------------------------------------------------------
 !
-!  time_IAU       Duration of the Incremental Analysis Update (days),
+!  timeIAU        Duration of the Incremental Analysis Update (days),
 !                 [1:Ngrids]. It controls the time interval over which
 !                 the IAU is applied.
 !
@@ -727,11 +727,11 @@ Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
 !                 RPCG minimizer.
 !
 !                 In SPLIT_RBL4DVAR, you can the analysis phase multiple 
-!                 times experimenting with different values of time_IAU
+!                 times experimenting with different values of timeIAU
 !                 to see which works best, without having to rerun the
 !                 inner-loops again (increment phase). You can only do
 !                 this if SPLIT_RBL4DVAR is first run with a non-zero
-!                 value of time_IAU, otherwise the initial condition will
+!                 value of timeIAU, otherwise the initial condition will
 !                 get overwritten in the initial NetCDF file.
 !
 !------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Since no dynamical balance constraint is imposed on the analysis increments computed during **4D-Var**, the resulting geostrophic adjustment process at the beginning of the assimilation window can lead to the generation of large amplitude inertia-gravity waves, so-called **initialization shocks**. These waves typically dissipate within 12-24 hours and are not usually a concern for the physical circulations that develop at the end of the assimilation window. However, these inertia-gravity waves can be very detrimental for coupled biogeochemical configurations of **ROMS** or those that include sediment processes. Therefore, it is desirable to suppress the generation of inertia-gravity waves during the assimilation window to the maximum extent possible. 

Initialization shock is a severe issue in numerical weather prediction (**NWP**), and mitigation attempts have a long history (_e.g._, Machenhaur,1977). Two common approaches used to minimize the influence of initialization shock in modern **NWP** systems are the application of a digital filter (Gauthier and Thépaut, 2001) and incremental analysis updates (**IAU**; Bloom _et al._, 1996), although under certain conditions, the two approaches are equivalent (Polavarapu _et al._, 2004).

**IAU** is straightforward to implement and has been included as an option in **ROMS 4D-Var**. Following the usual convention, we will denote by $𝒙(𝑡_k)$ the ocean state vector at time $𝑡_k$. Integration of the **ROMS** nonlinear model can then be represented as $𝒙(𝑡_{k+1}) = ℳ(𝒙(𝑡_k))$ where $ℳ$ represents the nonlinear model operators. Let $[𝑡_k−\tau, 𝑡_k]$ represent the **4D-Var** data assimilation window of length $\tau$, where $𝑡_k$ is the current time. The usual practice in **4D-Var** is to compute the analysis increment $\Delta 𝒙(𝑡_k − \tau)$ at the beginning of the analysis window and then integrate $𝒙(𝑡_k − \tau) + \Delta 𝒙(𝑡_k − \tau)$ forward in time to the end of the assimilation window using the nonlinear model $ℳ$. This occurs at the end of each **4D-Var** outer loop. However, since no explicit dynamical balance constraints are imposed on $\Delta 𝒙(𝑡_k − \tau)$, the ensuing geostrophic adjustment process during the assimilation window $[𝑡_k − \tau, 𝑡_k]$ can lead to the generation of inertia-gravity waves as described above. Instead of adding the increment $\Delta 𝒙(𝑡_k − \tau)$ to the initial condition $𝒙(𝑡_k − \tau)$, the **IAU** approach imposes the increment as a forcing term in the nonlinear model so that:

$$𝒙(𝑡_{k+1}) = ℳ 𝒙(t_k)) + 𝒇(𝑡)$$

where $𝒇(𝑡) = \Delta 𝒙(𝑡_k − \tau)\Delta 𝑡/𝑇$ for $𝑡_k − \tau \leq 𝑡 \leq 𝑡_k− \tau + 𝑇$ and $𝒇(𝑡) = 0$ for $𝑡 > 𝑡_k − \tau + 𝑇$. In this way, the nonlinear model at the end of each outer loop can be gently steered toward the desired analysis increment over some time interval $[𝑡_k − \tau, 𝑡_k − \tau + 𝑇]$ during the assimilation window with the result that the initialization shock is greatly reduced. The size of the forcing term $𝒇(𝑡)$ each timestep $\Delta 𝑡$ depends on the choice of $𝑇$, which in turn influences the filtering properties of the **IAU** procedure. The **IAU** procedure, as implemented in **ROMS**, is illustrated in the figure below. Since the forcing amplitude is generally small, the response function resulting from **IAU** can be conveniently quantified using the tangent linear approximation described by Bloom _et al._ (1996). The connection between the **IAU** and the digital filter approach was explored by Polavarapu _et al._ (2004).

![cropped](https://github.com/user-attachments/assets/d07bc490-ecb7-4b19-b5e1-d4ec38d1ab1f)

## ROMS Implementation

In **ROMS 4D-Var**, the **IAU** is activated by the parameter **timeIAU** in **`s4dvar.in`**, where **time_IAU** represents $T$ in the equation for $𝒇(𝑡)$ introduced in above. If **timeIAU**=0, then the **IAU** is not applied, and the increment $\Delta 𝒙(𝑡_k − \tau)$ is added to the initial condition at the beginning of the analysis window as normal.

### NOTE:

* The **IAU** is only available for dual **4D-Var** using the **`RBL4DVAR`** and **`SPLIT_RBL4DVAR`** algorithms. **IAU** is not currently implemented in the primal formulation of **4D-Var** (**`I4DVAR`**).

* If **timeIAU** $\neq$ 0, the **IAU** is activated in each outer-loop. 

* If running **`SPLIT_RBL4DVAR`**, the analysis phase can be run separately with different values of **timeIAU** but **only** if **timeIAU** was initially chosen as non-zero in the background and increment phases. This allows users to explore different choices of **timeIAU** without rerunning the inner loops.

## Dependencies:

None.  The **`ws_remove.sh`** script cleaned several files by removing white spaces after the text.

## References:

- Bloom, S.C., L.L. Takacs, A.M. da Silva and D. Ledvina, 1996: Data assimilation using incremental analysis updates, _Mon. Wea. Rev._, **124**, 1256-1271.
- Gauthier, P., and J.-N. Thépaut, 2001: Impact of the digital filter as a weak constraint in the preoperational 4DVAR assimilation system of Météo-France, _Mon. Wea. Rev._, **129**, 2089–2102.
- Machenhaur, B., 1977: On the dynamics of gravity oscillations in a shallow water model with
application to non-linear initialization, _Beit. Phys. Atmos._, **50**, 253-271.
- Polavarparu, S., R. Shuzan, A.M. Clayton, D. Sankey and Y. Rochon, 2004: On the relationship
between incremental analysis updating and incremental digital filtering, _Mon. Wea. Rev._, **132**,
2495-2502.

---

Many Thanks to Andy Moore for implementing this option and writing the documentation. Notice that the PDF file uses **timIAU** instead of **timeIAU** in the code.

[ROMS_IAU_v2.pdf](https://github.com/user-attachments/files/16570896/ROMS_IAU_v2.pdf)

