### PR TITLE
Updated TL/AD currents variable changes 

### DIFF
--- a/ROMS/Adjoint/ad_def_his.F
+++ b/ROMS/Adjoint/ad_def_his.F
@@ -895,6 +895,7 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 #  endif
+#  if defined JEDI || defined UV_DESTAGGERED
 !
 !  Define 3D Eastward momentum at RHO-points, A-grid.
 !
@@ -904,9 +905,9 @@
           Vinfo( 3)=Vname(3,idu3dE)
           Vinfo(14)=Vname(4,idu3dE)
           Vinfo(16)=Vname(1,idtime)
-#  if defined WRITE_WATER && defined MASKING
+#   if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#  endif
+#   endif
           Vinfo(21)=Vname(6,idu3dE)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idu3dE,ng),r8)
@@ -923,9 +924,9 @@
           Vinfo( 3)=Vname(3,idv3dN)
           Vinfo(14)=Vname(4,idv3dN)
           Vinfo(16)=Vname(1,idtime)
-#  if defined WRITE_WATER && defined MASKING
+#   if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#  endif
+#   endif
           Vinfo(21)=Vname(6,idv3dN)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idv3dN,ng),r8)
@@ -933,6 +934,7 @@
      &                   NF_FOUT, nvd4, t3dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
+#  endif
 !
 !  Define S-coordinate omega vertical velocity.
 !
@@ -1302,12 +1304,14 @@
             got_var(idSbry(isVvel))=.TRUE.
             ADM(ng)%Vid(idSbry(isVvel))=var_id(i)
 #  endif
+#  if defined JEDI || defined UV_DESTAGGERED
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idu3dE))) THEN
             got_var(idu3dE)=.TRUE.
             ADM(ng)%Vid(idu3dE)=var_id(i)
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idv3dN))) THEN
             got_var(idv3dN)=.TRUE.
             ADM(ng)%Vid(idv3dN)=var_id(i)
+#  endif
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idOvel))) THEN
             got_var(idOvel)=.TRUE.
             ADM(ng)%Vid(idOvel)=var_id(i)
@@ -1455,6 +1459,7 @@
           RETURN
         END IF
 #  endif
+#  if defined JEDI || defined UV_DESTAGGERED
         IF (.not.got_var(idu3dE).and.Hout(idu3dE,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idu3dE)),          &
      &                                  TRIM(ncname)
@@ -1467,6 +1472,7 @@
           exit_flag=3
           RETURN
         END IF
+#  endif
         IF (.not.got_var(idOvel).and.Hout(idOvel,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idOvel)),          &
      &                                  TRIM(ncname)
@@ -1549,7 +1555,7 @@
 !
 !  Imported variable declarations.
 !
-      integer, intent(in) :: ng
+      integer, intent(in) :: ng, model
 
       logical, intent(in) :: ldef
 !
@@ -2421,6 +2427,7 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 #   endif
+#   if defined JEDI || defined UV_DESTAGGERED
 !
 !  Define 3D Eastward momentum at RHO-points, A-grid.
 !
@@ -2430,9 +2437,9 @@
           Vinfo( 3)=Vname(3,idu3dE)
           Vinfo(14)=Vname(4,idu3dE)
           Vinfo(16)=Vname(1,idtime)
-#   if defined WRITE_WATER && defined MASKING
+#    if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#   endif
+#    endif
           Vinfo(21)=Vname(6,idu3dE)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idu3dE,ng),r8)
@@ -2453,9 +2460,9 @@
           Vinfo( 3)=Vname(3,idv3dN)
           Vinfo(14)=Vname(4,idv3dN)
           Vinfo(16)=Vname(1,idtime)
-#   if defined WRITE_WATER && defined MASKING
+#    if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#   endif
+#    endif
           Vinfo(21)=Vname(6,idv3dN)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idv3dN,ng),r8)
@@ -2467,6 +2474,7 @@
      &                   PIO_FOUT, nvd4, t3dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
+#   endif
 !
 !  Define S-coordinate omega vertical velocity.
 !
@@ -2914,6 +2922,7 @@
             ADM(ng)%pioVar(idSbry(isVvel))%dkind=PIO_FOUT
             ADM(ng)%pioVar(idSbry(isVvel))%gtype=v3dvar
 #   endif
