### PR TITLE
Added logic for CMEPS internal CPP flags

### DIFF
--- a/ROMS/Include/globaldefs.h
+++ b/ROMS/Include/globaldefs.h
@@ -841,6 +841,7 @@
 #endif
 
 #if defined ATM_COUPLING  || \
+    defined CMEPS         || \
     defined DATA_COUPLING || \
     defined ICE_COUPLING  || \
     defined WAV_COUPLING
@@ -848,7 +849,8 @@
 #endif
 
 #if defined MODEL_COUPLING && \
-    defined ESMF_LIB
+    defined ESMF_LIB       && \
+   !defined CMEPS
 # define REGRESS_STARTCLOCK
 # define ESM_SETRUNCLOCK
 #endif


### PR DESCRIPTION
The internal **ROMS** logic in **`globaldefs.h`** for coupling to the **UFS** using **CMEPS** was removed during merging.  We must activate the internal flag **`MODEL_COUPLING`** and deactivate internal flags **`REGRESS_STARTCLOCK`** and define **`ESM_SETRUNCLOCK`** when coupling with **CMEPS**:
``` c
#if defined ATM_COUPLING  || \
    defined CMEPS         || \
    defined DATA_COUPLING || \
    defined ICE_COUPLING  || \
    defined WAV_COUPLING
# define MODEL_COUPLING
#endif

#if defined MODEL_COUPLING && \
    defined ESMF_LIB       && \
   !defined CMEPS
# define REGRESS_STARTCLOCK
# define ESM_SETRUNCLOCK
#endif
```