### PR TITLE
Importing Planetary Boundary Layer Height (PBLH) from Coupling

### DIFF
--- a/ESM/coupling_esmf.in
+++ b/ESM/coupling_esmf.in
@@ -253,6 +253,7 @@ WeightsFile(atmos) =  meld_weights_atm.nc
 ! Ustr        atmos   roms, cice         surface U-momentum stress
 ! Vstr        atmos   roms, cice         surface V-momentum stress
 ! Wstar       atmos   roms               turbulent frictional wind magnitude
+! pblh        atmos   roms               atmosphere boundary layer thickness
 !
 ! zlvl        atmos   cice               atmspheric height lowest level
 ! rhoa        atmos   cice               surface air density

--- a/ESM/coupling_esmf.yaml
+++ b/ESM/coupling_esmf.yaml
@@ -349,3 +349,18 @@ metadata:
     connected_to:        *ATM
     regrid_method:       bilinear
     extrapolate_method:  nearest
+
+  - standard_name:       atmosphere_boundary_layer_thickness
+    long_name:           atmosphere boundary layer thickness
+    short_name:          pblh
+    data_variables:      [pblh, time]
+    source_units:        m
+    destination_units:   m
+    source_grid:         cell_center
+    destination_grid:    cell_center
+    add_offset:          0.0d0
+    scale:               1.0d0
+    debug_write:         false
+    connected_to:        *ATM
+    regrid_method:       bilinear
+    extrapolate_method:  nearest

--- a/ESM/coupling_esmf_wrf.yaml
+++ b/ESM/coupling_esmf_wrf.yaml
@@ -469,3 +469,18 @@ metadata:
     connected_to:        *ATM
     regrid_method:       bilinear
     extrapolate_method:  nearest
+
+  - standard_name:       atmosphere_boundary_layer_thickness
+    long_name:           atmosphere boundary layer thickness
+    short_name:          pblh
+    data_variables:      [pblh, time]
+    source_units:        m
+    destination_units:   m
+    source_grid:         cell_center
+    destination_grid:    cell_center
+    add_offset:          0.0d0
+    scale:               1.0d0
+    debug_write:         false
+    connected_to:        *ATM
+    regrid_method:       bilinear
+    extrapolate_method:  nearest

--- a/ESM/roms_cmeps.yaml
+++ b/ESM/roms_cmeps.yaml
@@ -431,3 +431,18 @@ import:
     connected_to:        *ATM
     map_type:            mapbilnr
     map_norm:            none
+
+  - standard_name:       atmosphere_boundary_layer_thickness
+    long_name:           atmosphere boundary layer thickness
+    short_name:          pblh
+    data_variables:      [pblh, time]
+    source_units:        m
+    destination_units:   m
+    source_grid:         cell_center
+    destination_grid:    cell_center
+    add_offset:          0.0d0
+    scale:               1.0d0
+    debug_write:         false
+    connected_to:        *ATM
+    map_type:            mapbilnr
+    map_norm:            none

--- a/Master/esmf_atm_wrf.h
+++ b/Master/esmf_atm_wrf.h
@@ -4580,6 +4580,27 @@
                   ptr2d(i,j)=Fval
                 END DO
               END DO
+# if defined BULK_FLUXES & defined PBLH
+!
+!  Atmosphere boundary layer thickness (m).
+!
+            CASE ('pblh', 'PBLh')
+              MyFmin(1)= MISSING_dp
+              MyFmax(1)=-MISSING_dp
+              DO j=Jstr,Jend
+                DO i=Istr,Iend
+#  ifdef WRF_TIMEAVG
+!                 Fval=REAL(grid%pblhavg(i,j),dp)
+                  Fval=REAL(grid%pblh(i,j),dp)
+#  else
+                  Fval=REAL(grid%pblh(i,j),dp)
+#  endif
+                  MyFmin(1)=MIN(MyFmin(1),Fval)
+                  MyFmax(1)=MAX(MyFmax(1),Fval)
+                  ptr2d(i,j)=Fval
+                END DO
+              END DO
+# endif
 !
 !  Surface (2m) air temperature (K).
 !

--- a/Master/esmf_roms.h
+++ b/Master/esmf_roms.h
@@ -108,9 +108,9 @@
       USE mod_iounits,      ONLY : Iname, SourceFile, stdout
       USE mod_mixing,       ONLY : MIXING
       USE mod_ncparam,      ONLY : Iinfo,  idLdwn, idLrad, idPair,      &
