### PR TITLE
Corrections to GLS and MY25 Vertical closures

### DIFF
--- a/ROMS/Nonlinear/gls_corstep.F
+++ b/ROMS/Nonlinear/gls_corstep.F
@@ -628,15 +628,16 @@
 !
         DO j=Jstr,Jend
           DO i=Istr,Iend
+            cff1=0.5_r8*(Hz(i,j,k)+Hz(i,j,k+1))         ! RRH, Jan 2025
             cff=dt(ng)*pm(i,j)*pn(i,j)
             tke(i,j,k,nnew)=tke(i,j,k,nnew)-                            &
      &                      cff*(FXK(i+1,j)-FXK(i,j)+                   &
      &                           FEK(i,j+1)-FEK(i,j))
-            tke(i,j,k,nnew)=MAX(tke(i,j,k,nnew),gls_Kmin(ng))
+            tke(i,j,k,nnew)=MAX(tke(i,j,k,nnew),cff1*gls_Kmin(ng))
             gls(i,j,k,nnew)=gls(i,j,k,nnew)-                            &
      &                      cff*(FXP(i+1,j)-FXP(i,j)+                   &
      &                           FEP(i,j+1)-FEP(i,j))
-            gls(i,j,k,nnew)=MAX(gls(i,j,k,nnew),gls_Pmin(ng))
+            gls(i,j,k,nnew)=MAX(gls(i,j,k,nnew),cff1*gls_Pmin(ng))
           END DO
         END DO
       END DO
@@ -705,13 +706,14 @@
 !
         DO k=1,N(ng)-1
           DO i=Istr,Iend
+            cff1=0.5_r8*(Hz(i,j,k)+Hz(i,j,k+1))         ! RRH, Jan 2025
             cff=dt(ng)*pm(i,j)*pn(i,j)
             tke(i,j,k,nnew)=tke(i,j,k,nnew)-                            &
      &                      cff*(FCK(i,k+1)-FCK(i,k))
-            tke(i,j,k,nnew)=MAX(tke(i,j,k,nnew),gls_Kmin(ng))
+            tke(i,j,k,nnew)=MAX(tke(i,j,k,nnew),cff1*gls_Kmin(ng))
             gls(i,j,k,nnew)=gls(i,j,k,nnew)-                            &
      &                      cff*(FCP(i,k+1)-FCP(i,k))
-            gls(i,j,k,nnew)=MAX(gls(i,j,k,nnew),gls_Pmin(ng))
+            gls(i,j,k,nnew)=MAX(gls(i,j,k,nnew),cff1*gls_Pmin(ng))
           END DO
         END DO
 !
@@ -1009,6 +1011,14 @@
               Ls_lmt=Ls_unlmt
             END IF
 !