+#   if defined JEDI || defined UV_DESTAGGERED
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idu3dE))) THEN
             got_var(idu3dE)=.TRUE.
             ADM(ng)%pioVar(idu3dE)%vd=var_desc(i)
@@ -2924,6 +2933,7 @@
             ADM(ng)%pioVar(idv3dN)%vd=var_desc(i)
             ADM(ng)%pioVar(idv3dN)%dkind=PIO_FOUT
             ADM(ng)%pioVar(idv3dN)%gtype=r3dvar
+#   endif
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idOvel))) THEN
             got_var(idOvel)=.TRUE.
             ADM(ng)%pioVar(idOvel)%vd=var_desc(i)
@@ -3093,6 +3103,7 @@
           exit_flag=3
           RETURN
         END IF
+#   if defined JEDI || defined UV_DESTAGGERED
         IF (.not.got_var(idu3dE).and.Hout(idu3dE,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idu3dE)),          &
      &                                  TRIM(ncname)
@@ -3105,6 +3116,7 @@
           exit_flag=3
           RETURN
         END IF
+#   endif
         IF (.not.got_var(idDano).and.Hout(idDano,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idDano)),          &
      &                                  TRIM(ncname)

--- a/ROMS/Adjoint/ad_def_his.F
+++ b/ROMS/Adjoint/ad_def_his.F
@@ -895,7 +895,6 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 #  endif
-#  ifdef UV_DESTAGGERED
 !
 !  Define 3D Eastward momentum at RHO-points, A-grid.
 !
@@ -905,9 +904,9 @@
           Vinfo( 3)=Vname(3,idu3dE)
           Vinfo(14)=Vname(4,idu3dE)
           Vinfo(16)=Vname(1,idtime)
-#   if defined WRITE_WATER && defined MASKING
+#  if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#   endif
+#  endif
           Vinfo(21)=Vname(6,idu3dE)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idu3dE,ng),r8)
@@ -924,9 +923,9 @@
           Vinfo( 3)=Vname(3,idv3dN)
           Vinfo(14)=Vname(4,idv3dN)
           Vinfo(16)=Vname(1,idtime)
-#   if defined WRITE_WATER && defined MASKING
+#  if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#   endif
+#  endif
           Vinfo(21)=Vname(6,idv3dN)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idv3dN,ng),r8)
@@ -934,7 +933,6 @@
      &                   NF_FOUT, nvd4, t3dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
-#  endif
 !
 !  Define S-coordinate omega vertical velocity.
 !
@@ -1304,14 +1302,12 @@
             got_var(idSbry(isVvel))=.TRUE.
             ADM(ng)%Vid(idSbry(isVvel))=var_id(i)
 #  endif
-#  ifdef UV_DESTAGGERED
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idu3dE))) THEN
             got_var(idu3dE)=.TRUE.
             ADM(ng)%Vid(idu3dE)=var_id(i)
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idv3dN))) THEN
             got_var(idv3dN)=.TRUE.
             ADM(ng)%Vid(idv3dN)=var_id(i)
-#  endif
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idOvel))) THEN
             got_var(idOvel)=.TRUE.
             ADM(ng)%Vid(idOvel)=var_id(i)
@@ -1459,7 +1455,6 @@
           RETURN
         END IF
 #  endif
-#  ifdef UV_DESTAGGERED
         IF (.not.got_var(idu3dE).and.Hout(idu3dE,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idu3dE)),          &
      &                                  TRIM(ncname)
@@ -1472,7 +1467,6 @@
           exit_flag=3
           RETURN
         END IF
-#  endif
         IF (.not.got_var(idOvel).and.Hout(idOvel,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idOvel)),          &
      &                                  TRIM(ncname)
@@ -2427,7 +2421,6 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 #   endif
-#   ifdef UV_DESTAGGERED
 !
 !  Define 3D Eastward momentum at RHO-points, A-grid.
 !
@@ -2437,9 +2430,9 @@
           Vinfo( 3)=Vname(3,idu3dE)
           Vinfo(14)=Vname(4,idu3dE)
           Vinfo(16)=Vname(1,idtime)
-#    if defined WRITE_WATER && defined MASKING
+#   if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#    endif
+#   endif
           Vinfo(21)=Vname(6,idu3dE)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idu3dE,ng),r8)