-     &                             idQair, idrain, idSrad, idTair,      &
-     &                             idTsur, idUair, idUsms, idVair,      &
-     &                             idVsms
+     &                             idPBLh, idQair, idrain, idSrad,      &
+     &                             idTair, idTsur, idUair, idUsms,      &
+     &                             idVair, idVsms
 # ifdef TIME_INTERP
       USE mod_netcdf,       ONLY : netcdf_get_ivar,                     &
      &                             netcdf_get_svar,                     &
@@ -3932,6 +3932,42 @@
      &                              NghostPoints,                       &
      &                              EWperiodic(ng), NSperiodic(ng),     &
      &                              Vstress)
+              END IF
+# endif
+# if defined BULK_FLUXES & defined PBLH
+!
+!  Atmosphere boundary layer thickness (m).
+!
+            CASE ('pblh', 'PBLh')
+              romsScale=scale
+              ifield=idPBLh
+              gtype=r2dvar
+              Tindex=3-Iinfo(8,ifield,ng)
+              DO j=JstrR,JendR
+                DO i=IstrR,IendR
+                  IF (ABS(ptr2d(i,j)).lt.TOL_dp) THEN
+                    Fval=scale*ptr2d(i,j)+add_offset
+                  ELSE
+                    Fval=0.0_dp
+                  END IF
+                  MyFmin(1)=MIN(MyFmin(1),ptr2d(i,j))
+                  MyFmax(1)=MAX(MyFmax(1),ptr2d(i,j))
+                  MyFmin(2)=MIN(MyFmin(2),Fval)
+                  MyFmax(2)=MAX(MyFmax(2),Fval)
+                  FORCES(ng)%PBLh(i,j)=Fval
+                END DO
+              END DO
+              IF (localDE.eq.localDEcount-1) THEN
+                IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
+                  CALL exchange_r2d_tile (ng, tile,                     &
+     &                                    LBi, UBi, LBj, UBj,           &
+     &                                    FORCES(ng)%PBLh)
+                END IF
+                CALL mp_exchange2d (ng, tile, iNLM, 1,                  &
+     &                              LBi, UBi, LBj, UBj,                 &
+     &                              NghostPoints,                       &
+     &                              EWperiodic(ng), NSperiodic(ng),     &
+     &                              FORCES(ng)%PBLh)
               END IF
 # endif
 # if defined WIND_MINUS_CURRENT && !defined BULK_FLUXES

--- a/ROMS/External/roms_basin.in
+++ b/ROMS/External/roms_basin.in
@@ -744,6 +744,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2830,6 +2831,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_benchmark1.in
+++ b/ROMS/External/roms_benchmark1.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_benchmark2.in
+++ b/ROMS/External/roms_benchmark2.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_benchmark3.in
+++ b/ROMS/External/roms_benchmark3.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_bio_toy.in
+++ b/ROMS/External/roms_bio_toy.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2839,6 +2840,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_bl_test.in
+++ b/ROMS/External/roms_bl_test.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_canyon2d.in
+++ b/ROMS/External/roms_canyon2d.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_canyon3d.in
+++ b/ROMS/External/roms_canyon3d.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_channel.in
+++ b/ROMS/External/roms_channel.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_damee_4.in
+++ b/ROMS/External/roms_damee_4.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_dogbone_composite.in
+++ b/ROMS/External/roms_dogbone_composite.in
@@ -774,6 +774,7 @@ Qout(idWdis) == 2*F     ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == 2*F     ! roller_action      wave roller action density
 
 Qout(idPair) == 2*F     ! Pair               surface air pressure
+Qout(idPBLh) == 2*F     ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == 2*F     ! Tair               surface air temperature
 Qout(idUair) == 2*F     ! Uair               surface U-wind
 Qout(idVair) == 2*F     ! Vair               surface V-wind
@@ -2869,6 +2870,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_dogbone_refined.in
+++ b/ROMS/External/roms_dogbone_refined.in
@@ -774,6 +774,7 @@ Qout(idWdis) == 2*F     ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == 2*F     ! roller_action      wave roller action density
 
 Qout(idPair) == 2*F     ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == 2*F     ! Tair               surface air temperature
 Qout(idUair) == 2*F     ! Uair               surface U-wind
 Qout(idVair) == 2*F     ! Vair               surface V-wind