+! New constraint controls instabilities in gls by limiting length scale,
+! L <= kappa*Depth. After harmonizing default advective schemes, this
+! limit is primarily active for inflows at the boundary or rivers where
+! upstream tke and gls are not well defined. (RRH, Jan 2025)
+!
+            cff1=0.4_r8*(z_w(i,j,N(ng))-z_w(i,j,0))
+            Ls_lmt=MIN(Ls_lmt,cff1)
+!
 ! Recompute gls based on limited length scale
 !
             gls(i,j,k,nnew)=MAX(gls_cmu0(ng)**gls_p(ng)*                &
@@ -1020,7 +1030,12 @@
 !
             Gh=MIN(gls_Gh0,-buoy2(i,j,k)*Ls_lmt*Ls_lmt/                 &
      &                    (2.0_r8*tke(i,j,k,nnew)))
-            Gh=MIN(Gh,Gh-(Gh-gls_Ghcri)**2/                             &
+
+!  Update to remove sharp discontinuity per Harcourt post 
+!  "Equation error in GLS model coded into gls_corstep.F" to myroms.org 
+!  board 13 Dec 2018. (RRH, Jan 2025)
+!
+            Gh=MIN(Gh,Gh-MAX(0.0_r8,Gh-gls_Ghcri)**2/                   &
      &                    (Gh+gls_Gh0-2.0_r8*gls_Ghcri))
             Gh=MAX(Gh,gls_Ghmin)
 # if defined CANUTO_A || defined CANUTO_B

--- a/ROMS/Nonlinear/gls_corstep.F
+++ b/ROMS/Nonlinear/gls_corstep.F
@@ -43,6 +43,10 @@
       USE mod_mixing
       USE mod_ocean
       USE mod_stepping
+# if defined VEGETATION && defined VEG_TURB
+      USE mod_vegarr
+      USE vegetation_turb_mod, ONLY : vegetation_turb_cal
+# endif
 !
 !  Imported variable declarations.
 !
@@ -54,6 +58,15 @@
      &  __FILE__
 !
 # include "tile.h"
+!
+# if defined VEGETATION && defined VEG_TURB
+! 
+!  Add the effect of vegetation on the turbulence model.
+!
+      CALL vegetation_turb_cal (ng, tile)
+# endif
+!
+!  GLS corrector step.
 !
 # ifdef PROFILE
       CALL wclock_on (ng, iNLM, 19, __LINE__, MyFile)
@@ -79,6 +92,10 @@
      &                       OCEAN(ng) % W,                             &
 # ifdef WEC_VF
      &                       OCEAN(ng) % W_stokes,                      &
+# endif
+# if defined VEGETATION && defined VEG_TURB 
+     &                       VEG(ng) % tke_veg,                         &
+     &                       VEG(ng) % gls_veg,                         &
 # endif
      &                       FORCES(ng) % bustr,                        &
      &                       FORCES(ng) % bvstr,                        &
@@ -119,6 +136,9 @@
      &                             u, v, W,                             &
 # ifdef WEC_VF
      &                             W_stokes,                            &
+# endif
+# if defined VEGETATION && defined VEG_TURB
+     &                             tke_veg, gls_veg,                    &
 # endif
      &                             bustr, bvstr, sustr, svstr,          &
 # ifdef ZOS_HSIG
@@ -167,6 +187,10 @@
 # ifdef WEC_VF
       real(r8), intent(in) :: W_stokes(LBi:,LBj:,0:)
 # endif
+# if defined VEGETATION && defined VEG_TURB
+      real(r8), intent(in) :: tke_veg(LBi:,LBj:,0:)
+      real(r8), intent(in) :: gls_veg(LBi:,LBj:,0:)
+# endif
       real(r8), intent(in) :: bustr(LBi:,LBj:)
       real(r8), intent(in) :: bvstr(LBi:,LBj:)
       real(r8), intent(in) :: sustr(LBi:,LBj:)
@@ -206,6 +230,10 @@
 # ifdef WEC_VF
       real(r8), intent(in) :: W_stokes(LBi:UBi,LBj:UBj,0:N(ng))
 # endif
+# if defined VEGETATION && defined VEG_TURB
+      real(r8), intent(in) :: tke_veg(LBi:UBi,LBj:UBj,0:N(ng))
+      real(r8), intent(in) :: gls_veg(LBi:UBi,LBj:UBj,0:N(ng))
+# endif
       real(r8), intent(in) :: bustr(LBi:UBi,LBj:UBj)
       real(r8), intent(in) :: bvstr(LBi:UBi,LBj:UBj)
       real(r8), intent(in) :: sustr(LBi:UBi,LBj:UBj)
@@ -240,6 +268,9 @@
       real(r8) :: Gh, Gm, Kprod, Ls_unlmt, Ls_lmt, Pprod, Sh, Sm
       real(r8) :: cff, cff1, cff2, cff3
       real(r8) :: cmu_fac1, cmu_fac2, cmu_fac3, cmu_fac4
+# if defined KANTHA_CLAYSON_KCQE
+      real(r8) :: cmu, cmup, alphan, alpham
+# endif
       real(r8) :: gls_c3, gls_exp1, gls_fac1, gls_fac2, gls_fac3
       real(r8) :: gls_fac4, gls_fac5, gls_fac6, ql, sqrt2, strat2
       real(r8) :: tke_exp1, tke_exp2, tke_exp3, tke_exp4, wall_fac
@@ -779,6 +810,14 @@
             gls(i,j,k,nnew)=gls(i,j,k,nnew)+                            &
      &                      dt(ng)*cff*Pprod*gls(i,j,k,nstp)/           &
      &                      MAX(tke(i,j,k,nstp),gls_Kmin(ng))
+
+# if defined VEGETATION && defined VEG_TURB
+!
+!  Add the effect of vegetation on tke and gls 
+!          
+            tke(i,j,k,nnew)=tke(i,j,k,nnew)+dt(ng)*tke_veg(i,j,k)
+            gls(i,j,k,nnew)=gls(i,j,k,nnew)+dt(ng)*gls_veg(i,j,k)
+# endif 
 !
 !  Compute dissipation of turbulent energy (m3/s3).
 !
@@ -914,10 +953,12 @@
      &                           FCK(i,k+1)*tke(i,j,k+1,nnew))
           END DO
           tke(i,j,1,nnew)=tke(i,j,1,nnew)-cff*tke_fluxb(i)
+          tke(i,j,1,nnew)=MAX(tke(i,j,1,nnew),gls_Kmin(ng))
         END DO
         DO k=2,N(ng)-1
           DO i=Istr,Iend
             tke(i,j,k,nnew)=tke(i,j,k,nnew)-CF(i,k)*tke(i,j,k-1,nnew)
+            tke(i,j,k,nnew)=MAX(tke(i,j,k,nnew),gls_Kmin(ng))
           END DO
         END DO
 !
@@ -967,12 +1008,12 @@
      &                           FCP(i,k+1)*gls(i,j,k+1,nnew))
           END DO
           gls(i,j,1,nnew)=gls(i,j,1,nnew)-cff*gls_fluxb(i)