@@ -2460,9 +2453,9 @@
           Vinfo( 3)=Vname(3,idv3dN)
           Vinfo(14)=Vname(4,idv3dN)
           Vinfo(16)=Vname(1,idtime)
-#    if defined WRITE_WATER && defined MASKING
+#   if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#    endif
+#   endif
           Vinfo(21)=Vname(6,idv3dN)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idv3dN,ng),r8)
@@ -2474,7 +2467,6 @@
      &                   PIO_FOUT, nvd4, t3dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
-#   endif
 !
 !  Define S-coordinate omega vertical velocity.
 !
@@ -2922,7 +2914,6 @@
             ADM(ng)%pioVar(idSbry(isVvel))%dkind=PIO_FOUT
             ADM(ng)%pioVar(idSbry(isVvel))%gtype=v3dvar
 #   endif
-#   ifdef UV_DESTAGGERED
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idu3dE))) THEN
             got_var(idu3dE)=.TRUE.
             ADM(ng)%pioVar(idu3dE)%vd=var_desc(i)
@@ -2933,7 +2924,6 @@
             ADM(ng)%pioVar(idv3dN)%vd=var_desc(i)
             ADM(ng)%pioVar(idv3dN)%dkind=PIO_FOUT
             ADM(ng)%pioVar(idv3dN)%gtype=r3dvar
-#   endif
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idOvel))) THEN
             got_var(idOvel)=.TRUE.
             ADM(ng)%pioVar(idOvel)%vd=var_desc(i)
@@ -3103,7 +3093,6 @@
           exit_flag=3
           RETURN
         END IF
-#   ifdef UV_DESTAGGERED
         IF (.not.got_var(idu3dE).and.Hout(idu3dE,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idu3dE)),          &
      &                                  TRIM(ncname)
@@ -3116,7 +3105,6 @@
           exit_flag=3
           RETURN
         END IF
-#   endif
         IF (.not.got_var(idDano).and.Hout(idDano,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idDano)),          &
      &                                  TRIM(ncname)

--- a/ROMS/Adjoint/ad_wrt_his.F
+++ b/ROMS/Adjoint/ad_wrt_his.F
@@ -842,6 +842,7 @@
         END IF
       END IF
 #  endif
+#  if defined JEDI || defined UV_DESTAGGERED
 !
 !  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid.
 !
@@ -852,9 +853,9 @@
      &                     ADM(ng)%Vid(idu3dE),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#  ifdef MASKING
+#   ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#  endif
+#   endif
      &                     OCEAN(ng) % ad_ua)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -873,9 +874,9 @@
      &                     ADM(ng)%Vid(idv3dN),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#  ifdef MASKING
+#   ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#  endif
+#   endif
      &                     OCEAN(ng) % ad_va)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -886,6 +887,7 @@
           RETURN
         END IF
       END IF
+#  endif
 !
 !  Write out S-coordinate omega vertical velocity (m/s).
 !
@@ -1290,7 +1292,7 @@
 # if defined PIO_LIB && defined DISTRIBUTE
 !
 !***********************************************************************
-      SUBROUTINE ad_wrt_his_pio (ng, tile,                              &
+      SUBROUTINE ad_wrt_his_pio (ng, model, tile,                       &
 #  ifdef ADJUST_BOUNDARY
      &                           LBij, UBij,                            &
 #  endif
@@ -1301,7 +1303,7 @@
 !
 !  Imported variable declarations.
 !
-      integer, intent(in) :: ng, tile
+      integer, intent(in) :: ng, model, tile
 #  ifdef ADJUST_BOUNDARY
       integer, intent(in) :: LBij, UBij
 #  endif
@@ -2085,6 +2087,7 @@
         END IF
       END IF
 #   endif
+#   if defined JEDI || defined UV_DESTAGGERED
 !
 !  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid
 !
@@ -2100,9 +2103,9 @@
      &                     ADM(ng)%Rindex,                              &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#   ifdef MASKING
+#    ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#   endif
+#    endif
      &                     OCEAN(ng) % ad_ua)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -2127,9 +2130,9 @@
      &                     ADM(ng)%Rindex,                              &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#   ifdef MASKING
+#    ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#   endif
+#    endif
      &                     OCEAN(ng) % ad_va)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -2140,6 +2143,7 @@
           RETURN
         END IF
       END IF
+#   endif
 !
 !  Write out S-coordinate omega vertical velocity (m/s).
 !