@@ -2869,6 +2870,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_dogbone_whole.in
+++ b/ROMS/External/roms_dogbone_whole.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_double_gyre.in
+++ b/ROMS/External/roms_double_gyre.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_estuary_test.in
+++ b/ROMS/External/roms_estuary_test.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_flt_test2d.in
+++ b/ROMS/External/roms_flt_test2d.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_flt_test3d.in
+++ b/ROMS/External/roms_flt_test3d.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_grav_adj.in
+++ b/ROMS/External/roms_grav_adj.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_inlet_test.in
+++ b/ROMS/External/roms_inlet_test.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_kelvin.in
+++ b/ROMS/External/roms_kelvin.in
@@ -752,6 +752,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2838,6 +2839,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_lab_canyon.in
+++ b/ROMS/External/roms_lab_canyon.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_lake_jersey.in
+++ b/ROMS/External/roms_lake_jersey.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_lake_signell.in
+++ b/ROMS/External/roms_lake_signell.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_lmd_test.in
+++ b/ROMS/External/roms_lmd_test.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_overflow.in
+++ b/ROMS/External/roms_overflow.in
@@ -744,6 +744,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2830,6 +2831,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_riverplume1.in
+++ b/ROMS/External/roms_riverplume1.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_riverplume2.in
+++ b/ROMS/External/roms_riverplume2.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_seamount.in
+++ b/ROMS/External/roms_seamount.in
@@ -743,6 +743,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2829,6 +2830,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_sed_test1.in
+++ b/ROMS/External/roms_sed_test1.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_sed_toy.in
+++ b/ROMS/External/roms_sed_toy.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_shoreface.in
+++ b/ROMS/External/roms_shoreface.in
@@ -746,6 +746,7 @@ Qout(idWdis) == T       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == T       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_soliton.in
+++ b/ROMS/External/roms_soliton.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_test_chan.in
+++ b/ROMS/External/roms_test_chan.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_test_head.in
+++ b/ROMS/External/roms_test_head.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_upwelling.in
+++ b/ROMS/External/roms_upwelling.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_wc13.in
+++ b/ROMS/External/roms_wc13.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == T       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == T       ! Tair               surface air temperature
 Qout(idUair) == T       ! Uair               surface U-wind
 Qout(idVair) == T       ! Vair               surface V-wind
@@ -2838,6 +2839,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_weddell.in
+++ b/ROMS/External/roms_weddell.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/roms_windbasin.in
+++ b/ROMS/External/roms_windbasin.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/ROMS/External/varinfo.yaml
+++ b/ROMS/External/varinfo.yaml
@@ -1624,6 +1624,17 @@ metadata:
     add_offset:     0.0d0
     scale:          1.0d0
 
+  - variable:       PBLh                                             # Input
+    standard_name:  atmosphere_boundary_layer_thickness
+    long_name:      atmosphere boundary layer thickness
+    units:          m                                                # [m]
+    field:          planetary boundary layer height
+    time:           pblh_time
+    index_code:     idPBLh
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
   - variable:       Tair                                             # Input
     standard_name:  surface_air_temperature
     long_name:      surface air temperature

--- a/ROMS/Modules/mod_forces.F
+++ b/ROMS/Modules/mod_forces.F
@@ -70,6 +70,13 @@
 !  cloud        Cloud fraction (percentage/100).                       !
 !  cloudG       Latest two-time snapshots of input "cloud" grided      !
 !                 data used for interpolation.                         !
+
+#if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+!                                                                      !
+!  Atmosphere boundary layer.                                          !
+!                                                                      !
+!  PBLh         Planetary boundary layer height (m).                   !
+#endif
 !                                                                      !
 !  Surface heat fluxes, Atmosphere-Ocean bulk parameterization.        !
 !                                                                      !
@@ -224,7 +231,9 @@
           real(r8), pointer :: PairG(:,:,:)
 # endif
 #endif
-
+#if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+          real(r8), pointer :: PBLh(:,:)
+#endif
 #ifdef WAVES_DIR
           real(r8), pointer :: Dwave(:,:)
 # ifndef ANA_WWAVE
@@ -627,6 +636,11 @@
       allocate ( FORCES(ng) % PairG(LBi:UBi,LBj:UBj,2) )
       Dmem(ng)=Dmem(ng)+2.0_r8*size2d
 # endif
+#endif
+
+#if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH 
+      allocate ( FORCES(ng) % PBLh(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
 #endif
 
 #ifdef WAVES_DIR
@@ -1205,6 +1219,11 @@
       IF (.not.destroy(ng, FORCES(ng)%PairG, MyFile,                    &
      &                 __LINE__, 'FORCES(ng)%PairG')) RETURN
 #  endif
+# endif
+
+#if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+    IF (.not.destroy(ng, FORCES(ng)%PBLh, MyFile,                       &
+     &                 __LINE__, 'FORCES(ng)%PBLh')) RETURN
 # endif
 
 # ifdef WAVES_DIR