-!!        gls(i,j,1,nnew)=MAX(gls(i,j,1,nnew), gls_Pmin(ng))
+          gls(i,j,1,nnew)=MAX(gls(i,j,1,nnew),gls_Pmin(ng))
         END DO
         DO k=2,N(ng)-1
           DO i=Istr,Iend
             gls(i,j,k,nnew)=gls(i,j,k,nnew)-CF(i,k)*gls(i,j,k-1,nnew)
-!!          gls(i,j,k,nnew)=MAX(gls(i,j,k,nnew), gls_Pmin(ng))
+            gls(i,j,k,nnew)=MAX(gls(i,j,k,nnew),gls_Pmin(ng))
           END DO
         END DO
 !
@@ -985,8 +1026,8 @@
 !
 !  Compute turbulent length scale (m).
 !
-            tke(i,j,k,nnew)=MAX(tke(i,j,k,nnew),gls_Kmin(ng))
-            gls(i,j,k,nnew)=MAX(gls(i,j,k,nnew),gls_Pmin(ng))
+!           tke(i,j,k,nnew)=MAX(tke(i,j,k,nnew),gls_Kmin(ng))
+!           gls(i,j,k,nnew)=MAX(gls(i,j,k,nnew),gls_Pmin(ng))
             IF (gls_n(ng).ge.0.0_r8) THEN
               gls(i,j,k,nnew)=MIN(gls(i,j,k,nnew),gls_fac5*             &
      &                            tke(i,j,k,nnew)**(tke_exp4)*          &
@@ -1062,6 +1103,16 @@
 !
             Sm=Sm*sqrt2/gls_cmu0(ng)**3
             Sh=Sh*sqrt2/gls_cmu0(ng)**3
+# elif defined KANTHA_CLAYSON_KCQE
+            cff=MAX((0.5477_r8**6)*tke(i,j,k,nnew),1.0E-4_r8)
+            alpham=Ls_lmt*Ls_lmt*shear2(i,j,k)/cff
+            alphan=-2.0_r8*Gh/(gls_cmu0(ng)**6)
+            cff2=(1.0_r8+0.4679_r8*alphan+0.07372_r8*alpham+             &
+     &           0.01761_r8*alphan*alpham+0.03371_r8*alphan*alphan)
+            cmu=(0.1682_r8+0.03269_r8*alphan)/cff2
+            cmup=(0.1783_r8+0.01586_r8*alphan+0.003173_r8*alpham)/cff2
+            Sm=cmu/(sqrt(2.0_r8)*gls_cmu0(ng)**3)
+            Sh=cmup/(sqrt(2.0_r8)*gls_cmu0(ng)**3)
 # elif defined KANTHA_CLAYSON
             cff=1.0_r8-my_Sh2*Gh
             Sh=my_Sh1/cff

--- a/ROMS/Nonlinear/gls_prestep.F
+++ b/ROMS/Nonlinear/gls_prestep.F
@@ -145,6 +145,7 @@
       integer :: i, indx, j, k
 
       real(r8), parameter :: Gamma = 1.0_r8/6.0_r8
+      real(r8), parameter :: Gadv = 1.0_r8/3.0_r8
 
       real(r8) :: cff, cff1, cff2, cff3, cff4
 
@@ -160,6 +161,8 @@
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: FX
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: FXL
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: XF
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: curv
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: curvL
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: grad
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: gradL
 
@@ -179,6 +182,9 @@
 !
 ! Either centered fourth-order accurate or standard second order
 ! accurate versions are supported.
+!
+! Adding support U3, because it is the default in gls_corstep.
+! (RRH, Jan 2025)
 !
 ! At the same time prepare for corrector step for tke,gls: set tke,
 ! gls(:,:,:,nnew) to  tke,gls(:,:,:,nstp) multiplied by the
@@ -213,7 +219,8 @@
         END DO
 # else
 !
-!  Fourth-order, centered differences advection.
+!  Fourth-order, centered differences advections OR Third-order,
+!  upstream bias advection with velocity dependent hyperdiffusion.
 !
         DO j=Jstr,Jend
           DO i=Istrm1,Iendp2
@@ -243,6 +250,10 @@
             END DO
           END IF
         END IF
+#  ifdef K_C4ADVECTION
+!
+!  Fourth-order, centered differences advection.
+!
         cff=1.0_r8/6.0_r8
         DO j=Jstr,Jend
           DO i=Istr,Iend+1
@@ -255,7 +266,34 @@
      &                       cff*(gradL(i+1,j)-gradL(i-1,j)))
           END DO
         END DO