--- a/ROMS/Adjoint/ad_wrt_his.F
+++ b/ROMS/Adjoint/ad_wrt_his.F
@@ -842,7 +842,6 @@
         END IF
       END IF
 #  endif
-#  ifdef UV_DESTAGGERED
 !
 !  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid.
 !
@@ -853,9 +852,9 @@
      &                     ADM(ng)%Vid(idu3dE),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#   ifdef MASKING
+#  ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#   endif
+#  endif
      &                     OCEAN(ng) % ad_ua)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -874,9 +873,9 @@
      &                     ADM(ng)%Vid(idv3dN),                         &
      &                     ADM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#   ifdef MASKING
+#  ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#   endif
+#  endif
      &                     OCEAN(ng) % ad_va)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -887,7 +886,6 @@
           RETURN
         END IF
       END IF
-#  endif
 !
 !  Write out S-coordinate omega vertical velocity (m/s).
 !
@@ -2087,7 +2085,6 @@
         END IF
       END IF
 #   endif
-#   ifdef UV_DESTAGGERED
 !
 !  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid
 !
@@ -2103,9 +2100,9 @@
      &                     ADM(ng)%Rindex,                              &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#    ifdef MASKING
+#   ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#    endif
+#   endif
      &                     OCEAN(ng) % ad_ua)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -2130,9 +2127,9 @@
      &                     ADM(ng)%Rindex,                              &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#    ifdef MASKING
+#   ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#    endif
+#   endif
      &                     OCEAN(ng) % ad_va)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -2143,7 +2140,6 @@
           RETURN
         END IF
       END IF
-#   endif
 !
 !  Write out S-coordinate omega vertical velocity (m/s).
 !

--- a/ROMS/Include/cppdefs.h
+++ b/ROMS/Include/cppdefs.h
@@ -629,6 +629,7 @@
 ** ICE_MODEL               to activate sea-ice model                         **
 ** ICE_THERMO              if thermodynamic component                        **
 ** ICE_MK                  if Mellor-Kantha thermodynamics (only choice)     **
+** ICE_ALBEDO              if computing surface albedo over water/snow/ice   **
 ** ICE_ALB_EC92            if albedo computation from Ebert and Curry        **
 ** ICE_MOMENTUM            if momentum component                             **
 ** ICE_MOM_BULK            if alternate ice-water stress computation         **

--- a/ROMS/Tangent/tl_def_his.F
+++ b/ROMS/Tangent/tl_def_his.F
@@ -1077,6 +1077,7 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 #  endif
+#  if defined JEDI || defined UV_DESTAGGERED
 !
 !  Define 3D Eastward momentum at RHO-points, A-grid.
 !
@@ -1086,9 +1087,9 @@
           Vinfo( 3)=Vname(3,idu3dE)
           Vinfo(14)=Vname(4,idu3dE)
           Vinfo(16)=Vname(1,idtime)
-#  if defined WRITE_WATER && defined MASKING
+#   if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#  endif
+#   endif
           Vinfo(21)=Vname(6,idu3dE)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idu3dE,ng),r8)
@@ -1105,9 +1106,9 @@
           Vinfo( 3)=Vname(3,idv3dN)
           Vinfo(14)=Vname(4,idv3dN)
           Vinfo(16)=Vname(1,idtime)
-#  if defined WRITE_WATER && defined MASKING
+#   if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#  endif
+#   endif
           Vinfo(21)=Vname(6,idv3dN)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idv3dN,ng),r8)
@@ -1115,6 +1116,7 @@
      &                   NF_FOUT, nvd4, t3dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
+#  endif
 !
 !  Define tracer type variables.
 !
@@ -1480,12 +1482,14 @@
             got_var(idSbry(isVvel))=.TRUE.
             TLM(ng)%Vid(idSbry(isVvel))=var_id(i)
 #  endif
+#  if defined JEDI || defined UV_DESTAGGERED
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idu3dE))) THEN
             got_var(idu3dE)=.TRUE.
             TLM(ng)%Vid(idu3dE)=var_id(i)
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idv3dN))) THEN
             got_var(idv3dN)=.TRUE.
             TLM(ng)%Vid(idv3dN)=var_id(i)
+#  endif
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idDano))) THEN
             got_var(idDano)=.TRUE.
             TLM(ng)%Vid(idDano)=var_id(i)