@@ -1833,6 +1852,9 @@
             FORCES(ng) % PairG(i,j,1) = IniVal
             FORCES(ng) % PairG(i,j,2) = IniVal
 # endif
+#endif
+#if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+            FORCES(ng) % PBLh(i,j) = IniVal
 #endif
 #ifdef WAVES_DIR
             FORCES(ng) % Dwave(i,j) = IniVal

--- a/ROMS/Modules/mod_ncparam.F
+++ b/ROMS/Modules/mod_ncparam.F
@@ -261,6 +261,7 @@
       integer  :: idOvel        ! omega vertical velocity
       integer  :: idOvil        ! omega vertical velocity implicit
       integer  :: idPair        ! surface air pressure
+      integer  :: idPBLh        ! planetary boundary layer height
       integer  :: idPbar        ! streamfunction
       integer  :: idPwet        ! wet/dry mask on PSI-points
       integer  :: idpmdx        ! inverse grid x-spacing
@@ -1725,6 +1726,8 @@
             idVwet=varid
           CASE ('idPair')
             idPair=varid
+          CASE ('idPBLh')
+            idPBLh=varid
           CASE ('idTair')
             idTair=varid
           CASE ('idQair')

--- a/ROMS/Nonlinear/bulk_flux.F
+++ b/ROMS/Nonlinear/bulk_flux.F
@@ -155,6 +155,9 @@
 # ifdef CLOUDS
      &                     FORCES(ng) % cloud,                          &
 # endif
+# if defined FRC_COUPLING && defined PBLH
+     &                     FORCES(ng) % PBLh,                           &
+# endif
 # if defined COARE_TAYLOR_YELLAND || defined DRENNAN
      &                     FORCES(ng) % Hwave,                          &
 # endif
@@ -226,6 +229,9 @@
 # ifdef CLOUDS
      &                           cloud,                                 &
 # endif
+# if defined FRC_COUPLING && defined PBLH
+     &                           PBLh,                                  &
+# endif
 # if defined COARE_TAYLOR_YELLAND || defined DRENNAN
      &                           Hwave,                                 &
 # endif
@@ -296,18 +302,21 @@
 #  ifdef CLOUDS
       real(r8), intent(in   ) :: cloud(LBi:,LBj:)
 #  endif
-# if defined COARE_TAYLOR_YELLAND || defined DRENNAN
+#  if defined FRC_COUPLING && defined PBLH
+      real(r8), intent(in   ) :: PBLh(LBi:,LBj:)
+#  endif
+#  if defined COARE_TAYLOR_YELLAND || defined DRENNAN
       real(r8), intent(in   ) :: Hwave(LBi:,LBj:)
-# endif
-# if defined COARE_TAYLOR_YELLAND || defined COARE_OOST || \
+#  endif
+#  if defined COARE_TAYLOR_YELLAND || defined COARE_OOST || \
       defined DRENNAN
       real(r8), intent(in   ) :: Pwave_top(LBi:,LBj:)
-# endif
-# if !defined DEEPWATER_WAVES      && \
+#  endif
+#  if !defined DEEPWATER_WAVES      && \
      (defined COARE_TAYLOR_YELLAND || defined COARE_OOST || \
       defined DRENNAN)
       real(r8), intent(in   ) :: Lwavep(LBi:,LBj:)
-# endif
+#  endif
 #  if defined ICE_MODEL  && defined ICE_BULK_FLUXES && \
       defined ICE_ALBEDO && defined SHORTWAVE
       real(r8), intent(in   ) :: albedo_ice(LBi:,LBj:)
@@ -364,19 +373,22 @@
 #  ifdef CLOUDS
       real(r8), intent(in   ) :: cloud(LBi:UBi,LBj:UBj)
 #  endif
-# if defined COARE_TAYLOR_YELLAND || \
+#  if defined FRC_COUPLING && defined PBLH
+      real(r8), intent(in   ) :: PBLh(LBi:UBi,LBj:UBj)
+#  endif
+#  if defined COARE_TAYLOR_YELLAND || \
       defined DRENNAN
       real(r8), intent(in   ) :: Hwave(LBi:UBi,LBj:UBj)