+#  else
 !
+!  Third-order, upstream bias advection with velocity dependent
+!  hyperdiffusion.
+!
+        DO j=Jstr,Jend
+          DO i=Istr-1,Iend+1
+            curv(i,j)=grad(i+1,j)-grad(i,j)
+            curvL(i,j)=gradL(i+1,j)-gradL(i,j)
+          END DO
+        END DO
+        DO j=Jstr,Jend
+          DO i=Istr,Iend+1
+            XF(i,j)=0.5_r8*(Huon(i,j,k)+Huon(i,j,k+1))
+            IF (XF(i,j).gt.0.0_r8) THEN
+              cff1=curv(i-1,j)
+              cff2=curvL(i-1,j)
+            ELSE
+              cff1=curv(i,j)
+              cff2=curvL(i,j)
+            END IF
+            FX(i,j)=XF(i,j)*0.5_r8*(tke(i-1,j,k,nstp)+tke(i,j,k,nstp)-  &
+     &                              Gadv*cff1)
+            FXL(i,j)=XF(i,j)*0.5_r8*(gls(i-1,j,k,nstp)+gls(i,j,k,nstp)- &
+     &                               Gadv*cff2)
+          END DO
+        END DO
+#  endif
         DO j=Jstrm1,Jendp2
           DO i=Istr,Iend
             grad (i,j)=(tke(i,j,k,nstp)-tke(i,j-1,k,nstp))
@@ -284,6 +322,7 @@
             END DO
           END IF
         END IF
+#  ifdef K_C4ADVECTION
         cff=1.0_r8/6.0_r8
         DO j=Jstr,Jend+1
           DO i=Istr,Iend
@@ -296,6 +335,30 @@
      &                       cff*(gradL(i,j+1)-gradL(i,j-1)))
           END DO
         END DO
+#  else
+        DO j=Jstr-1,Jend+1
+          DO i=Istr,Iend
+            curv(i,j)=grad(i,j+1)-grad(i,j)
+            curvL(i,j)=gradL(i,j+1)-gradL(i,j)
+          END DO
+        END DO
+        DO j=Jstr,Jend+1
+          DO i=Istr,Iend
+            EF(i,j)=0.5_r8*(Hvom(i,j,k)+Hvom(i,j,k+1))
+            IF (EF(i,j).gt.0.0_r8) THEN
+              cff1=curv(i,j-1)
+              cff2=curvL(i,j-1)
+            ELSE
+              cff1=curv(i,j)
+              cff2=curvL(i,j)
+            END IF
+            FE(i,j)=EF(i,j)*0.5_r8*(tke(i,j-1,k,nstp)+tke(i,j,k,nstp)-  &
+     &                              Gadv*cff1)
+            FEL(i,j)=EF(i,j)*0.5_r8*(gls(i,j-1,k,nstp)+gls(i,j,k,nstp)- &
+     &                               Gadv*cff2)
+          END DO
+        END DO
+#  endif
 # endif
 !
 !  Time-step horizontal advection.

--- a/ROMS/Nonlinear/gls_prestep.F
+++ b/ROMS/Nonlinear/gls_prestep.F
@@ -323,6 +323,9 @@
           END IF
         END IF
 #  ifdef K_C4ADVECTION
+!
+!  Fourth-order, centered differences advection.
+!
         cff=1.0_r8/6.0_r8
         DO j=Jstr,Jend+1
           DO i=Istr,Iend
@@ -336,6 +339,10 @@
           END DO
         END DO
 #  else
+!
+!  Third-order, upstream bias advection with velocity dependent
+!  hyperdiffusion.
+!
         DO j=Jstr-1,Jend+1
           DO i=Istr,Iend
             curv(i,j)=grad(i,j+1)-grad(i,j)