@@ -1718,6 +1722,7 @@
           RETURN
         END IF
 #  endif
+#  if defined JEDI || defined UV_DESTAGGERED
         IF (.not.got_var(idu3dE).and.Hout(idu3dE,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idu3dE)),          &
      &                                  TRIM(ncname)
@@ -1730,6 +1735,7 @@
           exit_flag=3
           RETURN
         END IF
+#  endif
         IF (.not.got_var(idDano).and.Hout(idDano,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idDano)),          &
      &                                  TRIM(ncname)
@@ -1869,14 +1875,14 @@
 # if defined PIO_LIB && defined DISTRIBUTE
 !
 !***********************************************************************
-      SUBROUTINE tl_def_his_pio (ng, ldef)
+      SUBROUTINE tl_def_his_pio (ng, model, ldef)
 !***********************************************************************
 !
       USE mod_pio_netcdf
 !
 !  Imported variable declarations.
 !
-      integer, intent(in) :: ng
+      integer, intent(in) :: ng, model
 
       logical, intent(in) :: ldef
 !
@@ -2992,6 +2998,7 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 #   endif
+#   if defined JEDI || defined UV_DESTAGGERED
 !
 !  Define 3D Eastward momentum at RHO-points, A-grid.
 !
@@ -3001,9 +3008,9 @@
           Vinfo( 3)=Vname(3,idu3dE)
           Vinfo(14)=Vname(4,idu3dE)
           Vinfo(16)=Vname(1,idtime)
-#   if defined WRITE_WATER && defined MASKING
+#    if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#   endif
+#    endif
           Vinfo(21)=Vname(6,idu3dE)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idu3dE,ng),r8)
@@ -3024,9 +3031,9 @@
           Vinfo( 3)=Vname(3,idv3dN)
           Vinfo(14)=Vname(4,idv3dN)
           Vinfo(16)=Vname(1,idtime)
-#   if defined WRITE_WATER && defined MASKING
+#    if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#   endif
+#    endif
           Vinfo(21)=Vname(6,idv3dN)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idv3dN,ng),r8)
@@ -3038,6 +3045,7 @@
      &                   PIO_FOUT, nvd4, t3dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
+#   endif
 !
 !  Define tracer type variables.
 !
@@ -3498,6 +3506,7 @@
             TLM(ng)%pioVar(idSbry(isVvel))%dkind=PIO_FOUT
             TLM(ng)%pioVar(idSbry(isVvel))%gtype=v3dobc
 #   endif
+#   if defined JEDI || defined UV_DESTAGGERED
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idu3dE))) THEN
             got_var(idu3dE)=.TRUE.
             TLM(ng)%pioVar(idu3dE)%vd=var_desc(i)
@@ -3508,6 +3517,7 @@
             TLM(ng)%pioVar(idv3dN)%vd=var_desc(i)
             TLM(ng)%pioVar(idv3dN)%dkind=PIO_FOUT
             TLM(ng)%pioVar(idv3dN)%gtype=r3dvar
+#   endif
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idDano))) THEN
             got_var(idDano)=.TRUE.
             TLM(ng)%pioVar(idDano)%vd=var_desc(i)
@@ -3768,6 +3778,7 @@
           RETURN
         END IF
 #   endif
+#   if defined JEDI || defined UV_DESTAGGERED
         IF (.not.got_var(idu3dE).and.Hout(idu3dE,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idu3dE)),          &
      &                                  TRIM(ncname)
@@ -3780,6 +3791,7 @@
           exit_flag=3
           RETURN
         END IF
+#   endif
         IF (.not.got_var(idDano).and.Hout(idDano,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idDano)),          &
      &                                  TRIM(ncname)

--- a/ROMS/Tangent/tl_def_his.F
+++ b/ROMS/Tangent/tl_def_his.F
@@ -1077,7 +1077,6 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 #  endif
-#  ifdef UV_DESTAGGERED
 !
 !  Define 3D Eastward momentum at RHO-points, A-grid.
 !
@@ -1087,9 +1086,9 @@
           Vinfo( 3)=Vname(3,idu3dE)
           Vinfo(14)=Vname(4,idu3dE)
           Vinfo(16)=Vname(1,idtime)
-#   if defined WRITE_WATER && defined MASKING
+#  if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#   endif
+#  endif
           Vinfo(21)=Vname(6,idu3dE)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idu3dE,ng),r8)