-# endif
-# if defined COARE_TAYLOR_YELLAND || defined COARE_OOST || \
+#  endif
+#  if defined COARE_TAYLOR_YELLAND || defined COARE_OOST || \
       defined DRENNAN
       real(r8), intent(in   ) :: Pwave_top(LBi:UBi,LBj:UBj)
-# endif
-# if !defined DEEPWATER_WAVES      && \
+#  endif
+#  if !defined DEEPWATER_WAVES      && \
      (defined COARE_TAYLOR_YELLAND || defined COARE_OOST || \
       defined DRENNAN)
       real(r8), intent(in   ) :: Lwavep(LBi:UBi,LBj:UBj)
-# endif
+#  endif
 #  if defined ICE_MODEL  && defined ICE_BULK_FLUXES && \
       defined ICE_ALBEDO && defined SHORTWAVE
       real(r8), intent(in   ) :: albedo_ice(LBi:UBi,LBj:UBj)
@@ -881,11 +893,18 @@
      &               (LOG(blk_ZQ(ng)/ZoQ(i))-Qpsi(i))
 !
 !  Compute gustiness in wind speed.
+# if defined FRC_COUPLING && defined PBLH
+!  Use atmosphere boundary layer thickness from coupled model.
+# endif
 !
             Bf=-g/TairK(i)*                                             &
      &         Wstar(i)*(Tstar(i)+0.61_r8*TairK(i)*Qstar(i))
             IF (Bf.gt.0.0_r8) THEN
+# if defined FRC_COUPLING && defined PBLH
+              Wgus(i)=blk_beta*(Bf*PBLh(i,j))**r3
+# else
               Wgus(i)=blk_beta*(Bf*blk_Zabl)**r3
+# endif
             ELSE
               Wgus(i)=0.2_r8
             END IF

--- a/ROMS/Nonlinear/bulk_flux.F
+++ b/ROMS/Nonlinear/bulk_flux.F
@@ -904,7 +904,7 @@
 !  Use atmosphere boundary layer thickness from coupled model.
 # endif
 !
-            Bf=-g/TairK(i)*                                             &
+            Bf=-g/(TairK(i)+0.61_r8*Qstar(i))*                          &
      &         Wstar(i)*(Tstar(i)+0.61_r8*TairK(i)*Qstar(i))
             IF (Bf.gt.0.0_r8) THEN
 # if defined FRC_COUPLING && defined PBLH

--- a/ROMS/Nonlinear/bulk_flux.F
+++ b/ROMS/Nonlinear/bulk_flux.F
@@ -36,7 +36,7 @@
 !      409-438.                                                        !
 !                                                                      !
 !    Fairall, C.W., Bradley, E.F., Hare, J.E., Grachev, A.A. and       !
-!      Edson, J.B., 2003. Bulk parameterization of air–sea fluxes:     !
+!      Edson, J.B., 2003. Bulk parameterization of air-sea fluxes:     !
 !      Updates and verification for the COARE algorithm. Journal of    !
 !      Climate, 16, 571-591.                                           !
 !                                                                      !
@@ -758,6 +758,9 @@
           Cd=(vonKar/LOG(blk_ZW(ng)/Zo10(i)))**2
 !
 !  Compute Richardson number.
+# if defined FRC_COUPLING && defined PBLH
+!  Use atmosphere boundary layer thickness from coupled model.
+# endif
 !
           Ct(i)=vonKar/LOG(blk_ZT(ng)/ZoT10(i))  ! T transfer coefficient
           CC(i)=vonKar*Ct(i)/Cd
@@ -765,7 +768,11 @@
 # ifdef COOL_SKIN
           delTc(i)=blk_dter
 # endif
+# if defined FRC_COUPLING && defined PBLH
+          Ribcu(i)=-blk_ZW(ng)/(PBLh(i,j)*0.004_r8*blk_beta**3)
+# else
           Ribcu(i)=-blk_ZW(ng)/(blk_Zabl*0.004_r8*blk_beta**3)
+# endif
           Ri(i)=-g*blk_ZW(ng)*((delT(i)-delTc(i))+                      &
      &                          0.61_r8*TairK(i)*delQ(i))/              &
      &          (TairK(i)*delW(i)*delW(i)+eps)

--- a/ROMS/Utility/checkdefs.F
+++ b/ROMS/Utility/checkdefs.F
@@ -2031,6 +2031,13 @@
       is=LEN_TRIM(Coptions)+1
       Coptions(is:is+13)=' PARALLEL_IO,'
 #endif