--- a/ROMS/Nonlinear/my25_prestep.F
+++ b/ROMS/Nonlinear/my25_prestep.F
@@ -136,6 +136,7 @@
       integer :: i, indx, j, k
 
       real(r8), parameter :: Gamma = 1.0_r8/6.0_r8
+      real(r8), parameter :: Gadv = 1.0_r8/3.0_r8
 
       real(r8) :: cff, cff1, cff2, cff3, cff4
 
@@ -151,6 +152,8 @@
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: FX
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: FXL
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: XF
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: curv
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: curvL
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: grad
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: gradL
 
@@ -170,6 +173,9 @@
 !
 ! Either centered fourth-order accurate or standard second order
 ! accurate versions are supported.
+!
+! Adding support U3, because it is the default in gls_corstep.
+! (RRH, Jan 2025)
 !
 ! At the same time prepare for corrector step for tke,gls: set tke,
 ! gls(:,:,:,nnew) to  tke, gls(:,:,:,nstp) multiplied by the
@@ -204,7 +210,8 @@
         END DO
 # else
 !
-!  Fourth-order, centered differences advection.
+!  Fourth-order, centered differences advections OR Third-order,
+!  upstream bias advection with velocity dependent hyperdiffusion.
 !
         DO j=Jstr,Jend
           DO i=Istrm1,Iendp2
@@ -234,6 +241,10 @@
             END DO
           END IF
         END IF
+#  ifdef K_C4ADVECTION
+!
+!  Fourth-order, centered differences advection.
+!
         cff=1.0_r8/6.0_r8
         DO j=Jstr,Jend
           DO i=Istr,Iend+1
@@ -246,6 +257,34 @@
      &                       cff*(gradL(i+1,j)-gradL(i-1,j)))
           END DO
         END DO
+#  else
+!
+!  Third-order, upstream bias advection with velocity dependent
+!  hyperdiffusion.
+!
+        DO j=Jstr,Jend
+          DO i=Istr-1,Iend+1
+            curv(i,j)=grad(i+1,j)-grad(i,j)
+            curvL(i,j)=gradL(i+1,j)-gradL(i,j)
+          END DO
+        END DO
+        DO j=Jstr,Jend
+          DO i=Istr,Iend+1
+            XF(i,j)=0.5_r8*(Huon(i,j,k)+Huon(i,j,k+1))
+            IF (XF(i,j).gt.0.0_r8) THEN
+              cff1=curv(i-1,j)
+              cff2=curvL(i-1,j)
+            ELSE
+              cff1=curv(i,j)
+              cff2=curvL(i,j)
+            END IF
+            FX(i,j)=XF(i,j)*0.5_r8*(tke(i-1,j,k,nstp)+tke(i,j,k,nstp)-  &
+     &                              Gadv*cff1)
+            FXL(i,j)=XF(i,j)*0.5_r8*(gls(i-1,j,k,nstp)+gls(i,j,k,nstp)- &
+     &                               Gadv*cff2)
+          END DO
+        END DO
+#  endif
 !
         DO j=Jstrm1,Jendp2
           DO i=Istr,Iend
@@ -275,6 +314,7 @@
             END DO
           END IF
         END IF
+#  ifdef K_C4ADVECTION
         cff=1.0_r8/6.0_r8
         DO j=Jstr,Jend+1
           DO i=Istr,Iend
@@ -287,6 +327,30 @@
      &                       cff*(gradL(i,j+1)-gradL(i,j-1)))
           END DO
         END DO
+#  else
+        DO j=Jstr-1,Jend+1
+          DO i=Istr,Iend
+            curv(i,j)=grad(i,j+1)-grad(i,j)
+            curvL(i,j)=gradL(i,j+1)-gradL(i,j)
+          END DO
+        END DO
+        DO j=Jstr,Jend+1
+          DO i=Istr,Iend
+            EF(i,j)=0.5_r8*(Hvom(i,j,k)+Hvom(i,j,k+1))
+            IF (EF(i,j).gt.0.0_r8) THEN
+              cff1=curv(i,j-1)
+              cff2=curvL(i,j-1)
+            ELSE
+              cff1=curv(i,j)
+              cff2=curvL(i,j)
+            END IF
+            FE(i,j)=EF(i,j)*0.5_r8*(tke(i,j-1,k,nstp)+tke(i,j,k,nstp)-  &
+     &                              Gadv*cff1)
+            FEL(i,j)=EF(i,j)*0.5_r8*(gls(i,j-1,k,nstp)+gls(i,j,k,nstp)- &
+     &                               Gadv*cff2)
+          END DO
+        END DO
+#  endif
 # endif
 !
 !  Time-step horizontal advection.