@@ -1106,9 +1105,9 @@
           Vinfo( 3)=Vname(3,idv3dN)
           Vinfo(14)=Vname(4,idv3dN)
           Vinfo(16)=Vname(1,idtime)
-#   if defined WRITE_WATER && defined MASKING
+#  if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#   endif
+#  endif
           Vinfo(21)=Vname(6,idv3dN)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idv3dN,ng),r8)
@@ -1116,7 +1115,6 @@
      &                   NF_FOUT, nvd4, t3dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
-#  endif
 !
 !  Define tracer type variables.
 !
@@ -1482,14 +1480,12 @@
             got_var(idSbry(isVvel))=.TRUE.
             TLM(ng)%Vid(idSbry(isVvel))=var_id(i)
 #  endif
-#  ifdef UV_DESTAGGERED
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idu3dE))) THEN
             got_var(idu3dE)=.TRUE.
             TLM(ng)%Vid(idu3dE)=var_id(i)
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idv3dN))) THEN
             got_var(idv3dN)=.TRUE.
             TLM(ng)%Vid(idv3dN)=var_id(i)
-#  endif
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idDano))) THEN
             got_var(idDano)=.TRUE.
             TLM(ng)%Vid(idDano)=var_id(i)
@@ -1722,7 +1718,6 @@
           RETURN
         END IF
 #  endif
-#  ifdef UV_DESTAGGERED
         IF (.not.got_var(idu3dE).and.Hout(idu3dE,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idu3dE)),          &
      &                                  TRIM(ncname)
@@ -1735,7 +1730,6 @@
           exit_flag=3
           RETURN
         END IF
-#  endif
         IF (.not.got_var(idDano).and.Hout(idDano,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idDano)),          &
      &                                  TRIM(ncname)
@@ -2998,7 +2992,6 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 #   endif
-#   ifdef UV_DESTAGGERED
 !
 !  Define 3D Eastward momentum at RHO-points, A-grid.
 !
@@ -3008,9 +3001,9 @@
           Vinfo( 3)=Vname(3,idu3dE)
           Vinfo(14)=Vname(4,idu3dE)
           Vinfo(16)=Vname(1,idtime)
-#    if defined WRITE_WATER && defined MASKING
+#   if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#    endif
+#   endif
           Vinfo(21)=Vname(6,idu3dE)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idu3dE,ng),r8)
@@ -3031,9 +3024,9 @@
           Vinfo( 3)=Vname(3,idv3dN)
           Vinfo(14)=Vname(4,idv3dN)
           Vinfo(16)=Vname(1,idtime)
-#    if defined WRITE_WATER && defined MASKING
+#   if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
-#    endif
+#   endif
           Vinfo(21)=Vname(6,idv3dN)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(Iinfo(1,idv3dN,ng),r8)
@@ -3045,7 +3038,6 @@
      &                   PIO_FOUT, nvd4, t3dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
-#   endif
 !
 !  Define tracer type variables.
 !
@@ -3506,7 +3498,6 @@
             TLM(ng)%pioVar(idSbry(isVvel))%dkind=PIO_FOUT
             TLM(ng)%pioVar(idSbry(isVvel))%gtype=v3dobc
 #   endif
-#   ifdef UV_DESTAGGERED
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idu3dE))) THEN
             got_var(idu3dE)=.TRUE.
             TLM(ng)%pioVar(idu3dE)%vd=var_desc(i)
@@ -3517,7 +3508,6 @@
             TLM(ng)%pioVar(idv3dN)%vd=var_desc(i)
             TLM(ng)%pioVar(idv3dN)%dkind=PIO_FOUT
             TLM(ng)%pioVar(idv3dN)%gtype=r3dvar
-#   endif
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idDano))) THEN
             got_var(idDano)=.TRUE.
             TLM(ng)%pioVar(idDano)%vd=var_desc(i)
@@ -3778,7 +3768,6 @@
           RETURN
         END IF
 #   endif
-#   ifdef UV_DESTAGGERED
         IF (.not.got_var(idu3dE).and.Hout(idu3dE,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idu3dE)),          &
      &                                  TRIM(ncname)
@@ -3791,7 +3780,6 @@
           exit_flag=3
           RETURN
         END IF