+#if defined PBLH && defined BULK_FLUXES && defined FRC_COUPLING
+!
+      IF (Master) WRITE (stdout,20) 'PBLH',                             &
+     &   'Use atmosphere boundary layer thickness for wind gustiness'
+      is=LEN_TRIM(Coptions)+1
+      Coptions(is:is+10)=' PBLH,'
+#endif
 #if defined CARBON && defined BIO_FENNEL
 # if defined PCO2AIR_DATA
 !

--- a/ROMS/Utility/def_quick.F
+++ b/ROMS/Utility/def_quick.F
@@ -1170,6 +1170,27 @@
      &                   NF_FOUT, nvd3, t2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
+# endif 
+# if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+!
+!  Define atmosphere boundary layer thickness.
+!
+        IF (Qout(idPBLh,ng)) THEN
+          Vinfo( 1)=Vname(1,idPBLh)
+          Vinfo( 2)=Vname(2,idPBLh)
+          Vinfo( 3)=Vname(3,idPBLh)
+          Vinfo(14)=Vname(4,idPBLh)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_rho'
+#  endif
+          Vinfo(21)=Vname(6,idPBLh)
+          Vinfo(22)='coordinates'
+          Aval(5)=REAL(Iinfo(1,idPBLh,ng),r8)
+          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idPBLh),  &
+     &                   NF_FOUT, nvd3, t2dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
 # endif
 # if defined BULK_FLUXES || defined ECOSIM
 !
@@ -1741,6 +1762,11 @@
             got_var(idPair)=.TRUE.
             QCK(ng)%Vid(idPair)=var_id(i)
 # endif
+# if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idPBLh))) THEN
+            got_var(idPBLh)=.TRUE.
+            QCK(ng)%Vid(idPBLh)=var_id(i)
+# endif
 # if defined BULK_FLUXES || defined ECOSIM
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idUair))) THEN
             got_var(idUair)=.TRUE.
@@ -2032,6 +2058,14 @@
 # if defined BULK_FLUXES || defined ECOSIM || defined ATM_PRESS
         IF (.not.got_var(idPair).and.Qout(idPair,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idPair)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+# endif
+# if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+        IF (.not.got_var(idPBLh).and.Qout(idPBLh,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idPBLh)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
@@ -3436,6 +3470,31 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 #  endif
+#  if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+!
+!  Define atmosphere boundary layer thickness.
+!
+        IF (Qout(idPBLh,ng)) THEN
+          Vinfo( 1)=Vname(1,idPBLh)
+          Vinfo( 2)=Vname(2,idPBLh)
+          Vinfo( 3)=Vname(3,idPBLh)
+          Vinfo(14)=Vname(4,idPBLh)
+          Vinfo(16)=Vname(1,idtime)
+#   if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_rho'
+#   endif
+          Vinfo(21)=Vname(6,idPBLh)
+          Vinfo(22)='coordinates'
+          Aval(5)=REAL(Iinfo(1,idPBLh,ng),r8)
+          QCK(ng)%pioVar(idPBLh)%dkind=PIO_FOUT
+          QCK(ng)%pioVar(idPBLh)%gtype=r2dvar
+!
+          status=def_var(ng, model, QCK(ng)%pioFile,                    &
+     &                   QCK(ng)%pioVar(idPBLh)%vd,                     &
+     &                   PIO_FOUT, nvd3, t2dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+#  endif
 #  if defined BULK_FLUXES || defined ECOSIM
 !
 !  Define surface winds.
@@ -4138,6 +4197,12 @@
             QCK(ng)%pioVar(idPair)%dkind=PIO_FOUT
             QCK(ng)%pioVar(idPair)%gtype=r2dvar
 #  endif
+#  if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+            got_var(idPBLh)=.TRUE.
+            QCK(ng)%pioVar(idPBLh)%vd=var_desc(i)
+            QCK(ng)%pioVar(idPBLh)%dkind=PIO_FOUT
+            QCK(ng)%pioVar(idPBLh)%gtype=r2dvar
+#  endif
 #  if defined BULK_FLUXES || defined ECOSIM
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idUair))) THEN
             got_var(idUair)=.TRUE.