--- a/ROMS/Nonlinear/t3dmix2_geo.h
+++ b/ROMS/Nonlinear/t3dmix2_geo.h
@@ -58,6 +58,7 @@
      &                       GRID(ng) % vmask,                          &
 #endif
 #ifdef WET_DRY
+     &                       GRID(ng) % rmask_wet,                      &
      &                       GRID(ng) % umask_wet,                      &
      &                       GRID(ng) % vmask_wet,                      &
 #endif
@@ -95,7 +96,7 @@
      &                             umask, vmask,                        &
 #endif
 #ifdef WET_DRY
-     &                             umask_wet, vmask_wet,                &
+     &                             rmask_wet, umask_wet, vmask_wet,     &
 #endif
      &                             om_v, on_u, pm, pn,                  &
      &                             Hz, z_r,                             &
@@ -129,6 +130,7 @@
       real(r8), intent(in) :: vmask(LBi:,LBj:)
 # endif
 # ifdef WET_DRY
+      real(r8), intent(in) :: rmask_wet(LBi:,LBj:)
       real(r8), intent(in) :: umask_wet(LBi:,LBj:)
       real(r8), intent(in) :: vmask_wet(LBi:,LBj:)
 # endif
@@ -156,6 +158,7 @@
       real(r8), intent(in) :: vmask(LBi:UBi,LBj:UBj)
 # endif
 # ifdef WET_DRY
+      real(r8), intent(in) :: rmask_wet(LBi:UBi,LBj:UBj)
       real(r8), intent(in) :: umask_wet(LBi:UBi,LBj:UBj)
       real(r8), intent(in) :: vmask_wet(LBi:UBi,LBj:UBj)
 # endif
@@ -298,6 +301,9 @@
             DO j=Jstr-1,Jend+1
               DO i=Istr-1,Iend+1
                 cff=1.0_r8/(z_r(i,j,k+1)-z_r(i,j,k))