-#   endif
         IF (.not.got_var(idDano).and.Hout(idDano,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idDano)),          &
      &                                  TRIM(ncname)

--- a/ROMS/Tangent/tl_wrt_his.F
+++ b/ROMS/Tangent/tl_wrt_his.F
@@ -896,7 +896,6 @@
         END IF
       END IF
 #  endif
-#  ifdef UV_DESTAGGERED
 !
 !  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid.
 !
@@ -907,9 +906,9 @@
      &                     TLM(ng)%Vid(idu3dE),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#   ifdef MASKING
+#  ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#   endif
+#  endif
      &                     OCEAN(ng) % tl_ua)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -928,9 +927,9 @@
      &                     TLM(ng)%Vid(idv3dN),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#   ifdef MASKING
+#  ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#   endif
+#  endif
      &                     OCEAN(ng) % tl_va)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -941,7 +940,6 @@
           RETURN
         END IF
       END IF
-#  endif
 !
 !  Write out tracer type variables.
 !
@@ -2189,7 +2187,6 @@
         END IF
       END IF
 #  endif
-#  ifdef UV_DESTAGGERED
 !
 !  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid
 !
@@ -2205,9 +2202,9 @@
      &                     TLM(ng)%Rindex,                              &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#   ifdef MASKING
+#  ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#   endif
+#  endif
      &                     OCEAN(ng) % tl_ua)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -2232,9 +2229,9 @@
      &                     TLM(ng)%Rindex,                              &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#   ifdef MASKING
+#  ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#   endif
+#  endif
      &                     OCEAN(ng) % tl_va)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -2245,7 +2242,6 @@
           RETURN
         END IF
       END IF
-#  endif
 !
 !  Write out tracer type variables.
 !

--- a/ROMS/Tangent/tl_wrt_his.F
+++ b/ROMS/Tangent/tl_wrt_his.F
@@ -896,6 +896,7 @@
         END IF
       END IF
 #  endif
+#  if defined JEDI || defined UV_DESTAGGERED
 !
 !  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid.
 !
@@ -906,9 +907,9 @@
      &                     TLM(ng)%Vid(idu3dE),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#  ifdef MASKING
+#   ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#  endif
+#   endif
      &                     OCEAN(ng) % tl_ua)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -927,9 +928,9 @@
      &                     TLM(ng)%Vid(idv3dN),                         &
      &                     TLM(ng)%Rindex, gtype,                       &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#  ifdef MASKING
+#   ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#  endif
+#   endif
      &                     OCEAN(ng) % tl_va)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -940,6 +941,7 @@
           RETURN
         END IF
       END IF
+#  endif
 !
 !  Write out tracer type variables.
 !
@@ -2187,6 +2189,7 @@
         END IF
       END IF
 #  endif
+#  if defined JEDI || defined UV_DESTAGGERED
 !
 !  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid
 !
@@ -2202,9 +2205,9 @@
      &                     TLM(ng)%Rindex,                              &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#  ifdef MASKING
+#   ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#  endif
+#   endif
      &                     OCEAN(ng) % tl_ua)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -2229,9 +2232,9 @@
      &                     TLM(ng)%Rindex,                              &
      &                     ioDesc,                                      &
      &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-#  ifdef MASKING
+#   ifdef MASKING
      &                     GRID(ng) % rmask_full,                       &
-#  endif
+#   endif
      &                     OCEAN(ng) % tl_va)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
@@ -2242,6 +2245,7 @@
           RETURN
         END IF
       END IF
+#  endif
 !
 !  Write out tracer type variables.
 !

--- a/ROMS/Utility/checkdefs.F
+++ b/ROMS/Utility/checkdefs.F
@@ -1340,6 +1340,13 @@
       is=LEN_TRIM(Coptions)+1
       Coptions(is:is+12)=' ICE_ADVECT,'
 # endif
+# ifdef ICE_ALBEDO
+!
+      IF (Master) WRITE (stdout,20) 'ICE_ALB_EC92',                     &
+     &   'Surface albedo computation over seawater, snow, or ice'
+      is=LEN_TRIM(Coptions)+1
+      Coptions(is:is+12)=' ICE_ALBEDO,'
+# endif
 # ifdef ICE_ALB_EC92
 !
       IF (Master) WRITE (stdout,20) 'ICE_ALB_EC92',                     &