@@ -4467,6 +4532,14 @@
 #  if defined BULK_FLUXES || defined ECOSIM || defined ATM_PRESS
         IF (.not.got_var(idPair).and.Qout(idPair,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idPair)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+#  endif
+#  if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+        IF (.not.got_var(idPBLh).and.Qout(idPBLh,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idPBLh)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN

--- a/ROMS/Utility/read_phypar.F
+++ b/ROMS/Utility/read_phypar.F
@@ -2510,6 +2510,16 @@
               Npts=load_l(Nval, Cval, Ngrids, Lswitch)
               Qout(idPair,1:Ngrids)=Lswitch(1:Ngrids)
 # endif
+# if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+            CASE ('Qout(idPBLh)')
+              IF (idPBLh.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idPBLh'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Qout(idPBLh,1:Ngrids)=Lswitch(1:Ngrids)
+# endif
 # if defined BULK_FLUXES
             CASE ('Qout(idTair)')
               Npts=load_l(Nval, Cval, Ngrids, Lswitch)
@@ -6524,6 +6534,11 @@
             IF (Qout(idPair,ng)) WRITE (out,170) Qout(idPair,ng),       &
      &         'Qout(idPair)',                                          &
      &         'Write out surface air pressure.'
+# endif
+# if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+            IF (Qout(idPBLh,ng)) WRITE (out,170) Qout(idPBLh,ng),       &
+     &         'Qout(idPBLh)',                                          &
+     &         'Write out atmosphere boundary layer thickness.'
 # endif
 # if defined BULK_FLUXES
             IF (Qout(idTair,ng)) WRITE (out,170) Qout(idTair,ng),       &

--- a/ROMS/Utility/wrt_quick.F
+++ b/ROMS/Utility/wrt_quick.F
@@ -1064,6 +1064,31 @@
         END IF
       END IF
 # endif
+# if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+!
+!  Write atmosphere boundary layer thickness.
+!
+      IF (Qout(idPBLh,ng)) THEN
+        scale=1.0_dp
+        gtype=gfactor*r2dvar
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idPBLh,             &
+     &                     QCK(ng)%Vid(idPBLh),                         &
+     &                     QCK(ng)%Rindex, gtype,                       &
+     &                     LBi, UBi, LBj, UBj, scale,                   &
+#  ifdef MASKING
+     &                     GRID(ng) % rmask,                            &
+#  endif
+     &                     FORCES(ng) % PBLh)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idPBLh)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+      END IF
+# endif
 # if defined BULK_FLUXES
 !
 !  Write out surface air temperature.
@@ -2678,6 +2703,37 @@
           RETURN
         END IF
       END IF
+#  endif
+#  if defined BULK_FLUXES && defined FRC_COUPLING && defined PBLH
+!
+!  Write atmosphere boundary layer thickness.
+!
+      IF (Qout(idPBLh,ng)) THEN
+        scale=1.0_dp
+        IF (QCK(ng)%pioVar(idPBLh)%dkind.eq.PIO_double) THEN
+          ioDesc => ioDesc_dp_r2dvar(ng)
+        ELSE
+          ioDesc => ioDesc_sp_r2dvar(ng)
+        END IF
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idPBLh,          &
+     &                     QCK(ng)%pioVar(idPBLh),                      &
+     &                     QCK(ng)%Rindex,                              &
+     &                     ioDesc,                                      &
+     &                     LBi, UBi, LBj, UBj, scale,                   &
+#   ifdef MASKING
+     &                     GRID(ng) % rmask,                            &
+#   endif
+     &                     FORCES(ng) % PBLh)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idPBLh)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+      END IF
+
 #  endif
 #  if defined BULK_FLUXES
 !

--- a/User/External/roms_adria02.in
+++ b/User/External/roms_adria02.in
@@ -745,6 +745,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2835,6 +2836,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/User/External/roms_cblast.in
+++ b/User/External/roms_cblast.in
@@ -745,6 +745,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2834,6 +2835,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/User/External/roms_doppio.in
+++ b/User/External/roms_doppio.in
@@ -746,6 +746,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2839,6 +2840,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/User/External/roms_eac_4.in
+++ b/User/External/roms_eac_4.in
@@ -745,6 +745,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2831,6 +2832,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/User/External/roms_eac_8.in
+++ b/User/External/roms_eac_8.in
@@ -745,6 +745,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2831,6 +2832,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/User/External/roms_ias.in
+++ b/User/External/roms_ias.in
@@ -745,6 +745,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2831,6 +2832,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/User/External/roms_ias_40.in
+++ b/User/External/roms_ias_40.in
@@ -744,6 +744,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2830,6 +2831,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/User/External/roms_natl.in
+++ b/User/External/roms_natl.in
@@ -745,6 +745,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2831,6 +2832,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/User/External/roms_nena.in
+++ b/User/External/roms_nena.in
@@ -745,6 +745,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2832,6 +2833,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/User/External/roms_nj_bight.in
+++ b/User/External/roms_nj_bight.in
@@ -751,6 +751,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2844,6 +2845,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/User/External/roms_scb.in
+++ b/User/External/roms_scb.in
@@ -745,6 +745,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2831,6 +2832,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/User/External/roms_scb.in
+++ b/User/External/roms_scb.in
@@ -767,20 +767,12 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-<<<<<<< HEAD
 Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