+#ifdef WET_DRY
+                cff=cff*rmask_wet(i,j)
+#endif
 #if defined TS_MIX_STABILITY
                 dTdz(i,j,k2)=cff*(0.75_r8*(t(i,j,k+1,nrhs,itrc)-        &
      &                                     t(i,j,k  ,nrhs,itrc))+       &

--- a/ROMS/Nonlinear/t3dmix2_iso.h
+++ b/ROMS/Nonlinear/t3dmix2_iso.h
@@ -58,6 +58,7 @@
      &                       GRID(ng) % vmask,                          &
 #endif
 #ifdef WET_DRY
+     &                       GRID(ng) % rmask_wet,                      &
      &                       GRID(ng) % umask_wet,                      &
      &                       GRID(ng) % vmask_wet,                      &
 #endif
@@ -96,7 +97,7 @@
      &                             umask, vmask,                        &
 #endif
 #ifdef WET_DRY
-     &                             umask_wet, vmask_wet,                &
+     &                             rmask_wet, umask_wet, vmask_wet,     &
 #endif
      &                             om_v, on_u, pm, pn,                  &
      &                             Hz, z_r,                             &
@@ -131,6 +132,7 @@
       real(r8), intent(in) :: vmask(LBi:,LBj:)
 # endif
 # ifdef WET_DRY
+      real(r8), intent(in) :: rmask_wet(LBi:,LBj:)
       real(r8), intent(in) :: umask_wet(LBi:,LBj:)
       real(r8), intent(in) :: vmask_wet(LBi:,LBj:)
 # endif
@@ -159,6 +161,7 @@
       real(r8), intent(in) :: vmask(LBi:UBi,LBj:UBj)
 # endif
 # ifdef WET_DRY
+      real(r8), intent(in) :: rmask_wet(LBi:UBi,LBj:UBj)
       real(r8), intent(in) :: umask_wet(LBi:UBi,LBj:UBj)
       real(r8), intent(in) :: vmask_wet(LBi:UBi,LBj:UBj)
 # endif
@@ -317,6 +320,9 @@
 #else
                 cff1=MAX(pden(i,j,k)-pden(i,j,k+1),eps)
                 cff=-1.0_r8/cff1
+#endif
+#ifdef WET_DRY
+                cff=cff*rmask_wet(i,j)
 #endif
 #if defined TS_MIX_STABILITY
                 dTdr(i,j,k2)=cff*(0.75_r8*(t(i,j,k+1,nrhs,itrc)-        &

--- a/ROMS/Nonlinear/t3dmix4_geo.h
+++ b/ROMS/Nonlinear/t3dmix4_geo.h
@@ -58,6 +58,7 @@
      &                       GRID(ng) % vmask,                          &
 #endif
 #ifdef WET_DRY
+     &                       GRID(ng) % rmask_wet,                      &
      &                       GRID(ng) % umask_wet,                      &
      &                       GRID(ng) % vmask_wet,                      &
 #endif
@@ -100,7 +101,7 @@
      &                             umask, vmask,                        &
 #endif
 #ifdef WET_DRY
-     &                             umask_wet, vmask_wet,                &
+     &                             rmask_wet, umask_wet, vmask_wet,     &
 #endif
      &                             om_v, on_u, pm, pn,                  &
      &                             Hz, z_r,                             &
@@ -139,6 +140,7 @@
       real(r8), intent(in) :: vmask(LBi:,LBj:)
 # endif
 # ifdef WET_DRY
+      real(r8), intent(in) :: rmask_wet(LBi:,LBj:)
       real(r8), intent(in) :: umask_wet(LBi:,LBj:)
       real(r8), intent(in) :: vmask_wet(LBi:,LBj:)
 # endif
@@ -171,6 +173,7 @@
       real(r8), intent(in) :: vmask(LBi:UBi,LBj:UBj)
 # endif
 # ifdef WET_DRY
+      real(r8), intent(in) :: rmask_wet(LBi:UBi,LBj:UBj)
       real(r8), intent(in) :: umask_wet(LBi:UBi,LBj:UBj)
       real(r8), intent(in) :: vmask_wet(LBi:UBi,LBj:UBj)
 # endif
@@ -342,6 +345,9 @@
               DO i=Imin-1,Imax+1
                 cff=1.0_r8/(z_r(i,j,k+1)-                               &
      &                      z_r(i,j,k  ))
+#ifdef WET_DRY
+                cff=cff*rmask_wet(i,j)
+#endif
 #if defined TS_MIX_STABILITY
                 dTdz(i,j,k2)=cff*(0.75_r8*(t(i,j,k+1,nrhs,itrc)-        &
      &                                     t(i,j,k  ,nrhs,itrc))+       &

--- a/ROMS/Nonlinear/t3dmix4_iso.h
+++ b/ROMS/Nonlinear/t3dmix4_iso.h
@@ -58,6 +58,7 @@
      &                       GRID(ng) % vmask,                          &
 #endif
 #ifdef WET_DRY
+     &                       GRID(ng) % rmask_wet,                      &
      &                       GRID(ng) % umask_wet,                      &
      &                       GRID(ng) % vmask_wet,                      &
 #endif
@@ -101,7 +102,7 @@
      &                             umask, vmask,                        &
 #endif
 #ifdef WET_DRY
-     &                             umask_wet, vmask_wet,                &
+     &                             rmask_wet, umask_wet, vmask_wet,     &
 #endif
      &                             om_v, on_u, pm, pn,                  &
      &                             Hz, z_r,                             &
@@ -141,6 +142,7 @@
       real(r8), intent(in) :: vmask(LBi:,LBj:)
 # endif
 # ifdef WET_DRY
+      real(r8), intent(in) :: rmask_wet(LBi:,LBj:)
       real(r8), intent(in) :: umask_wet(LBi:,LBj:)
       real(r8), intent(in) :: vmask_wet(LBi:,LBj:)
 # endif
@@ -174,6 +176,7 @@
       real(r8), intent(in) :: vmask(LBi:UBi,LBj:UBj)
 # endif
 # ifdef WET_DRY
+      real(r8), intent(in) :: rmask_wet(LBi:UBi,LBj:UBj)
       real(r8), intent(in) :: umask_wet(LBi:UBi,LBj:UBj)
       real(r8), intent(in) :: vmask_wet(LBi:UBi,LBj:UBj)
 # endif
@@ -365,6 +368,9 @@
 #else
                 cff1=MAX(pden(i,j,k)-pden(i,j,k+1),eps)
                 cff=-1.0_r8/cff1
+#endif
+#ifdef WET_DRY
+                cff=cff*rmask_wet(i,j)
 #endif
 #if defined TS_MIX_STABILITY
                 dTdr(i,j,k2)=cff*(0.75_r8*(t(i,j,k+1,nrhs,itrc)-        &
@@ -683,6 +689,9 @@
 #else
                 cff1=MAX(pden(i,j,k)-pden(i,j,k+1),eps)
                 cff=-1.0_r8/cff1
+#endif
+#ifdef WET_DRY
+                cff=cff*rmask_wet(i,j)
 #endif
                 dTdr(i,j,k2)=cff*(LapT(i,j,k+1)-                        &
      &                            LapT(i,j,k  ))


### PR DESCRIPTION
# Description

We have revised the modules for the predictor and corrector steps of the **GLS** and **MY25** second-moment closure schemes. These revisions address a long-standing inconsistency in the default CPP selection of predictor and corrector advection schemes, an issue that dates back at least two decades to version 2.0. 

## Summary of the Issue

Currently, under the default turbulence advection mode (i.e., without defining  **`K_C4ADVECTION`** for fourth-order centered advection or **`K_C2ADVECTION`** for second-order centered advection), the following incongruities exist:

 - **`Corrector Steps`**: Both **GLS** and **MY25** use third-order upwind advection.
 - **`Predictor Steps`**:  **GLS** and **MY25** default to fourth-order centered advection.

This mismatch causes turbulent length scales to become highly noisy under strong tidal or coastal current advection, leading to instability. The result is a persistent lock on the high default setting **gls_kmin=7.6E-6** (m2/s2), producing spuriously high diffusivity in low-stratification regions. [M. Scully](https://myroms.org/forum/viewtopic.php?p=8433#p8433) has noted this problem of spuriously high diffusivity in low stratification and by [J. Pringle](https://myroms.org/forum/viewtopic.php?p=18566#p18566).

However, the problem of instabilities arising on lowered **gls_kmin** was not discussed.

## Code Changes
1.	**Harmonizing Advection Steps:** We extended the CPP conditional statement in the predictor steps to make **`K_C4ADVECTION`** an explicit directive, setting third-order upwind advection as the default (consistent with the corrector modules).
2.	**Length Scale Constraint:** In the **GLS** corrector module, the turbulence length scale is now constrained to be less than **0.4** times the total water depth by imposing a floor on dissipation. This limit was critical to identifying the inconsistency between predictor and corrector steps. Still, it is recommended to retain it, as it controls instabilities at boundaries or rivers where upstream **tke** and  **gls** (or **q2** and **q2l** for **MY25**) are not well defined.
3.	**Correction to the Gh limiter:** A potentially noisy error in the **Gh** limiter, first identified 6 years ago [here](https://www.myroms.org/forum/viewtopic.php?p=19637#p19637), has also been fixed.

## Impact and Observations
- These changes stabilize tidally driven **ROMS** in the LiveOcean model (Parker MacCready & team, University of Washington Oceanography) while maintaining realistic turbulence length scales. We were able to lower the floor on the **tke** level to **gls_kmin=1.6e-10** (m2/s2) to get better model-data comparisons over the outer continental shelf without generating sudden instabilities in the tidally driven channel flow that would crash the model at the lower **tke** floor before straightening out the default advective scheme for **tke** and **gls** variables. (We also used **gls_Pmin=1.e-12** (m2/s3).
- Some noise in the **GLS** length scale persists near domain boundaries and river inflow points, though it does not cause model crashes. Retaining the limit of von Karman times water depth (_i.e._, turbulent overturns cannot be larger or even as large as the water depth) is left in place to help stabilize the **GLS** closure long enough to approach equilibrium. 

## Notes on MY25

The same corrections to the advective scheme were still needed and were applied to the **MY25** scheme. Although **MY25** already constrains the length scale through an ad-hoc wall function in the dissipation term of the **q2l** equation so that **L=q2l/q2** never gets remotely close to $\kappa$*WaterDepth, the inconsistency in advection schemes likely affects its performance with spurious noise, however muffled. Harmonizing these steps ensures a more robust and accurate closure scheme.

## Alternative Solution

Users can define **`K_C4ADVECTION`** or **`K_C2ADVECTION`** in the current code to manually select the advection scheme. However, this might cause turbulence advection to differ materially from the default third-order upstream advection for density and scalars.

Contact Ramsey R Harcourt at harcourt@uw.edu OR
Ravi Prakash, at [rprakash@uw.edu](mailto:rprakash@uw.edu) if you have any questions.

---

John Warner agrees that we should update the code and said:

> As a test, I ran one of our Hudson River applications. The attached figure shows near-bottom salinity after 7 days for the original, the modified, and the difference. The difference was up to +-0.3 psu, but most of the change happened near the beginning of the simulation. The surface changes were about the same +/-0.3 psu in the same locations. Most of the changes were in shallow waters with more mixing. The strongly stratified section of the river did not show much change.

![gls_test](https://github.com/user-attachments/assets/1ff68d6c-931b-483a-9d52-99cd1bff3487)