--- a/ROMS/Utility/get_grid.F
+++ b/ROMS/Utility/get_grid.F
@@ -3152,7 +3152,7 @@
           CASE ('wtype_grid')
             pioVar%vd=var_desc(i)
             pioVar%gtype=r2dvar
-            IF (KIND(GRID(ng)%Jwtype).eq.8) THEN
+            IF (KIND(MIXING(ng)%Jwtype).eq.8) THEN
               pioVar%dkind=PIO_double
               ioDesc => ioDesc_dp_r2dvar(ng)
             ELSE

--- a/ROMS/Utility/nf_fwrite3d.F
+++ b/ROMS/Utility/nf_fwrite3d.F
@@ -867,7 +867,6 @@
 #  ifdef MASKING
      &                  Fmask = Amask,                                  &
 #  endif
-     &                  Extract_Flag = Extract_Flag,                    &
      &                  debug = .FALSE.)
       IF (OutThread) THEN
         WRITE (stdout,10) TRIM(Vname(1,ifield)), Stats%min, Stats%max,  &

--- a/ROMS/Utility/nf_fwrite4d.F
+++ b/ROMS/Utility/nf_fwrite4d.F
@@ -658,7 +658,9 @@
 # ifdef MASKING
      &                       Amask,                                     &
 # endif
-     &                       Adat, SetFillVal,                          &
+     &                       Adat,                                      &
+     &                       SetFillVal,                                &
+     &                       ExtractField,                              &
      &                       MinValue, MaxValue) RESULT (status)
 !***********************************************************************
 !

--- a/ROMS/Utility/uv_var_change.F
+++ b/ROMS/Utility/uv_var_change.F
@@ -332,7 +332,7 @@
 !  Compute staggered C-grid components.
 !
         DO j=JstrR,JendR
-          DO i=Istr,IstrR
+          DO i=Istr,IendR
             u(i,j,k,nout)=0.5_r8*(Urho(i-1,j)+Urho(i,j))
 # ifdef MASKING
             u(i,j,k,nout)=u(i,j,k,nout)*umask(i,j)
@@ -661,7 +661,7 @@
 !  Compute staggered C-grid components.
 !
         DO j=JstrR,JendR
-          DO i=Istr,IstrR
+          DO i=Istr,IendR
 !>          u(i,j,k,nout)=0.5_r8*(Urho(i-1,j)+Urho(i,j))
 !>
             tl_u(i,j,k,nout)=0.5_r8*(tl_Urho(i-1,j)+tl_Urho(i,j))

--- a/ROMS/Utility/uv_var_change.F
+++ b/ROMS/Utility/uv_var_change.F
@@ -909,7 +909,7 @@
 !>
             adfac=0.5_r8*ad_Urho(i,j)
             ad_u(i  ,j,k,ninp)=ad_u(i  ,j,k,ninp)+adfac
-            ad_u(i+1,j,k,ninp)=AD_u(i+1,j,k,ninp)+adfac
+            ad_u(i+1,j,k,ninp)=ad_u(i+1,j,k,ninp)+adfac
             ad_Urho(i,j)=0.0_r8
           END DO
         END DO

--- a/ROMS/Utility/wrt_station.F
+++ b/ROMS/Utility/wrt_station.F
@@ -1054,7 +1054,7 @@
 !
 !  Imported variable declarations.
 !
-      integer, intent(in) :: ng, tile
+      integer, intent(in) :: ng, model, tile
       integer, intent(in) :: LBi, UBi, LBj, UBj
 !
 !  Local variable declarations.


### PR DESCRIPTION
## Description

- Updated the de-staggering of horizontal currents from Arakawa's  **C**- to  **A**-grid and vice versa.  In **`ROMS-JEDI`**, the de-staggering variable changes are done directly in the **`LinearModel`** interface.  The **u**- and **v**-components are located at the grid cell center in the **A**-grid. 

- Notice that **ROMS** has a left-handed indexing **(i,j)** enumeration:

 | C-grid   |
:---------:
|<img width="200" alt="image" align="center" src="https://github.com/user-attachments/assets/412d2b7b-577d-4ef4-8fca-179ecabad1f2"> |

- This PR allows writing the **A**-grid currents from **`ROMS-JEDI`** into the tangent linear and adjoint history output NetCDF files.
-  It also corrects typos in **PIO** routines.
-  It adds documentation for **ICE_ALBEDO**.