-=======
 Qout(idTair) == F       ! Tair               near surface air temperature
 Qout(idUair) == F       ! Uair               near surface U-wind
 Qout(idVair) == F       ! Vair               near surface V-wind
 Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
 Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
->>>>>>> develop
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -2895,20 +2887,12 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-<<<<<<< HEAD
 ! Qout(idPBLh)   Write out atmosphere boundary layer height.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
-=======
 ! Qout(idTair)   Write out near surface air temperature.
 ! Qout(idUair)   Write out near surface U-wind component.
 ! Qout(idVair)   Write out near surface V-wind component.
 ! Qout(idUaiE)   Write out near surface Eastward  U-wind.
 ! Qout(idVaiN)   Write out near surface Northward V-wind.
->>>>>>> develop
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_sw06_fine.in
+++ b/User/External/roms_sw06_fine.in
@@ -745,6 +745,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2831,6 +2832,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.

--- a/User/External/roms_wcofs.in
+++ b/User/External/roms_wcofs.in
@@ -743,6 +743,7 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
+Qout(idPBLh) == F       ! PBLh               atmosphere boundary layer thickness
 Qout(idTair) == F       ! Tair               surface air temperature
 Qout(idUair) == F       ! Uair               surface U-wind
 Qout(idVair) == F       ! Vair               surface V-wind
@@ -2829,6 +2830,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
+! Qout(idPBLh)   Write out atmosphere boundary layer height.
 ! Qout(idTair)   Write out surface air temperature.
 ! Qout(idUair)   Write out surface U-wind component.
 ! Qout(idVair)   Write out surface V-wind component.


### PR DESCRIPTION
# Description

This PR adds the Planetary Boundary Layer Height (**PBLH**), also known as the atmosphere boundary layer thickness (m), to the Import and Export state of **ROMS** and **WRF ESMF**-based **NUOPC** coupling modules. The **PBLH** is defined as the height of the turbulent mixed layer of the atmosphere in contact with the Earth's surface. The **PBLH** is crucial in computing turbulent heat, moisture, and momentum fluxes.

In **bulk_fluxes.F** is used to estimate wind gustiness:
``` F90
!
!  Compute gustiness in wind speed.
!
            Bf=-g/(TairK(i)+0.61_r8*Qstar(i))*                          &
     &         Wstar(i)*(Tstar(i)+0.61_r8*TairK(i)*Qstar(i))
            IF (Bf.gt.0.0_r8) THEN
# if defined FRC_COUPLING && defined PBLH
              Wgus(i)=blk_beta*(Bf*PBLh(i,j))**r3
# else
              Wgus(i)=blk_beta*(Bf*blk_Zabl)**r3
# endif
            ELSE
              Wgus(i)
           END IF
           delW(i)=SQRT(Wmag(i)*Wmag(i)+Wgus(i)*Wgus(i))
```
This option is possible when **`BULK_FLUXES`** and **`PBLH`** are activated during **ESMF** coupling using **`FRC_COUPLING`** and **`WRF_COUPLING.`**.  For example, if we turn on and off **`PBLH`** in **WRF-ROMS** coupling, we get the following difference in the computed sensible heat flux.

![sensible](https://github.com/user-attachments/assets/3a510834-bdb3-48c7-8d62-91babe8af26d)

---

**`WARNING:`**  All the input scripts **roms.in** and **varinfo.yaml** were updated to include new metadata for atmosphere boundary layer thickness:

``` d
Qout(idPBLh) == T       ! PBLh               atmosphere boundary layer thickness
```

and

``` yaml
  - variable:       PBLh                                             # Input
    standard_name:  atmosphere_boundary_layer_thickness
    long_name:      atmosphere boundary layer thickness
    units:          m                                                # [m]
    field:          planetary boundary layer height
    time:           pblh_time
    index_code:     idPBLh
    type:           r2dvar
    add_offset:     0.0d0
    scale:          1.0d0
```
---

Many thanks to Fernando Pareja (Rutgers) for testing this option.

---
