### PR TITLE
Updating output NetCDF files to include fields at specified constant depth slices

### DIFF
--- a/ROMS/External/da_roms.tmp
+++ b/ROMS/External/da_roms.tmp
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2665,6 +2698,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2773,7 +2818,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3057,6 +3112,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/da_roms.tmp
+++ b/ROMS/External/da_roms.tmp
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -740,7 +740,7 @@ Qout(idWbeh) == F       ! bernoulli_head     WEC_VF Bernoulli head adjustment
 Qout(idU2rs) == F       ! ubar_wec_stress    WEC 2D U-stress
 Qout(idV2rs) == F       ! vbar_wec_stress    WEC 2D V-stress
 Qout(idU3rs) == F       ! u_wec_stress       WEC 3D U-stress
-Qout(idV3rs) == F       ! v_wec_stress        WEC 3D V-stress
+Qout(idV3rs) == F       ! v_wec_stress       WEC 3D V-stress
 
 Qout(idU2Sd) == F       ! ubar_stokes        2D Stokes U-velocity
 Qout(idV2Sd) == F       ! vbar_stokes        2D Stokes V-velocity
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2684,15 +2684,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2767,11 +2767,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2800,25 +2800,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2886,11 +2886,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2920,14 +2920,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2985,11 +2985,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/nl_roms.tmp
+++ b/ROMS/External/nl_roms.tmp
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2665,6 +2698,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2773,7 +2818,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3057,6 +3112,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/nl_roms.tmp
+++ b/ROMS/External/nl_roms.tmp
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2684,15 +2684,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2767,11 +2767,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2800,25 +2800,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2886,11 +2886,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2920,14 +2920,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2985,11 +2985,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_basin.in
+++ b/ROMS/External/roms_basin.in
@@ -641,11 +641,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -692,12 +692,12 @@ Qout(idBath) == F       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -766,11 +766,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -869,11 +869,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2683,15 +2683,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2766,11 +2766,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2799,25 +2799,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2885,11 +2885,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2919,14 +2919,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2984,11 +2984,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_basin.in
+++ b/ROMS/External/roms_basin.in
@@ -572,6 +572,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -686,6 +698,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -974,6 +996,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2664,6 +2697,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2772,7 +2817,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3056,6 +3111,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_benchmark1.in
+++ b/ROMS/External/roms_benchmark1.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_benchmark1.in
+++ b/ROMS/External/roms_benchmark1.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_benchmark2.in
+++ b/ROMS/External/roms_benchmark2.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_benchmark2.in
+++ b/ROMS/External/roms_benchmark2.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_benchmark3.in
+++ b/ROMS/External/roms_benchmark3.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_benchmark3.in
+++ b/ROMS/External/roms_benchmark3.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_bio_toy.in
+++ b/ROMS/External/roms_bio_toy.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2692,15 +2692,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2775,11 +2775,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2808,25 +2808,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2894,11 +2894,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2928,14 +2928,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2993,11 +2993,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_bio_toy.in
+++ b/ROMS/External/roms_bio_toy.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2673,6 +2706,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2781,7 +2826,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3065,6 +3120,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_bl_test.in
+++ b/ROMS/External/roms_bl_test.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_bl_test.in
+++ b/ROMS/External/roms_bl_test.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == T F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == T       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == T F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == T       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_canyon2d.in
+++ b/ROMS/External/roms_canyon2d.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_canyon2d.in
+++ b/ROMS/External/roms_canyon2d.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == F F     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == F F     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == F F     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == F F     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == F F     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_canyon3d.in
+++ b/ROMS/External/roms_canyon3d.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T F     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_canyon3d.in
+++ b/ROMS/External/roms_canyon3d.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_channel.in
+++ b/ROMS/External/roms_channel.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_channel.in
+++ b/ROMS/External/roms_channel.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_damee_4.in
+++ b/ROMS/External/roms_damee_4.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_damee_4.in
+++ b/ROMS/External/roms_damee_4.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_dogbone_composite.in
+++ b/ROMS/External/roms_dogbone_composite.in
@@ -671,11 +671,11 @@ Hout(idWdis) == 2*F     ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == 2*F     ! roller_action      wave roller action density
 
 Hout(idPair) == 2*F     ! Pair               surface air pressure
-Hout(idTair) == 2*F     ! Tair               surface air temperature
-Hout(idUair) == 2*F     ! Uwind              surface U-wind
-Hout(idVair) == 2*F     ! Vwind              surface V-wind
-Hout(idUaiE) == 2*F     ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == 2*F     ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == 2*F     ! Tair               near surface air temperature
+Hout(idUair) == 2*F     ! Uwind              near surface U-wind
+Hout(idVair) == 2*F     ! Vwind              near surface V-wind
+Hout(idUaiE) == 2*F     ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == 2*F     ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == 2*F 2*F ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == 2*F     ! latent             latent heat flux
@@ -722,12 +722,12 @@ Qout(idBath) == 2*T     ! bath               time-dependent bathymetry
 
 Qout(idTvar) == 2*F 2*F ! temp, salt         temperature and salinity
 
-Qout(idUsur) == 2*T     ! u_sur              surface U-velocity
-Qout(idVsur) == 2*T     ! v_sur              surface V-velocity
-Qout(idUsuE) == 2*T     ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == 2*T     ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == 2*T     ! u_sur              surface level U-velocity
+Qout(idVsur) == 2*T     ! v_sur              surface level V-velocity
+Qout(idUsuE) == 2*T     ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == 2*T     ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == 2*T 2*T ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == 2*T 2*T ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == 2*F     ! u_slice            U-velocity depth slices
 Qout(idVzsl) == 2*F     ! v_slice            V-velocity depth slices
@@ -796,11 +796,11 @@ Qout(idWdis) == 2*F     ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == 2*F     ! roller_action      wave roller action density
 
 Qout(idPair) == 2*F     ! Pair               surface air pressure
-Qout(idTair) == 2*F     ! Tair               surface air temperature
-Qout(idUair) == 2*F     ! Uair               surface U-wind
-Qout(idVair) == 2*F     ! Vair               surface V-wind
-Qout(idUaiE) == 2*F     ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == 2*F     ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == 2*F     ! Tair               near surface air temperature
+Qout(idUair) == 2*F     ! Uair               near surface U-wind
+Qout(idVair) == 2*F     ! Vair               near surface V-wind
+Qout(idUaiE) == 2*F     ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == 2*F     ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == 2*F 2*F ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == 2*F     ! latent             latent heat flux
@@ -899,11 +899,11 @@ Aout(idWdis) == 2*F     ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == 2*F     ! roller_action      wave roller action density
 
 Aout(idPair) == 2*F     ! Pair               surface air pressure
-Aout(idTair) == 2*F     ! Tair               surface air temperature
-Aout(idUair) == 2*F     ! Uwind              surface U-wind
-Aout(idVair) == 2*F     ! Vwind              surface V-wind
-Aout(idUaiE) == 2*F     ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == 2*F     ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == 2*F     ! Tair               near surface air temperature
+Aout(idUair) == 2*F     ! Uwind              near surface U-wind
+Aout(idVair) == 2*F     ! Vwind              near surface V-wind
+Aout(idUaiE) == 2*F     ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == 2*F     ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == 2*F 2*F ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == 2*F     ! latent             latent heat flux
@@ -2722,15 +2722,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2805,11 +2805,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2838,25 +2838,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2924,11 +2924,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2958,14 +2958,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -3023,11 +3023,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_dogbone_composite.in
+++ b/ROMS/External/roms_dogbone_composite.in
@@ -602,6 +602,18 @@ Hout(idBath) == 2*F     ! bath               time-dependent bathymetry
 
 Hout(idTvar) == 2*T 2*T ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == 2*F     ! u_slice            U-velocity depth slices
+Hout(idVzsl) == 2*F     ! v_slice            V-velocity depth slices
+Hout(idUzsE) == 2*F     ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == 2*F     ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == 2*F     ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == 2*F     ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == 2*F     ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == 2*F     ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == 2*F 2*F ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == 2*F     ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == 2*F     ! z_u                time-varying depths of U-points
 Hout(idpthV) == 2*F     ! z_v                time-varying depths of V-points
@@ -716,6 +728,16 @@ Qout(idUsuE) == 2*T     ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == 2*T     ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == 2*T 2*T ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == 2*F     ! u_slice            U-velocity depth slices
+Qout(idVzsl) == 2*F     ! v_slice            V-velocity depth slices
+Qout(idUzsE) == 2*F     ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == 2*F     ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == 2*F     ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == 2*F     ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == 2*F 2*F ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == 2*F     ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == 2*F     ! z_u                time-varying depths of U-points
@@ -1004,6 +1026,17 @@ Dout(iTxdif) == 2*T 2*T ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == 2*T 2*T ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == 2*T 2*T ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == 2*T 2*T ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2703,6 +2736,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2811,7 +2856,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3095,6 +3150,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_dogbone_refined.in
+++ b/ROMS/External/roms_dogbone_refined.in
@@ -671,11 +671,11 @@ Hout(idWdis) == 2*F     ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == 2*F     ! roller_action      wave roller action density
 
 Hout(idPair) == 2*F     ! Pair               surface air pressure
-Hout(idTair) == 2*F     ! Tair               surface air temperature
-Hout(idUair) == 2*F     ! Uwind              surface U-wind
-Hout(idVair) == 2*F     ! Vwind              surface V-wind
-Hout(idUaiE) == 2*F     ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == 2*F     ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == 2*F     ! Tair               near surface air temperature
+Hout(idUair) == 2*F     ! Uwind              near surface U-wind
+Hout(idVair) == 2*F     ! Vwind              near surface V-wind
+Hout(idUaiE) == 2*F     ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == 2*F     ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == 2*F 2*F ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == 2*F     ! latent             latent heat flux
@@ -722,12 +722,12 @@ Qout(idBath) == 2*T     ! bath               time-dependent bathymetry
 
 Qout(idTvar) == 2*F 2*F ! temp, salt         temperature and salinity
 
-Qout(idUsur) == 2*T     ! u_sur              surface U-velocity
-Qout(idVsur) == 2*T     ! v_sur              surface V-velocity
-Qout(idUsuE) == 2*F     ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == 2*F     ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == 2*T     ! u_sur              surface level U-velocity
+Qout(idVsur) == 2*T     ! v_sur              surface level V-velocity
+Qout(idUsuE) == 2*F     ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == 2*F     ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == 2*T 2*T ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == 2*T 2*T ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -796,11 +796,11 @@ Qout(idWdis) == 2*F     ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == 2*F     ! roller_action      wave roller action density
 
 Qout(idPair) == 2*F     ! Pair               surface air pressure
-Qout(idTair) == 2*F     ! Tair               surface air temperature
-Qout(idUair) == 2*F     ! Uair               surface U-wind
-Qout(idVair) == 2*F     ! Vair               surface V-wind
-Qout(idUaiE) == 2*F     ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == 2*F     ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == 2*F     ! Tair               near surface air temperature
+Qout(idUair) == 2*F     ! Uair               near surface U-wind
+Qout(idVair) == 2*F     ! Vair               near surface V-wind
+Qout(idUaiE) == 2*F     ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == 2*F     ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == 2*F 2*F ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == 2*F     ! latent             latent heat flux
@@ -899,11 +899,11 @@ Aout(idWdis) == 2*F     ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == 2*F     ! roller_action      wave roller action density
 
 Aout(idPair) == 2*F     ! Pair               surface air pressure
-Aout(idTair) == 2*F     ! Tair               surface air temperature
-Aout(idUair) == 2*F     ! Uwind              surface U-wind
-Aout(idVair) == 2*F     ! Vwind              surface V-wind
-Aout(idUaiE) == 2*F     ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == 2*F     ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == 2*F     ! Tair               near surface air temperature
+Aout(idUair) == 2*F     ! Uwind              near surface U-wind
+Aout(idVair) == 2*F     ! Vwind              near surface V-wind
+Aout(idUaiE) == 2*F     ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == 2*F     ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == 2*F 2*F ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == 2*F     ! latent             latent heat flux
@@ -2722,15 +2722,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2805,11 +2805,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2838,25 +2838,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2924,11 +2924,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2958,14 +2958,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -3023,11 +3023,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_dogbone_refined.in
+++ b/ROMS/External/roms_dogbone_refined.in
@@ -602,6 +602,18 @@ Hout(idBath) == 2*F     ! bath               time-dependent bathymetry
 
 Hout(idTvar) == 2*T 2*T ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == 2*F     ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == 2*F     ! z_u                time-varying depths of U-points
 Hout(idpthV) == 2*F     ! z_v                time-varying depths of V-points
@@ -716,6 +728,16 @@ Qout(idUsuE) == 2*F     ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == 2*F     ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == 2*T 2*T ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == 2*F     ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == 2*F     ! z_u                time-varying depths of U-points
@@ -1004,6 +1026,17 @@ Dout(iTxdif) == 2*T 2*T ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == 2*T 2*T ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == 2*T 2*T ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == 2*T 2*T ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2703,6 +2736,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2811,7 +2856,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3095,6 +3150,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_dogbone_whole.in
+++ b/ROMS/External/roms_dogbone_whole.in
@@ -1,7 +1,7 @@
 !
 !  ROMS Standard Input parameters.
 !
-! ngit $Id$
+! git $Id$
 !========================================================= Hernan G. Arango ===
 !  Copyright (c) 2002-2025 The ROMS Group                                     !
 !    Licensed under a MIT/X style license                                     !
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 

--- a/ROMS/External/roms_dogbone_whole.in
+++ b/ROMS/External/roms_dogbone_whole.in
@@ -631,11 +631,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -682,12 +682,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -746,11 +746,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -849,11 +849,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2652,19 +2652,31 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
+!
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
@@ -2723,11 +2735,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2756,25 +2768,35 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -2832,11 +2854,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2866,14 +2888,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2931,11 +2953,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.
@@ -3058,6 +3080,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_double_gyre.in
+++ b/ROMS/External/roms_double_gyre.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_double_gyre.in
+++ b/ROMS/External/roms_double_gyre.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_estuary_test.in
+++ b/ROMS/External/roms_estuary_test.in
@@ -574,6 +574,18 @@ Hout(idBath) == T       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_estuary_test.in
+++ b/ROMS/External/roms_estuary_test.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_flt_test2d.in
+++ b/ROMS/External/roms_flt_test2d.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_flt_test2d.in
+++ b/ROMS/External/roms_flt_test2d.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == F F     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == F F     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == F F     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == F F     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == F F     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_flt_test3d.in
+++ b/ROMS/External/roms_flt_test3d.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_flt_test3d.in
+++ b/ROMS/External/roms_flt_test3d.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_grav_adj.in
+++ b/ROMS/External/roms_grav_adj.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_grav_adj.in
+++ b/ROMS/External/roms_grav_adj.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_inlet_test.in
+++ b/ROMS/External/roms_inlet_test.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_inlet_test.in
+++ b/ROMS/External/roms_inlet_test.in
@@ -643,11 +643,11 @@ Hout(idWdis) == T       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == T       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_kelvin.in
+++ b/ROMS/External/roms_kelvin.in
@@ -580,6 +580,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T F     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -694,6 +706,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -982,6 +1004,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2672,6 +2705,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2780,7 +2825,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3064,6 +3119,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_kelvin.in
+++ b/ROMS/External/roms_kelvin.in
@@ -649,11 +649,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -700,12 +700,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -774,11 +774,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -877,11 +877,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2691,15 +2691,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2774,11 +2774,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2807,25 +2807,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2893,11 +2893,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2927,14 +2927,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2992,11 +2992,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_lab_canyon.in
+++ b/ROMS/External/roms_lab_canyon.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_lab_canyon.in
+++ b/ROMS/External/roms_lab_canyon.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_lake_jersey.in
+++ b/ROMS/External/roms_lake_jersey.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_lake_jersey.in
+++ b/ROMS/External/roms_lake_jersey.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_lake_signell.in
+++ b/ROMS/External/roms_lake_signell.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_lake_signell.in
+++ b/ROMS/External/roms_lake_signell.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_lmd_test.in
+++ b/ROMS/External/roms_lmd_test.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_lmd_test.in
+++ b/ROMS/External/roms_lmd_test.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_overflow.in
+++ b/ROMS/External/roms_overflow.in
@@ -629,11 +629,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -680,12 +680,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -744,11 +744,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -847,11 +847,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2650,19 +2650,31 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
+!
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
@@ -2721,11 +2733,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2754,25 +2766,35 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -2830,11 +2852,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2864,14 +2886,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2929,11 +2951,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.
@@ -3056,6 +3078,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_riverplume1.in
+++ b/ROMS/External/roms_riverplume1.in
@@ -574,6 +574,30 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +712,26 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +1020,28 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2732,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2852,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3146,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_riverplume1.in
+++ b/ROMS/External/roms_riverplume1.in
@@ -655,11 +655,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -706,12 +706,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -790,11 +790,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -893,11 +893,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2718,15 +2718,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2801,11 +2801,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2834,25 +2834,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2920,11 +2920,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2954,14 +2954,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -3019,11 +3019,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_riverplume2.in
+++ b/ROMS/External/roms_riverplume2.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_riverplume2.in
+++ b/ROMS/External/roms_riverplume2.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_seamount.in
+++ b/ROMS/External/roms_seamount.in
@@ -640,11 +640,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -691,12 +691,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -738,7 +738,7 @@ Qout(idWbeh) == F       ! bernoulli_head     WEC_VF Bernoulli head adjustment
 Qout(idU2rs) == F       ! ubar_wec_stress    WEC 2D U-stress
 Qout(idV2rs) == F       ! vbar_wec_stress    WEC 2D V-stress
 Qout(idU3rs) == F       ! u_wec_stress       WEC 3D U-stress
-Qout(idV3rs) == F       ! v_wec_stress        WEC 3D V-stress
+Qout(idV3rs) == F       ! v_wec_stress       WEC 3D V-stress
 
 Qout(idU2Sd) == F       ! ubar_stokes        2D Stokes U-velocity
 Qout(idV2Sd) == F       ! vbar_stokes        2D Stokes V-velocity
@@ -765,11 +765,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -868,11 +868,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2682,15 +2682,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2765,11 +2765,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2798,25 +2798,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2884,11 +2884,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2918,14 +2918,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2983,11 +2983,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_seamount.in
+++ b/ROMS/External/roms_seamount.in
@@ -571,6 +571,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -685,6 +697,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -973,6 +995,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2663,6 +2696,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2771,7 +2816,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3055,6 +3110,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_sed_test1.in
+++ b/ROMS/External/roms_sed_test1.in
@@ -574,6 +574,18 @@ Hout(idBath) == T       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_sed_test1.in
+++ b/ROMS/External/roms_sed_test1.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_sed_toy.in
+++ b/ROMS/External/roms_sed_toy.in
@@ -574,6 +574,18 @@ Hout(idBath) == T       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_sed_toy.in
+++ b/ROMS/External/roms_sed_toy.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_shoreface.in
+++ b/ROMS/External/roms_shoreface.in
@@ -1,7 +1,7 @@
 !
 !  ROMS Standard Input parameters.
 !
-! n!ngit $Id$
+! git $Id$
 !========================================================= Hernan G. Arango ===
 !  Copyright (c) 2002-2025 The ROMS Group                                     !
 !    Licensed under a MIT/X style license                                     !
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == F       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == F       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_shoreface.in
+++ b/ROMS/External/roms_shoreface.in
@@ -643,11 +643,11 @@ Hout(idWdis) == T       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == T       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == F       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == F       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == F       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == F       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -741,7 +741,7 @@ Qout(idWbeh) == T       ! bernoulli_head     WEC_VF Bernoulli head adjustment
 Qout(idU2rs) == T       ! ubar_wec_stress    WEC 2D U-stress
 Qout(idV2rs) == T       ! vbar_wec_stress    WEC 2D V-stress
 Qout(idU3rs) == T       ! u_wec_stress       WEC 3D U-stress
-Qout(idV3rs) == T       ! v_wec_stress        WEC 3D V-stress
+Qout(idV3rs) == T       ! v_wec_stress       WEC 3D V-stress
 
 Qout(idU2Sd) == T       ! ubar_stokes        2D Stokes U-velocity
 Qout(idV2Sd) == T       ! vbar_stokes        2D Stokes V-velocity
@@ -768,11 +768,11 @@ Qout(idWdis) == T       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == T       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == T       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == T       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_soliton.in
+++ b/ROMS/External/roms_soliton.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_soliton.in
+++ b/ROMS/External/roms_soliton.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == F F     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == F F     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == F F     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == F F     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == F F     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_test_chan.in
+++ b/ROMS/External/roms_test_chan.in
@@ -643,11 +643,11 @@ Hout(idWdis) == T       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == T       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_test_chan.in
+++ b/ROMS/External/roms_test_chan.in
@@ -574,6 +574,18 @@ Hout(idBath) == T       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_test_head.in
+++ b/ROMS/External/roms_test_head.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_test_head.in
+++ b/ROMS/External/roms_test_head.in
@@ -643,11 +643,11 @@ Hout(idWdis) == T       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == T       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == T F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == T       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_upwelling.in
+++ b/ROMS/External/roms_upwelling.in
@@ -574,6 +574,13 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -987,10 +994,11 @@ Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
 
 ! Number of output field horizontal slices and their depths (negative, m).
 ! It is possible to extract selected state fields like temperature, salinity,
-! and velocity components at a constant depth in the QUICKSAVE NetCDF file.
-! Use wise depth values based on dynamics and model bathymetry and make sure
-! that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE file size
-! manageable. Order "Z_SLICE" in descending values (surface to bottom).
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
 
       NSLICE =  1
      Z_SLICE =  -100.0_r8
@@ -2684,6 +2692,13 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2795,12 +2810,12 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idsurT)   Write out surface temperature and salinity.
 !
-! Qout(idUzsl)   Write out U-velocity depth slices, Z_slice(1:Nslice).
-! Qout(idVzsl)   Write out V-velocity depth slices, Z_slice(1:Nslice).
-! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_slice(1:Nslice).
-! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_slice(1:Nslice).
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
 !
-! Qout(idzslT)   Write out temperature/salinity depth slices, Z_slice(1:Nslice).
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3091,12 +3106,10 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Selected state variables, such as temperature, salinity, U-velocity,
 ! V-velocity, U-eastward, and V-northward, can be extracted and saved at
-! specified constant depths (Z_SLICE) in the output QUICKSAVE NetCDF file.
-! It is advisable to limit the number of slices (NSLICE) to a small value,
-! ideally between 1 and 4, to keep the QUICKSAVE file size manageable.
-! Choose depths wisely based on the dynamics and model bathymetry.
-! Please avoid using Z_SLICE = 0.0, as extraction is performed through
-! linear interpolation, and extrapolations are not permitted.
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
 !
 ! NSLICE       Number of horizontal contant depth slices.
 ! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered

--- a/ROMS/External/roms_upwelling.in
+++ b/ROMS/External/roms_upwelling.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_upwelling.in
+++ b/ROMS/External/roms_upwelling.in
@@ -686,8 +686,16 @@ Qout(idUsur) == T       ! u_sur              surface U-velocity
 Qout(idVsur) == T       ! v_sur              surface V-velocity
 Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idRVsu) == T       ! rvorticity_sur     surface relative vorticity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -870,10 +878,10 @@ Aout(idSdif) == F       ! AKs                vertical Salinity diffusion
 Aout(idHsbl) == F       ! Hsbl               depth of surface boundary layer
 Aout(idHbbl) == F       ! Hbbl               depth of bottom boundary layer
 
-Aout(id2dRV) == F       ! pvorticity_bar     2D relative vorticity
-Aout(id3dRV) == F       ! pvorticity         3D relative vorticity
-Aout(id2dPV) == F       ! rvorticity_bar     2D potential vorticity
-Aout(id3dPV) == F       ! rvorticity         3D potential vorticity
+Aout(id2dRV) == F       ! rvorticity_bar     2D relative vorticity
+Aout(id3dRV) == F       ! rvorticity         3D relative vorticity
+Aout(id2dPV) == F       ! pvorticity_bar     2D potential vorticity
+Aout(id3dPV) == F       ! pvorticity         3D potential vorticity
 
 Aout(idu3dD) == F       ! u_detided          detided 3D U-velocity
 Aout(idv3dD) == F       ! v_detided          detided 3D V-velocity
@@ -976,6 +984,16 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE NetCDF file.
+! Use wise depth values based on dynamics and model bathymetry and make sure
+! that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE file size
+! manageable. Order "Z_SLICE" in descending values (surface to bottom).
+
+      NSLICE =  1
+     Z_SLICE =  -100.0_r8
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2773,8 +2791,16 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idVsur)   Write out surface V-velocity component.
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idRVsu)   Write out surface relative vorticity.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_slice(1:Nslice).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_slice(1:Nslice).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_slice(1:Nslice).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_slice(1:Nslice).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_slice(1:Nslice).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3084,23 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE NetCDF file.
+! It is advisable to limit the number of slices (NSLICE) to a small value,
+! ideally between 1 and 4, to keep the QUICKSAVE file size manageable.
+! Choose depths wisely based on the dynamics and model bathymetry.
+! Please avoid using Z_SLICE = 0.0, as extraction is performed through
+! linear interpolation, and extrapolations are not permitted.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_upwelling.in
+++ b/ROMS/External/roms_upwelling.in
@@ -579,6 +579,11 @@ Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
 Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
 Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
 
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
 Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
@@ -693,7 +698,6 @@ Qout(idUsur) == T       ! u_sur              surface U-velocity
 Qout(idVsur) == T       ! v_sur              surface V-velocity
 Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
-Qout(idRVsu) == T       ! rvorticity_sur     surface relative vorticity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
 
@@ -701,6 +705,9 @@ Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
 Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
 Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
 
 Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
@@ -1000,8 +1007,8 @@ Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
 ! file size manageable. Order "Z_SLICE" in descending values (surface to
 ! bottom).
 
-      NSLICE =  1
-     Z_SLICE =  -100.0_r8
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2699,6 +2706,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2806,7 +2818,6 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idVsur)   Write out surface V-velocity component.
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
-! Qout(idRVsu)   Write out surface relative vorticity.
 !
 ! Qout(idsurT)   Write out surface temperature and salinity.
 !
@@ -2814,6 +2825,9 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
@@ -3114,6 +3128,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! NSLICE       Number of horizontal contant depth slices.
 ! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
 !                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_wc13.in
+++ b/ROMS/External/roms_wc13.in
@@ -574,6 +574,30 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +712,26 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +1020,28 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2672,6 +2738,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2780,7 +2858,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3064,6 +3152,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_wc13.in
+++ b/ROMS/External/roms_wc13.in
@@ -655,11 +655,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == T       ! Pair               surface air pressure
-Hout(idTair) == T       ! Tair               surface air temperature
-Hout(idUair) == T       ! Uwind              surface U-wind
-Hout(idVair) == T       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == T       ! Tair               near surface air temperature
+Hout(idUair) == T       ! Uwind              near surface U-wind
+Hout(idVair) == T       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == T T     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == T       ! latent             latent heat flux
@@ -706,12 +706,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -790,11 +790,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == T       ! Pair               surface air pressure
-Qout(idTair) == T       ! Tair               surface air temperature
-Qout(idUair) == T       ! Uair               surface U-wind
-Qout(idVair) == T       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == T       ! Tair               near surface air temperature
+Qout(idUair) == T       ! Uair               near surface U-wind
+Qout(idVair) == T       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == T T     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == T       ! latent             latent heat flux
@@ -893,11 +893,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2724,15 +2724,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2807,11 +2807,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2840,25 +2840,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2926,11 +2926,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2960,14 +2960,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -3025,11 +3025,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_wc13.in
+++ b/ROMS/External/roms_wc13.in
@@ -586,18 +586,6 @@ Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
 
 Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
-Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
-Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
-Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
-Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
-
-Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
-Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
-Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
-Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
-
-Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
-
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -712,16 +700,6 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
-
-Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
-Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
-Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
-Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
-
-Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
-Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
-
-Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -1020,17 +998,6 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
-
-! Number of output field horizontal slices and their depths (negative, m).
-! It is possible to extract selected state fields like temperature, salinity,
-! and velocity components at a constant depth in the QUICKSAVE and HISTORY
-! NetCDF files. Use wise depth values based on dynamics and model bathymetry
-! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
-! file size manageable. Order "Z_SLICE" in descending values (surface to
-! bottom).
-
-      NSLICE =  0
-     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Number of output field horizontal slices and their depths (negative, m).
 ! It is possible to extract selected state fields like temperature, salinity,

--- a/ROMS/External/roms_weddell.in
+++ b/ROMS/External/roms_weddell.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_weddell.in
+++ b/ROMS/External/roms_weddell.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/roms_windbasin.in
+++ b/ROMS/External/roms_windbasin.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/ROMS/External/roms_windbasin.in
+++ b/ROMS/External/roms_windbasin.in
@@ -643,11 +643,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -694,12 +694,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -741,7 +741,7 @@ Qout(idWbeh) == F       ! bernoulli_head     WEC_VF Bernoulli head adjustment
 Qout(idU2rs) == F       ! ubar_wec_stress    WEC 2D U-stress
 Qout(idV2rs) == F       ! vbar_wec_stress    WEC 2D V-stress
 Qout(idU3rs) == F       ! u_wec_stress       WEC 3D U-stress
-Qout(idV3rs) == F       ! v_wec_stress        WEC 3D V-stress
+Qout(idV3rs) == F       ! v_wec_stress       WEC 3D V-stress
 
 Qout(idU2Sd) == F       ! ubar_stokes        2D Stokes U-velocity
 Qout(idV2Sd) == F       ! vbar_stokes        2D Stokes V-velocity
@@ -768,11 +768,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +871,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/ROMS/External/varinfo.yaml
+++ b/ROMS/External/varinfo.yaml
@@ -215,7 +215,7 @@ metadata:
 
   - variable:       u_slice                                          # Output
     standard_name:  sea_water_surface_x_velocity
-    long_name:      surface u-momentum component
+    long_name:      u-momentum component
     units:          meter second-1                                   # [m/s]
     field:          u-velocity constant depth slice
     time:           ocean_time
@@ -226,7 +226,7 @@ metadata:
 
   - variable:       v_slice                                          # Output
     standard_name:  sea_water_surface_y_velocity
-    long_name:      surface v-momentum component
+    long_name:      v-momentum component
     units:          meter second-1                                   # [m/s]
     field:          v-velocity constant depth slice
     time:           ocean_time
@@ -236,8 +236,8 @@ metadata:
     scale:          1.0d0
 
   - variable:       u_eastward_slice                                 # Output
-    standard_name:  surface_eastward_sea_water_velocity
-    long_name:      surface eastward momentum component at RHO-points
+    standard_name:  eastward_sea_water_velocity
+    long_name:      eastward momentum component at RHO-points
     units:          meter second-1                                   # [m/s]
     field:          u-eastward constant depth slice
     time:           ocean_time
@@ -247,8 +247,8 @@ metadata:
     scale:          1.0d0
 
   - variable:       v_northward_slice                                # Output
-    standard_name:  surface_northward_sea_water_velocity
-    long_name:      surface northward momentum component at RHO-points
+    standard_name:  northward_sea_water_velocity
+    long_name:      northward momentum component at RHO-points
     units:          meter second-1                                   # [m/s]
     field:          v-northward constant depth slice
     time:           ocean_time

--- a/ROMS/External/varinfo.yaml
+++ b/ROMS/External/varinfo.yaml
@@ -40,7 +40,7 @@
 #     field = field (source_units) * scale + add_offset
 #
 
-svn_repository: $URL: https://github.com/myroms/roms/External/varinfo.yaml $
+git_repository: $URL: https://github.com/myroms/roms/External/varinfo.yaml $
 
 convention:     CF 1.10
 
@@ -151,7 +151,7 @@ metadata:
     standard_name:  eastward_sea_water_velocity
     long_name:      eastward momentum component at RHO-points
     units:          meter second-1                                   # [m/s]
-    field:          u-velocity
+    field:          u-eastward
     time:           ocean_time
     index_code:     idu3dE
     type:           r3dvar
@@ -162,7 +162,7 @@ metadata:
     standard_name:  northward_sea_water_velocity
     long_name:      northward momentum component at RHO-points
     units:          meter second-1                                   # [m/s]
-    field:          v-velocity
+    field:          v-northward
     time:           ocean_time
     index_code:     idv3dN
     type:           r3dvar
@@ -195,7 +195,7 @@ metadata:
     standard_name:  surface_eastward_sea_water_velocity
     long_name:      surface eastward momentum component at RHO-points
     units:          meter second-1                                   # [m/s]
-    field:          surface u-velocity
+    field:          surface u-eastward
     time:           ocean_time
     index_code:     idUsuE
     type:           r2dvar
@@ -206,10 +206,54 @@ metadata:
     standard_name:  surface_northward_sea_water_velocity
     long_name:      surface northward momentum component at RHO-points
     units:          meter second-1                                   # [m/s]
-    field:          surface v-velocity
+    field:          surface v-northward
     time:           ocean_time
     index_code:     idVsuN
     type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       u_slice                                          # Output
+    standard_name:  sea_water_surface_x_velocity
+    long_name:      surface u-momentum component
+    units:          meter second-1                                   # [m/s]
+    field:          u-velocity constant depth slice
+    time:           ocean_time
+    index_code:     idUzsl
+    type:           u3dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       v_slice                                          # Output
+    standard_name:  sea_water_surface_y_velocity
+    long_name:      surface v-momentum component
+    units:          meter second-1                                   # [m/s]
+    field:          v-velocity constant depth slice
+    time:           ocean_time
+    index_code:     idVzsl
+    type:           v3dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       u_eastward_slice                                 # Output
+    standard_name:  surface_eastward_sea_water_velocity
+    long_name:      surface eastward momentum component at RHO-points
+    units:          meter second-1                                   # [m/s]
+    field:          u-eastward constant depth slice
+    time:           ocean_time
+    index_code:     idUzsE
+    type:           r3dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       v_northward_slice                                # Output
+    standard_name:  surface_northward_sea_water_velocity
+    long_name:      surface northward momentum component at RHO-points
+    units:          meter second-1                                   # [m/s]
+    field:          v-northward constant depth slice
+    time:           ocean_time
+    index_code:     idVzsN
+    type:           r3dvar
     add_offset:     0.0d0
     scale:          1.0d0
 
@@ -298,6 +342,29 @@ metadata:
     time:           ocean_time
     index_code:     idsurT(isalt)
     type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       temp_slice                                       # Output
+    standard_name:  sea_water_potential_temperature
+    long_name:      potential temperature
+    units:          Celsius                                          # [Celsius]
+    field:          temperature constant depth slices
+    time:           ocean_time
+    index_code:     idzslT(itemp)
+    type:           r3dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       salt_slice                                       # Output
+    standard_name:  sea_water_practical_salinity
+    standard_name:  sea_surface_salinity
+    long_name:      salinity
+    units:          nondimensional                                   # [PSS]
+    field:          salinity constant depth slices
+    time:           ocean_time
+    index_code:     idzslT(isalt)
+    type:           r3dvar
     add_offset:     0.0d0
     scale:          1.0d0
 
@@ -6578,7 +6645,7 @@ metadata:
 
   # 3D Momentum Terms
 
-  - variable:       pvorticity                                       # Input/Output
+  - variable:       pvorticity                                       # Output
     standard_name:  ocean_potential_vorticity
     long_name:      potential vorticity
     units:          meter-1 second-1                                 # [1/m/s]
@@ -6589,7 +6656,7 @@ metadata:
     add_offset:     0.0d0
     scale:          1.0d0
 
-  - variable:       rvorticity                                       # Input/Output
+  - variable:       rvorticity                                       # Output
     standard_name:  ocean_relative_vorticity
     long_name:      relative vorticity, vertical component
     units:          second-1                                         # [1/s]
@@ -6597,6 +6664,17 @@ metadata:
     time:           ocean_time
     index_code:     id3dRV
     type:           p3dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       rvorticity_sur                                   # Output
+    standard_name:  sea_surface_relative_vorticity
+    long_name:      surface relative vorticity
+    units:          second-1                                         # [1/s]
+    field:          relative vorticity
+    time:           ocean_time
+    index_code:     idRVsu
+    type:           p2dvar
     add_offset:     0.0d0
     scale:          1.0d0
 

--- a/ROMS/External/varinfo.yaml
+++ b/ROMS/External/varinfo.yaml
@@ -6358,7 +6358,7 @@ metadata:
   # 2D Momentum Terms
 
   - variable:       pvorticity_bar                                   # Input/Output
-    standard_name:  ocean_barotropic_potential_vorticity
+    standard_name:  sea_water_barotropic_potential_vorticity
     long_name:      2D potential vorticity
     units:          meter-1 second-1                                 # [1/m/s]
     field:          barotropic potential vorticity
@@ -6369,7 +6369,7 @@ metadata:
     scale:          1.0d0
 
   - variable:       rvorticity_bar                                   # Input/Output
-    standard_name:  ocean_barotropic_relative_vorticity
+    standard_name:  sea_water_barotropic_relative_vorticity
     long_name:      2D relative vorticity
     units:          second-1                                         # [1/s]
     field:          barotropic relative vorticity
@@ -6646,7 +6646,7 @@ metadata:
   # 3D Momentum Terms
 
   - variable:       pvorticity                                       # Output
-    standard_name:  ocean_potential_vorticity
+    standard_name:  sea_water_potential_vorticity
     long_name:      potential vorticity
     units:          meter-1 second-1                                 # [1/m/s]
     field:          potential vorticity
@@ -6656,8 +6656,19 @@ metadata:
     add_offset:     0.0d0
     scale:          1.0d0
 
+  - variable:       pvorticity_slice                                 # Output
+    standard_name:  sea_water_potential_vorticity
+    long_name:      potential vorticity
+    units:          meter-1 second-1                                 # [1/m/s]
+    field:          potential vorticity constant depth slice
+    time:           ocean_time
+    index_code:     idPVzs
+    type:           p3dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
   - variable:       rvorticity                                       # Output
-    standard_name:  ocean_relative_vorticity
+    standard_name:  sea_water_relative_vorticity
     long_name:      relative vorticity, vertical component
     units:          second-1                                         # [1/s]
     field:          relative vorticity
@@ -6667,14 +6678,14 @@ metadata:
     add_offset:     0.0d0
     scale:          1.0d0
 
-  - variable:       rvorticity_sur                                   # Output
-    standard_name:  sea_surface_relative_vorticity
+  - variable:       rvorticity_slice                                 # Output
+    standard_name:  sea_water_relative_vorticity
     long_name:      surface relative vorticity
     units:          second-1                                         # [1/s]
-    field:          relative vorticity
+    field:          relative vorticity constant depth slice
     time:           ocean_time
-    index_code:     idRVsu
-    type:           p2dvar
+    index_code:     idRVzs
+    type:           p3dvar
     add_offset:     0.0d0
     scale:          1.0d0
 

--- a/ROMS/Modules/mod_ncparam.F
+++ b/ROMS/Modules/mod_ncparam.F
@@ -262,6 +262,7 @@
       integer  :: idOvil        ! omega vertical velocity implicit
       integer  :: idPair        ! surface air pressure
       integer  :: idPbar        ! streamfunction
+      integer  :: idPVzs        ! potential vorticity depth slices
       integer  :: idPwet        ! wet/dry mask on PSI-points
       integer  :: idpmdx        ! inverse grid x-spacing
       integer  :: idpndy        ! inverse grid y-spacing
@@ -282,7 +283,7 @@
       integer  :: idRv3d        ! RHS of total V-momentum
       integer  :: idRxpo        ! river runoff XI-positions
       integer  :: idRvsh        ! river runoff transport profile
-      integer  :: idRVsu        ! surface relative vorticity
+      integer  :: idRVzs        ! relative vorticity depth slices
       integer  :: idRwet        ! wet/dry mask on RHO-points
       integer  :: idRzet        ! RHS of free-surface
       integer  :: idrain        ! rainfall rate
@@ -1596,6 +1597,10 @@
             idv3dN=varid
           CASE ('idRv3d')
             idRv3d=varid
+          CASE ('idPVzs')
+            idPVzs=varid
+          CASE ('idRVzs')
+            idRVzs=varid
           CASE ('idWvel')
             idWvel=varid
           CASE ('idOvil')
@@ -2076,8 +2081,6 @@
             id3dPV=varid
           CASE ('id3dRV')
             id3dRV=varid
-          CASE ('idRVsu')
-            idRVsu=varid
 #ifdef DIAGNOSTICS_UV
           CASE ('idDu2d(M2pgrd)')
             idDu2d(M2pgrd)=varid

--- a/ROMS/Modules/mod_ncparam.F
+++ b/ROMS/Modules/mod_ncparam.F
@@ -107,7 +107,7 @@
 !  Maximum number of dimension IDs stored in local array DimIDs used to
 !  defined variable dimensions in output NetCDF files.
 !
-      integer, parameter :: nDimID = 33
+      integer, parameter :: nDimID = 34
 !
 !  Number of horizontal interior and boundary water points.
 !
@@ -282,6 +282,7 @@
       integer  :: idRv3d        ! RHS of total V-momentum
       integer  :: idRxpo        ! river runoff XI-positions
       integer  :: idRvsh        ! river runoff transport profile
+      integer  :: idRVsu        ! surface relative vorticity
       integer  :: idRwet        ! wet/dry mask on RHO-points
       integer  :: idRzet        ! RHS of free-surface
       integer  :: idrain        ! rainfall rate
@@ -344,6 +345,8 @@
       integer  :: idUVwc        ! bottom wave-current stress magnitude
       integer  :: idUwav        ! 2D U-velocity Kirby and Chen
       integer  :: idUwet        ! wet/dry mask on U-points
+      integer  :: idUzsE        ! 3D U-eastward constant depth slices
+      integer  :: idUzsl        ! 3D U-velocity constant depth slices
       integer  :: idu2dD        ! detided 2D U-velocity
       integer  :: idu2dH        ! 2D U-velocity tide harmonics
       integer  :: idu2dE        ! 2D eastward velocity at RHO-points
@@ -382,6 +385,8 @@
       integer  :: idVvis        ! vertical viscosity coefficient
       integer  :: idVwav        ! 2D V-velocity Kirby and Chen
       integer  :: idVwet        ! wet/dry mask on V-points
+      integer  :: idVzsN        ! 3D V-northward constant depth slices
+      integer  :: idVzsl        ! 3D V-velocity constant depth slices
       integer  :: idv2dD        ! detided 2D U-velocity
       integer  :: idv2dH        ! 2D U-velocity tide harmonics
       integer  :: idv2dN        ! 2D northward velocity at RHO-points
@@ -444,7 +449,8 @@
 !  Input/output identification tracer indices.
 !
       integer, allocatable :: idRtrc(:)    ! river runoff for tracers
-      integer, allocatable :: idsurT(:)    ! model surface tracers
+      integer, allocatable :: idsurT(:)    ! surface tracers
+      integer, allocatable :: idzslT(:)    ! tracers depth slices
       integer, allocatable :: idTads(:)    ! tracers adjoint sentivity
       integer, allocatable :: idTbot(:)    ! bottom flux for tracers
       integer, allocatable :: idTbry(:,:)  ! tracers boundary
@@ -799,6 +805,10 @@
         allocate ( idsurT(MT) )
         Dmem(1)=Dmem(1)+REAL(MT,r8)
       END IF
+      IF (.not.allocated(idzslT)) THEN
+        allocate ( idzslT(MT) )
+        Dmem(1)=Dmem(1)+REAL(MT,r8)
+      END IF
       IF (.not.allocated(idTads)) THEN
         allocate ( idTads(MT) )
         Dmem(1)=Dmem(1)+REAL(MT,r8)
@@ -1074,6 +1084,7 @@
 !
       IF (allocated(idRtrc))      deallocate ( idRtrc )
       IF (allocated(idsurT))      deallocate ( idsurT )
+      IF (allocated(idsurT))      deallocate ( idzslT )
       IF (allocated(idTads))      deallocate ( idTads )
       IF (allocated(idTbot))      deallocate ( idTbot )
       IF (allocated(idTbry))      deallocate ( idTbry )
@@ -1563,6 +1574,10 @@
             idUsuE=varid
           CASE ('idUvel')
             idUvel=varid
+          CASE ('idUzsl')
+            idUzsl=varid
+          CASE ('idUzsE')
+            idUzsE=varid
           CASE ('idu3dE')
             idu3dE=varid
           CASE ('idRu3d')
@@ -1573,6 +1588,10 @@
             idVsuN=varid
           CASE ('idVvel')
             idVvel=varid
+          CASE ('idVzsl')
+            idVzsl=varid
+          CASE ('idVzsN')
+            idVzsN=varid
           CASE ('idv3dN')
             idv3dN=varid
           CASE ('idRv3d')
@@ -1587,9 +1606,13 @@
             idDano=varid
           CASE ('idsurT(itemp)')
             idsurT(itemp)=varid
+          CASE ('idzslT(itemp)')
+            idzslT(itemp)=varid
 #ifdef SALINITY
           CASE ('idsurT(isalt)')
             idsurT(isalt)=varid
+          CASE ('idzslT(isalt)')
+            idzslT(isalt)=varid
 #endif
           CASE ('idTvar(itemp)')
             idTvar(itemp)=varid
@@ -2053,6 +2076,8 @@
             id3dPV=varid
           CASE ('id3dRV')
             id3dRV=varid
+          CASE ('idRVsu')
+            idRVsu=varid
 #ifdef DIAGNOSTICS_UV
           CASE ('idDu2d(M2pgrd)')
             idDu2d(M2pgrd)=varid

--- a/ROMS/Modules/mod_pio_netcdf.F
+++ b/ROMS/Modules/mod_pio_netcdf.F
@@ -187,8 +187,8 @@
 !
 !  IO descriptor structures for tile decomposition of single and double
 !  precision data. They are used for the mapping between computational
-!  and I/O processes. It describes how the data is distributed on the
-!  computer.
+!  and I/O processes. It describes how the data is distributed on a
+!  tiled parallel application.
 !
       TYPE (IO_desc_t), pointer :: ioDesc_sp_p2dvar(:) ! (i,j)
       TYPE (IO_desc_t), pointer :: ioDesc_sp_r2dvar(:) ! (i,j)
@@ -210,6 +210,11 @@
       TYPE (IO_desc_t), pointer :: ioDesc_sp_u3dvar(:) ! (i,j,N)
       TYPE (IO_desc_t), pointer :: ioDesc_sp_v3dvar(:) ! (i,j,N)
       TYPE (IO_desc_t), pointer :: ioDesc_sp_w3dvar(:) ! (i,j,0:N)
+
+      TYPE (IO_desc_t), pointer :: ioDesZ_sp_p3dvar(:) ! (i,j,Nslice)
+      TYPE (IO_desc_t), pointer :: ioDesZ_sp_r3dvar(:) ! (i,j,Nslice)
+      TYPE (IO_desc_t), pointer :: ioDesZ_sp_u3dvar(:) ! (i,j,Nslice)
+      TYPE (IO_desc_t), pointer :: ioDesZ_sp_v3dvar(:) ! (i,j,Nslice)
 # endif
 # ifdef ADJUST_BOUNDARY
       TYPE (IO_desc_t), pointer :: ioDesc_sp_r2dobc(:) ! (ij,4,Nbrec)
@@ -249,6 +254,11 @@
       TYPE (IO_desc_t), pointer :: ioDesc_dp_u3dvar(:) ! (i,j,N)
       TYPE (IO_desc_t), pointer :: ioDesc_dp_v3dvar(:) ! (i,j,N)
       TYPE (IO_desc_t), pointer :: ioDesc_dp_w3dvar(:) ! (i,j,0:N)
+
+      TYPE (IO_desc_t), pointer :: ioDesZ_dp_p3dvar(:) ! (i,j,Nslice)
+      TYPE (IO_desc_t), pointer :: ioDesZ_dp_r3dvar(:) ! (i,j,Nslice)
+      TYPE (IO_desc_t), pointer :: ioDesZ_dp_u3dvar(:) ! (i,j,Nslice)
+      TYPE (IO_desc_t), pointer :: ioDesZ_dp_v3dvar(:) ! (i,j,Nslice)
 # endif
 # ifdef ADJUST_BOUNDARY
       TYPE (IO_desc_t), pointer :: ioDesc_dp_r2dobc(:) ! (ij,4,Nbrec)

--- a/ROMS/Modules/mod_scalars.F
+++ b/ROMS/Modules/mod_scalars.F
@@ -799,9 +799,19 @@
         real(dp) :: Ritz_tol = 1.0E-15_dp
 #endif
 !
+!  Number of output field horizontal slices and their depths (negative)
+!  in meters. It is possible to extract selected state fields like
+!  temperature, salinity, and velocity components at a constant depth
+!  in the QUICKSAVE NetCDF file. Use wise depth values based on dynamics
+!  and model bathymetry and make sure that "Nslice" is small (between 1
+!  and 4) to keep the QUICKSAVE file sizemanageable.
+!
+        integer :: Nslice = 0
+        real(r8), allocatable :: Zslice(:)
+!
 !  Vector containing USER generic parameters.
 !
-        integer :: Nuser
+        integer :: Nuser = 0
         real(r8), allocatable :: user(:)
 !
 !  Weights for the time average of 2D fields.

--- a/ROMS/Nonlinear/ini_fields.F
+++ b/ROMS/Nonlinear/ini_fields.F
@@ -33,23 +33,24 @@
       USE exchange_3d_mod
 # endif
 # ifdef DISTRIBUTE
-      USE mp_exchange_mod, ONLY : mp_exchange2d
+      USE mp_exchange_mod,   ONLY : mp_exchange2d
 #  ifdef SOLVE3D
-      USE mp_exchange_mod, ONLY : mp_exchange3d, mp_exchange4d
+      USE mp_exchange_mod,   ONLY : mp_exchange3d, mp_exchange4d
 #  else
 #   ifdef PERFECT_RESTART
-      USE mp_exchange_mod, ONLY : mp_exchange3d
+      USE mp_exchange_mod,   ONLY : mp_exchange3d
 #   endif
 #  endif
 # endif
 # ifdef SOLVE3D
-      USE t3dbc_mod,       ONLY : t3dbc_tile
-      USE u3dbc_mod,       ONLY : u3dbc_tile
-      USE v3dbc_mod,       ONLY : v3dbc_tile
+      USE t3dbc_mod,         ONLY : t3dbc_tile
+      USE uv_var_change_mod, ONLY : uv_C2A_grid
+      USE u3dbc_mod,         ONLY : u3dbc_tile
+      USE v3dbc_mod,         ONLY : v3dbc_tile
 # endif
-      USE u2dbc_mod,       ONLY : u2dbc_tile
-      USE v2dbc_mod,       ONLY : v2dbc_tile
-      USE zetabc_mod,      ONLY : zetabc_tile
+      USE u2dbc_mod,         ONLY : u2dbc_tile
+      USE v2dbc_mod,         ONLY : v2dbc_tile
+      USE zetabc_mod,        ONLY : zetabc_tile
 !
       implicit none
 !
@@ -345,6 +346,12 @@
      &                    u(:,:,:,nstp), v(:,:,:,nstp))
 #  endif
 # endif
+!
+!  Compute 3D momentum (ua, va) at RHO-points (A-Grid) for output
+!  purposes and data assimilation where the observations and state
+!  vector is located at the cell-center.
+!
+      CALL uv_C2A_grid (ng, tile, iNLM, nstp)
 
 # ifdef SOLVE3D
 !

--- a/ROMS/Nonlinear/main3d.F
+++ b/ROMS/Nonlinear/main3d.F
@@ -73,8 +73,7 @@
       USE gls_corstep_mod,      ONLY : gls_corstep
       USE gls_prestep_mod,      ONLY : gls_prestep
 # endif
-# if defined NLM_OUTER             || defined RBL4DVAR                 || \
-  defined RBL4DVAR_ANA_SENSITIVITY || defined RBL4DVAR_FCT_SENSITIVITY
+# if defined RBL4DVAR && defined RPCG
       USE frc_iau_mod,          ONLY : frc_iau
 # endif
 # if defined DIFF_3DCOEF || defined VISC_3DCOEF

--- a/ROMS/Nonlinear/omega.F
+++ b/ROMS/Nonlinear/omega.F
@@ -386,9 +386,6 @@
       USE mod_scalars
 !
       USE exchange_3d_mod, ONLY : exchange_w3d_tile
-# ifdef DISTRIBUTE
-      USE mp_exchange_mod, ONLY : mp_exchange3d
-# endif
 !
 !  Imported variable declarations.
 !
@@ -432,14 +429,6 @@
      &                          LBi, UBi, LBj, UBj, LBk, UBk,           &
      &                          Wscl)
       END IF
-
-# ifdef DISTRIBUTE
-      CALL mp_exchange3d (ng, tile, iNLM, 1,                            &
-     &                    LBi, UBi, LBj, UBj, 0, N(ng),                 &
-     &                    NghostPoints,                                 &
-     &                    EWperiodic(ng), NSperiodic(ng),               &
-     &                    Wscl)
-# endif
 !
       RETURN
       END SUBROUTINE scale_omega

--- a/ROMS/Nonlinear/set_avg.F
+++ b/ROMS/Nonlinear/set_avg.F
@@ -63,7 +63,7 @@
 # ifdef PROFILE
       CALL wclock_on (ng, iNLM, 5, __LINE__, MyFile)
 # endif
-      CALL set_avg_tile (ng, tile,                                      &
+      CALL set_avg_tile (ng, tile, iNLM,                                &
      &                   LBi, UBi, LBj, UBj,                            &
      &                   IminS, ImaxS, JminS, JmaxS,                    &
 # ifdef SOLVE3D
@@ -115,7 +115,7 @@
       END SUBROUTINE set_avg
 !
 !***********************************************************************
-      SUBROUTINE set_avg_tile (ng, tile,                                &
+      SUBROUTINE set_avg_tile (ng, tile, model,                         &
      &                         LBi, UBi, LBj, UBj,                      &
      &                         IminS, ImaxS, JminS, JmaxS,              &
 # ifdef SOLVE3D
@@ -159,13 +159,13 @@
 # ifdef SOLVE3D
       USE uv_rotate_mod, ONLY : uv_rotate3d
 # endif
-      USE vorticity_mod, ONLY : vorticity_tile
+      USE vorticity_mod, ONLY : vorticity_avg_tile
 !
       implicit none
 !
 !  Imported variable declarations.
 !
-      integer, intent(in) :: ng, tile
+      integer, intent(in) :: ng, tile, model
       integer, intent(in) :: LBi, UBi, LBj, UBj
       integer, intent(in) :: IminS, ImaxS, JminS, JmaxS
       integer, intent(in) :: Kout
@@ -209,38 +209,38 @@
 !
       IF (Aout(id2dPV,ng).or.Aout(id2dRV,ng).or.                        &
      &    Aout(id3dPV,ng).or.Aout(id3dRV,ng)) THEN
-        CALL vorticity_tile (ng, tile,                                  &
-     &                       LBi, UBi, LBj, UBj,                        &
-     &                       IminS, ImaxS, JminS, JmaxS,                &
+        CALL vorticity_avg_tile (ng, model, tile,                       &
+     &                           LBi, UBi, LBj, UBj,                    &
+     &                           IminS, ImaxS, JminS, JmaxS,            &
 # ifdef SOLVE3D
-     &                       Kout, Nout,                                &
+     &                           Kout, Nout,                            &
 # else
-     &                       Kout,                                      &
+     &                           Kout,                                  &
 # endif
 # ifdef MASKING
-     &                       GRID(ng) % pmask,                          &
-     &                       GRID(ng) % umask,                          &
-     &                       GRID(ng) % vmask,                          &
+     &                           GRID(ng) % pmask,                      &
+     &                           GRID(ng) % umask,                      &
+     &                           GRID(ng) % vmask,                      &
 # endif
-     &                       GRID(ng) % fomn,                           &
-     &                       GRID(ng) % h,                              &
-     &                       GRID(ng) % om_u,                           &
-     &                       GRID(ng) % on_v,                           &
-     &                       GRID(ng) % pm,                             &
-     &                       GRID(ng) % pn,                             &
+     &                           GRID(ng) % f,                          &
+     &                           GRID(ng) % h,                          &
+     &                           GRID(ng) % om_u,                       &
+     &                           GRID(ng) % on_v,                       &
+     &                           GRID(ng) % pm,                         &
+     &                           GRID(ng) % pn,                         &
 # ifdef SOLVE3D
-     &                       GRID(ng) % z_r,                            &
-     &                       OCEAN(ng) % pden,                          &
-     &                       OCEAN(ng) % u,                             &
-     &                       OCEAN(ng) % v,                             &
+     &                           GRID(ng) % z_r,                        &
+     &                           OCEAN(ng) % pden,                      &
+     &                           OCEAN(ng) % u,                         &
+     &                           OCEAN(ng) % v,                         &
 # endif
-     &                       OCEAN(ng) % ubar,                          &
-     &                       OCEAN(ng) % vbar,                          &
-     &                       OCEAN(ng) % zeta,                          &
+     &                           OCEAN(ng) % ubar,                      &
+     &                           OCEAN(ng) % vbar,                      &
+     &                           OCEAN(ng) % zeta,                      &
 # ifdef SOLVE3D
-     &                       potvor, relvor,                            &
+     &                           potvor, relvor,                        &
 # endif
-     &                       potvor_bar, relvor_bar)
+     &                           potvor_bar, relvor_bar)
       END IF
 !
 !-----------------------------------------------------------------------
@@ -3013,7 +3013,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgzeta)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3034,7 +3034,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgu2d)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3055,7 +3055,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgv2d)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3081,7 +3081,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgv2dN)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 2,                      &
+            CALL mp_exchange2d (ng, tile, model, 2,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3106,7 +3106,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgu3d)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3129,7 +3129,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgv3d)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3152,7 +3152,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgu3dE)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3175,7 +3175,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgv3dN)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3198,7 +3198,7 @@
      &                              LBi, UBi, LBj, UBj, 0, N(ng),       &
      &                              AVERAGE(ng)%avgw3d)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 0, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3221,7 +3221,7 @@
      &                              LBi, UBi, LBj, UBj, 0, N(ng),       &
      &                              AVERAGE(ng)%avgwvel)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 0, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3244,7 +3244,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgrho)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3268,7 +3268,7 @@
      &                                LBi, UBi, LBj, UBj, 1, N(ng),     &
      &                                AVERAGE(ng)%avgt(:,:,:,it))
 #  ifdef DISTRIBUTE
-              CALL mp_exchange3d (ng, tile, iNLM, 1,                    &
+              CALL mp_exchange3d (ng, tile, model, 1,                   &
      &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
      &                            NghostPoints,                         &
      &                            EWperiodic(ng), NSperiodic(ng),       &
@@ -3293,7 +3293,7 @@
      &                                LBi, UBi, LBj, UBj,               &
      &                                SEDBED(ng)%avgbedldu(:,:,it))
 #   ifdef DISTRIBUTE
-              CALL mp_exchange2d (ng, tile, iNLM, 1,                    &
+              CALL mp_exchange2d (ng, tile, model, 1,                   &
      &                            LBi, UBi, LBj, UBj,                   &
      &                            NghostPoints,                         &
      &                            EWperiodic(ng), NSperiodic(ng),       &
@@ -3315,7 +3315,7 @@
      &                                LBi, UBi, LBj, UBj,               &
      &                                SEDBED(ng)%avgbedldv(:,:,it))
 #   ifdef DISTRIBUTE
-              CALL mp_exchange2d (ng, tile, iNLM, 1,                    &
+              CALL mp_exchange2d (ng, tile, model, 1,                   &
      &                            LBi, UBi, LBj, UBj,                   &
      &                            NghostPoints,                         &
      &                            EWperiodic(ng), NSperiodic(ng),       &
@@ -3341,7 +3341,7 @@
      &                              LBi, UBi, LBj, UBj, 0, N(ng),       &
      &                              AVERAGE(ng)%avgAKv)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 0, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3364,7 +3364,7 @@
      &                              LBi, UBi, LBj, UBj, 0, N(ng),       &
      &                              AVERAGE(ng)%avgAKt)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 0, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3387,7 +3387,7 @@
      &                              LBi, UBi, LBj, UBj, 0, N(ng),       &
      &                              AVERAGE(ng)%avgAKs)
 #    ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 0, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3411,7 +3411,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avghsbl)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3434,7 +3434,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avghbbl)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3461,7 +3461,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgDU_avg1)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3482,7 +3482,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgDU_avg2)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3503,7 +3503,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgDV_avg1)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3524,7 +3524,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgDV_avg2)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3548,7 +3548,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgsus)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3569,7 +3569,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgsvs)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3590,7 +3590,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgbus)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3611,7 +3611,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgbvs)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3632,7 +3632,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgUbrs)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3652,7 +3652,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgVbrs)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3672,7 +3672,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgUbws)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3692,7 +3692,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgVbws)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3712,7 +3712,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgUbcs)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3732,7 +3732,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgVbcs)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3752,7 +3752,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgUVwc)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3772,7 +3772,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgUbot)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3792,7 +3792,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgVbot)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3812,7 +3812,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgUbur)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3832,7 +3832,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgVbvr)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3855,7 +3855,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgPair)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3878,7 +3878,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgTair)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3901,7 +3901,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgUwind)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3922,7 +3922,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgVwind)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3948,7 +3948,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgVwindN)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 2,                      &
+            CALL mp_exchange2d (ng, tile, model, 2,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3971,7 +3971,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgstf)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -3993,7 +3993,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgswf)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4016,7 +4016,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgsrf)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4039,7 +4039,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avglhf)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4060,7 +4060,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgshf)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4081,7 +4081,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avglrf)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4104,7 +4104,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgevap)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4125,7 +4125,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgrain)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4151,7 +4151,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgu2Sd)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4172,7 +4172,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgv2Sd)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4193,7 +4193,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgu2rs)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4214,7 +4214,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgv2rs)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4239,7 +4239,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgu3Sd)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4262,7 +4262,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgv3Sd)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4285,7 +4285,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgu3rs)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4308,7 +4308,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgv3RS)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4331,7 +4331,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgW3Sd)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4353,7 +4353,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgW3St)
 #   ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4376,7 +4376,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWztw)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4396,7 +4396,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWqsp)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4416,7 +4416,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWbeh)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4438,7 +4438,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWamp)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4458,7 +4458,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWam2)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4480,7 +4480,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWlen)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4502,7 +4502,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWlep)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4524,7 +4524,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWdir)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4546,7 +4546,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWdip)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4568,7 +4568,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWptp)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4590,7 +4590,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWpbt)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4612,7 +4612,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWorb)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4634,7 +4634,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWdif)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4657,7 +4657,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWdib)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4677,7 +4677,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWdiw)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4699,7 +4699,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWbrk)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4721,7 +4721,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWdis)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4741,7 +4741,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgWrol)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4763,7 +4763,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgUwav)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4783,7 +4783,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgVwav)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4807,7 +4807,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgpvor2d)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4828,7 +4828,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgrvor2d)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4852,7 +4852,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgpvor3d)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4875,7 +4875,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgrvor3d)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4899,7 +4899,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgZZ)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4920,7 +4920,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgU2)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4941,7 +4941,7 @@
      &                              LBi, UBi, LBj, UBj,                 &
      &                              AVERAGE(ng)%avgV2)
 # ifdef DISTRIBUTE
-            CALL mp_exchange2d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4965,7 +4965,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgUU)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -4988,7 +4988,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgVV)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -5011,7 +5011,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgUV)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -5034,7 +5034,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgHuon)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -5057,7 +5057,7 @@
      &                              LBi, UBi, LBj, UBj, 1, N(ng),       &
      &                              AVERAGE(ng)%avgHvom)
 #  ifdef DISTRIBUTE
-            CALL mp_exchange3d (ng, tile, iNLM, 1,                      &
+            CALL mp_exchange3d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
@@ -5081,7 +5081,7 @@
      &                                LBi, UBi, LBj, UBj, 1, N(ng),     &
      &                                AVERAGE(ng)%avgTT(:,:,:,it))
 #  ifdef DISTRIBUTE
-              CALL mp_exchange3d (ng, tile, iNLM, 1,                    &
+              CALL mp_exchange3d (ng, tile, model, 1,                   &
      &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
      &                            NghostPoints,                         &
      &                            EWperiodic(ng), NSperiodic(ng),       &
@@ -5104,7 +5104,7 @@
      &                                LBi, UBi, LBj, UBj, 1, N(ng),     &
      &                                AVERAGE(ng)%avgUT(:,:,:,it))
 #  ifdef DISTRIBUTE
-              CALL mp_exchange3d (ng, tile, iNLM, 1,                    &
+              CALL mp_exchange3d (ng, tile, model, 1,                   &
      &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
      &                            NghostPoints,                         &
      &                            EWperiodic(ng), NSperiodic(ng),       &
@@ -5127,7 +5127,7 @@
      &                                LBi, UBi, LBj, UBj, 1, N(ng),     &
      &                                AVERAGE(ng)%avgVT(:,:,:,it))
 #  ifdef DISTRIBUTE
-              CALL mp_exchange3d (ng, tile, iNLM, 1,                    &
+              CALL mp_exchange3d (ng, tile, model, 1,                   &
      &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
      &                            NghostPoints,                         &
      &                            EWperiodic(ng), NSperiodic(ng),       &
@@ -5150,7 +5150,7 @@
      &                                LBi, UBi, LBj, UBj, 1, N(ng),     &
      &                                AVERAGE(ng)%avgHuonT(:,:,:,it))
 #  ifdef DISTRIBUTE
-              CALL mp_exchange3d (ng, tile, iNLM, 1,                    &
+              CALL mp_exchange3d (ng, tile, model, 1,                   &
      &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
      &                            NghostPoints,                         &
      &                            EWperiodic(ng), NSperiodic(ng),       &
@@ -5173,7 +5173,7 @@
      &                                LBi, UBi, LBj, UBj, 1, N(ng),     &
      &                                AVERAGE(ng)%avgHvomT(:,:,:,it))
 #  ifdef DISTRIBUTE
-              CALL mp_exchange3d (ng, tile, iNLM, 1,                    &
+              CALL mp_exchange3d (ng, tile, model, 1,                   &
      &                            LBi, UBi, LBj, UBj, 1, N(ng),         &
      &                            NghostPoints,                         &
      &                            EWperiodic(ng), NSperiodic(ng),       &

--- a/ROMS/Utility/CMakeLists.txt
+++ b/ROMS/Utility/CMakeLists.txt
@@ -55,6 +55,7 @@ list( APPEND _files
       ROMS/Utility/erf.F
       ROMS/Utility/extract_field.F
       ROMS/Utility/extract_obs.F
+      ROMS/Utility/extract_slice.F
       ROMS/Utility/extract_sta.F
       ROMS/Utility/frc_weak.F
       ROMS/Utility/gasdev.F

--- a/ROMS/Utility/def_extract.F
+++ b/ROMS/Utility/def_extract.F
@@ -159,13 +159,10 @@
 #  ifdef SEDIMENT
       integer :: b3dgrd(4)
 #  endif
-      integer :: t3dgrd(4), u3dgrd(4), v3dgrd(4), w3dgrd(4)
+      integer :: p2grd(3), t3dgrd(4), u3dgrd(4), v3dgrd(4), w3dgrd(4)
 #  ifdef ADJUST_BOUNDARY
       integer :: t3dobc(5)
 #  endif
-# endif
-# ifdef WET_DRY
-      integer :: sp2dgrd(3)
 # endif
 !
       real(r8) :: Aval(6)
@@ -405,14 +402,12 @@
         t3dobc(5)=DimIDs(12)
 #  endif
 # endif
-# ifdef WET_DRY
 !
 !  Define dimension vectors for staggered type variables at PSI-points.
 !
-        sp2dgrd(1)=DimIDs( 4)
-        sp2dgrd(2)=DimIDs( 8)
-        sp2dgrd(3)=DimIDs(12)
-# endif
+        p2grd(1)=DimIDs( 4)
+        p2grd(2)=DimIDs( 8)
+        p2grd(3)=DimIDs(12)
 !
 !  Define dimension vectors for staggered u-momentum type variables.
 !
@@ -557,7 +552,7 @@
         Vinfo(22)='coordinates'
         Aval(5)=REAL(Iinfo(1,idPwet,ng),r8)
         status=def_var(ng, model, XTR(ng)%ncid, XTR(ng)%Vid(idPwet),    &
-     &                 NF_FOUT, nvd3, sp2dgrd, Aval, Vinfo, ncname,     &
+     &                 NF_FOUT, nvd3, p2grd, Aval, Vinfo, ncname,       &
      &                 SetFillVal = .FALSE.)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
@@ -2816,13 +2811,10 @@
 #   ifdef SEDIMENT
       integer :: b3dgrd(4)
 #   endif
-      integer :: t3dgrd(4), u3dgrd(4), v3dgrd(4), w3dgrd(4)
+      integer :: p2grd(3), t3dgrd(4), u3dgrd(4), v3dgrd(4), w3dgrd(4)
 #   ifdef ADJUST_BOUNDARY
       integer :: t3dobc(5)
 #   endif
-#  endif
-#  ifdef WET_DRY
-      integer :: sp2dgrd(3)
 #  endif
 !
       real(r8) :: Aval(6)
@@ -3064,14 +3056,12 @@
         t3dobc(5)=DimIDs(12)
 #   endif
 #  endif
-#  ifdef WET_DRY
 !
 !  Define dimension vectors for staggered type variables at PSI-points.
 !
-        sp2dgrd(1)=DimIDs( 4)
-        sp2dgrd(2)=DimIDs( 8)
-        sp2dgrd(3)=DimIDs(12)
-#  endif
+        p2grd(1)=DimIDs( 4)
+        p2grd(2)=DimIDs( 8)
+        p2grd(3)=DimIDs(12)
 !
 !  Define dimension vectors for staggered u-momentum type variables.
 !
@@ -3223,7 +3213,7 @@
 !
         status=def_var(ng, model, XTR(ng)%pioFile,                      &
      &                 XTR(ng)%pioVar(idPwet)%vd,                       &
-     &                 PIO_FOUT, nvd3, sp2dgrd, Aval, Vinfo, ncname,    &
+     &                 PIO_FOUT, nvd3, p2grd, Aval, Vinfo, ncname,      &
      &                 SetFillVal = .FALSE.)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !

--- a/ROMS/Utility/def_his.F
+++ b/ROMS/Utility/def_his.F
@@ -131,7 +131,7 @@
       integer :: IorJdim, brecdim
 #endif
       integer :: DimIDs(nDimID)
-      integer :: t2dgrd(3), u2dgrd(3), v2dgrd(3)
+      integer :: p2dgrd(3), t2dgrd(3), u2dgrd(3), v2dgrd(3)
 #ifdef ADJUST_BOUNDARY
       integer :: t2dobc(4)
 #endif
@@ -140,14 +140,12 @@
 # ifdef SEDIMENT
       integer :: b3dgrd(4)
 # endif
-      integer :: t3dgrd(4),  u3dgrd(4),  v3dgrd(4), w3dgrd(4)
-      integer :: t3dzgrd(4), u3dzgrd(4), v3dzgrd(4)
+      integer :: p3dgrd(4),  t3dgrd(4),  u3dgrd(4),  v3dgrd(4)
+      integer :: p3dzgrd(4), t3dzgrd(4), u3dzgrd(4), v3dzgrd(4)
+      integer :: w3dgrd(4)
 # ifdef ADJUST_BOUNDARY
       integer :: t3dobc(5)
 # endif
-#endif
-#ifdef WET_DRY
-      integer :: sp2dgrd(3)
 #endif
 !
       real(r8) :: Aval(6)
@@ -398,13 +396,22 @@
         t3dobc(5)=DimIDs(12)
 # endif
 #endif
-#ifdef WET_DRY
 !
 !  Define dimension vectors for staggered type variables at PSI-points.
 !
-        sp2dgrd(1)=DimIDs( 4)
-        sp2dgrd(2)=DimIDs( 8)
-        sp2dgrd(3)=DimIDs(12)
+        p2dgrd(1)=DimIDs( 4)
+        p2dgrd(2)=DimIDs( 8)
+        p2dgrd(3)=DimIDs(12)
+#ifdef SOLVE3D
+        p3dgrd(1)=DimIDs( 4)
+        p3dgrd(2)=DimIDs( 8)
+        p3dgrd(3)=DimIDs( 9)
+        p3dgrd(4)=DimIDs(12)
+!
+        p3dzgrd(1)=DimIDs( 4)
+        p3dzgrd(2)=DimIDs( 8)
+        p3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        p3dzgrd(4)=DimIDs(12)
 #endif
 !
 !  Define dimension vectors for staggered u-momentum type variables.
@@ -560,7 +567,7 @@
         Vinfo(22)='coordinates'
         Aval(5)=REAL(Iinfo(1,idPwet,ng),r8)
         status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(idPwet),    &
-     &                 NF_FOUT, nvd3, sp2dgrd, Aval, Vinfo, ncname,     &
+     &                 NF_FOUT, nvd3, p2dgrd, Aval, Vinfo, ncname,      &
      &                 SetFillVal = .FALSE.)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
@@ -1243,6 +1250,84 @@
           Aval(5)=REAL(Iinfo(1,idVzsN,ng),r8)
           status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(idVzsN),  &
      &                   NF_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define model potential vorticity at PSI-points.
+!
+        IF (Hout(id3dPV,ng)) THEN
+          Vinfo( 1)=Vname(1,id3dPV)
+          Vinfo( 2)=Vname(2,id3dPV)
+          Vinfo( 3)=Vname(3,id3dPV)
+          Vinfo(14)=Vname(4,id3dPV)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_psi'
+# endif
+          Vinfo(21)=Vname(6,id3dPV)
+          Vinfo(22)='coordinates'
+          Aval(5)=REAL(Iinfo(1,id3dPV,ng),r8)
+          status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(id3dPV),  &
+     &                   NF_FOUT, nvd4, p3dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define model relative vorticity at PSI-points.
+!
+        IF (Hout(id3dRV,ng)) THEN
+          Vinfo( 1)=Vname(1,id3dRV)
+          Vinfo( 2)=Vname(2,id3dRV)
+          Vinfo( 3)=Vname(3,id3dRV)
+          Vinfo(14)=Vname(4,id3dRV)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_psi'
+# endif
+          Vinfo(21)=Vname(6,id3dRV)
+          Vinfo(22)='coordinates'
+          Aval(5)=REAL(Iinfo(1,id3dRV,ng),r8)
+          status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(id3dRV),  &
+     &                   NF_FOUT, nvd4, p3dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define model potential vorticity at PSI-points for specified constant
+!  depth slices.
+!
+        IF (Hout(idPVzs,ng)) THEN
+          Vinfo( 1)=Vname(1,idPVzs)
+          Vinfo( 2)=Vname(2,idPVzs)
+          Vinfo( 3)=Vname(3,idPVzs)
+          Vinfo(14)=Vname(4,idPVzs)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_psi'
+# endif
+          Vinfo(21)=Vname(6,idPVzs)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idPVzs,ng),r8)
+          status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(idPVzs),  &
+     &                   NF_FOUT, nvd4, p3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define model relative vorticity at PSI-points for specified constant
+!  depth slices.
+!
+        IF (Hout(idRVzs,ng)) THEN
+          Vinfo( 1)=Vname(1,idRVzs)
+          Vinfo( 2)=Vname(2,idRVzs)
+          Vinfo( 3)=Vname(3,idRVzs)
+          Vinfo(14)=Vname(4,idRVzs)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_psi'
+# endif
+          Vinfo(21)=Vname(6,idRVzs)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,id3dRV,ng),r8)
+          status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(idRVzs),  &
+     &                   NF_FOUT, nvd4, p3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
@@ -2253,6 +2338,18 @@
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVzsN))) THEN
             got_var(idVzsN)=.TRUE.
             HIS(ng)%Vid(idVzsN)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,id3dPV))) THEN
+            got_var(id3dPV)=.TRUE.
+            HIS(ng)%Vid(id3dPV)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,id3dRV))) THEN
+            got_var(id3dRV)=.TRUE.
+            HIS(ng)%Vid(id3dRV)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idPVzs))) THEN
+            got_var(idPVzs)=.TRUE.
+            HIS(ng)%Vid(idRVzs)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idRVzs))) THEN
+            got_var(idRVzs)=.TRUE.
+            HIS(ng)%Vid(idRVzs)=var_id(i)
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idWvel))) THEN
             got_var(idWvel)=.TRUE.
             HIS(ng)%Vid(idWvel)=var_id(i)
@@ -2642,6 +2739,30 @@
           exit_flag=3
           RETURN
         END IF
+        IF (.not.got_var(id3dPV).and.Hout(id3dPV,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,id3dPV)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(id3dRV).and.Hout(id3dRV,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,id3dRV)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idPVzs).and.Hout(idPVzs,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idPVzs)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idRVzs).and.Hout(idRVzs,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idRVzs)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
         IF (.not.got_var(idWvel).and.Hout(idWvel,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idWvel)),          &
      &                                  TRIM(ncname)
@@ -2966,7 +3087,7 @@
       integer :: IorJdim, brecdim
 # endif
       integer :: DimIDs(nDimID)
-      integer :: t2dgrd(3), u2dgrd(3), v2dgrd(3)
+      integer :: p2dgrd(3), t2dgrd(3), u2dgrd(3), v2dgrd(3)
 # ifdef ADJUST_BOUNDARY
       integer :: t2dobc(4)
 # endif
@@ -2975,14 +3096,12 @@
 #  ifdef SEDIMENT
       integer :: b3dgrd(4)
 #  endif
-      integer :: t3dgrd(4),  u3dgrd(4),  v3dgrd(4), w3dgrd(4)
-      integer :: t3dzgrd(4), u3dzgrd(4), v3dzgrd(4)
+      integer :: p3dgrd(4),  t3dgrd(4),  u3dgrd(4),  v3dgrd(4)
+      integer :: p3dzgrd(4), t3dzgrd(4), u3dzgrd(4), v3dzgrd(4)
+      integer :: w3dgrd(4)
 #  ifdef ADJUST_BOUNDARY
       integer :: t3dobc(5)
 #  endif
-# endif
-# ifdef WET_DRY
-      integer :: sp2dgrd(3)
 # endif
 !
       real(r8) :: Aval(6)
@@ -3235,13 +3354,22 @@
         t3dobc(5)=DimIDs(12)
 #  endif
 # endif
-# ifdef WET_DRY
 !
 !  Define dimension vectors for staggered type variables at PSI-points.
 !
-        sp2dgrd(1)=DimIDs( 4)
-        sp2dgrd(2)=DimIDs( 8)
-        sp2dgrd(3)=DimIDs(12)
+        p2dgrd(1)=DimIDs( 4)
+        p2dgrd(2)=DimIDs( 8)
+        p2dgrd(3)=DimIDs(12)
+# ifdef SOLVE3D
+        p3dgrd(1)=DimIDs( 4)
+        p3dgrd(2)=DimIDs( 8)
+        p3dgrd(3)=DimIDs( 9)
+        p3dgrd(4)=DimIDs(12)
+!
+        p3dzgrd(1)=DimIDs( 4)
+        p3dzgrd(2)=DimIDs( 8)
+        p3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        p3dzgrd(4)=DimIDs(12)
 # endif
 !
 !  Define dimension vectors for staggered u-momentum type variables.
@@ -3404,7 +3532,7 @@
 !
         status=def_var(ng, model, HIS(ng)%pioFile,                      &
      &                 HIS(ng)%pioVar(idPwet)%vd,                       &
-     &                 PIO_FOUT, nvd3, sp2dgrd, Aval, Vinfo, ncname,    &
+     &                 PIO_FOUT, nvd3, p2dgrd, Aval, Vinfo, ncname,     &
      &                 SetFillVal = .FALSE.)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
@@ -4210,7 +4338,7 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
-!  Define 3D Northward momentum component at RHO-points  for selected
+!  Define 3D Northward momentum component at RHO-points for selected
 !  constant depth slices.
 !
         IF (Hout(idVzsN,ng).and.(Nslice.gt.0)) THEN
@@ -4231,6 +4359,100 @@
           status=def_var(ng, model, HIS(ng)%pioFile,                    &
      &                   HIS(ng)%pioVar(idVzsN)%vd,                     &
      &                   PIO_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define model potential vorticity at PSI-points.
+!
+        IF (Hout(id3dPV,ng)) THEN
+          Vinfo( 1)=Vname(1,id3dPV)
+          Vinfo( 2)=Vname(2,id3dPV)
+          Vinfo( 3)=Vname(3,id3dPV)
+          Vinfo(14)=Vname(4,id3dPV)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_psi'
+#  endif
+          Vinfo(21)=Vname(6,id3dPV)
+          Vinfo(22)='coordinates'
+          Aval(5)=REAL(Iinfo(1,id3dPV,ng),r8)
+          HIS(ng)%pioVar(id3dPV)%dkind=PIO_FOUT
+          HIS(ng)%pioVar(id3dPV)%gtype=p3dvar
+!
+          status=def_var(ng, model, HIS(ng)%pioFile,                    &
+     &                   HIS(ng)%pioVar(id3dPV)%vd,                     &
+     &                   PIO_FOUT, nvd4, p3dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define model relative vorticity at PSI-points.
+!
+        IF (Hout(id3dRV,ng)) THEN
+          Vinfo( 1)=Vname(1,id3dRV)
+          Vinfo( 2)=Vname(2,id3dRV)
+          Vinfo( 3)=Vname(3,id3dRV)
+          Vinfo(14)=Vname(4,id3dRV)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_psi'
+#  endif
+          Vinfo(21)=Vname(6,id3dRV)
+          Vinfo(22)='coordinates'
+          Aval(5)=REAL(Iinfo(1,id3dRV,ng),r8)
+          HIS(ng)%pioVar(id3dRV)%dkind=PIO_FOUT
+          HIS(ng)%pioVar(id3dRV)%gtype=p3dvar
+!
+          status=def_var(ng, model, HIS(ng)%pioFile,                    &
+     &                   HIS(ng)%pioVar(id3dRV)%vd,                     &
+     &                   PIO_FOUT, nvd4, p3dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define model potential vorticity at PSI-points for selected constant
+!  depth slices.
+!
+        IF (Hout(idPVzs,ng)) THEN
+          Vinfo( 1)=Vname(1,idPVzs)
+          Vinfo( 2)=Vname(2,idPVzs)
+          Vinfo( 3)=Vname(3,idPVzs)
+          Vinfo(14)=Vname(4,idPVzs)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_psi'
+#  endif
+          Vinfo(21)=Vname(6,idPVzs)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idPVzs,ng),r8)
+          HIS(ng)%pioVar(idPVzs)%dkind=PIO_FOUT
+          HIS(ng)%pioVar(idPVzs)%gtype=p3dvar
+!
+          status=def_var(ng, model, HIS(ng)%pioFile,                    &
+     &                   HIS(ng)%pioVar(idPVzs)%vd,                     &
+     &                   PIO_FOUT, nvd4, p3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define model relative vorticity at PSI-points for selected constant
+!  depth slices.
+!
+        IF (Hout(idRVzs,ng)) THEN
+          Vinfo( 1)=Vname(1,idRVzs)
+          Vinfo( 2)=Vname(2,idRVzs)
+          Vinfo( 3)=Vname(3,idRVzs)
+          Vinfo(14)=Vname(4,idRVzs)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_psi'
+#  endif
+          Vinfo(21)=Vname(6,idRVzs)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,id3dRV,ng),r8)
+          HIS(ng)%pioVar(idRVzs)%dkind=PIO_FOUT
+          HIS(ng)%pioVar(idRVzs)%gtype=p3dvar
+!
+          status=def_var(ng, model, HIS(ng)%pioFile,                    &
+     &                   HIS(ng)%pioVar(idRVzs)%vd,                     &
+     &                   PIO_FOUT, nvd4, p3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
@@ -5456,6 +5678,26 @@
             HIS(ng)%pioVar(idVzsN)%vd=var_desc(i)
             HIS(ng)%pioVar(idVzsN)%dkind=PIO_FOUT
             HIS(ng)%pioVar(idVzsN)%gtype=r3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,id3dPV))) THEN
+            got_var(id3dPV)=.TRUE.
+            HIS(ng)%pioVar(id3dPV)%vd=var_desc(i)
+            HIS(ng)%pioVar(id3dPV)%dkind=PIO_FOUT
+            HIS(ng)%pioVar(id3dPV)%gtype=p3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,id3dRV))) THEN
+            got_var(id3dRV)=.TRUE.
+            HIS(ng)%pioVar(id3dRV)%vd=var_desc(i)
+            HIS(ng)%pioVar(id3dRV)%dkind=PIO_FOUT
+            HIS(ng)%pioVar(id3dRV)%gtype=p3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idPVzs))) THEN
+            got_var(idPVzs)=.TRUE.
+            HIS(ng)%pioVar(idPVzs)%vd=var_desc(i)
+            HIS(ng)%pioVar(idPVzs)%dkind=PIO_FOUT
+            HIS(ng)%pioVar(idPVzs)%gtype=p3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idRVzs))) THEN
+            got_var(idRVzs)=.TRUE.
+            HIS(ng)%pioVar(idRVzs)%vd=var_desc(i)
+            HIS(ng)%pioVar(idRVzs)%dkind=PIO_FOUT
+            HIS(ng)%pioVar(idRVzs)%gtype=p3dvar
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idWvel))) THEN
             got_var(idWvel)=.TRUE.
             HIS(ng)%pioVar(idWvel)%vd=var_desc(i)
@@ -5907,6 +6149,30 @@
         END IF
         IF (.not.got_var(idVzsN).and.Hout(idVzsN,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idVzsN)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(id3dPV).and.Hout(id3dPV,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,id3dPV)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(id3dRV).and.Hout(id3dRV,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,id3dRV)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idPVzs).and.Hout(idPVzs,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idPVzs)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idRVzs).and.Hout(idRVzs,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idRVzs)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN

--- a/ROMS/Utility/def_his.F
+++ b/ROMS/Utility/def_his.F
@@ -140,7 +140,8 @@
 # ifdef SEDIMENT
       integer :: b3dgrd(4)
 # endif
-      integer :: t3dgrd(4), u3dgrd(4), v3dgrd(4), w3dgrd(4)
+      integer :: t3dgrd(4),  u3dgrd(4),  v3dgrd(4), w3dgrd(4)
+      integer :: t3dzgrd(4), u3dzgrd(4), v3dzgrd(4)
 # ifdef ADJUST_BOUNDARY
       integer :: t3dobc(5)
 # endif
@@ -274,6 +275,12 @@
      &                 N(ng)+1, DimIDs(10))
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
+        IF (Nslice.gt.0) THEN
+          status=def_dim(ng, model, HIS(ng)%ncid, ncname, 'z_slice',    &
+     &                   Nslice, DimIDs(34))
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+
         status=def_dim(ng, model, HIS(ng)%ncid, ncname, 'tracer',       &
      &                 NT(ng), DimIDs(11))
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -371,6 +378,11 @@
         t3dgrd(2)=DimIDs( 5)
         t3dgrd(3)=DimIDs( 9)
         t3dgrd(4)=DimIDs(12)
+!
+        t3dzgrd(1)=DimIDs( 1)
+        t3dzgrd(2)=DimIDs( 5)
+        t3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        t3dzgrd(4)=DimIDs(12)
 # endif
 #endif
 #ifdef ADJUST_BOUNDARY
@@ -413,6 +425,11 @@
         u3dgrd(2)=DimIDs( 6)
         u3dgrd(3)=DimIDs( 9)
         u3dgrd(4)=DimIDs(12)
+!
+        u3dzgrd(1)=DimIDs( 2)
+        u3dzgrd(2)=DimIDs( 6)
+        u3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        u3dzgrd(4)=DimIDs(12)
 # endif
 #endif
 !
@@ -434,6 +451,11 @@
         v3dgrd(2)=DimIDs( 7)
         v3dgrd(3)=DimIDs( 9)
         v3dgrd(4)=DimIDs(12)
+!
+        v3dzgrd(1)=DimIDs( 3)
+        v3dzgrd(2)=DimIDs( 7)
+        v3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        v3dzgrd(4)=DimIDs(12)
 # endif
 #endif
 #ifdef SOLVE3D
@@ -1030,6 +1052,25 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
         END IF
+!
+!  Define 3D U-momentum component at specified constant depth slices.
+!
+        IF (Hout(idUzsl,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idUzsl)
+          Vinfo( 2)=Vname(2,idUzsl)
+          Vinfo( 3)=Vname(3,idUzsl)
+          Vinfo(14)=Vname(4,idUzsl)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_u'
+# endif
+          Vinfo(21)=Vname(6,idUzsl)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idUzsl,ng),r8)
+          status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(idUzsl),  &
+     &                   NF_FOUT, nvd4, u3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
 
 # ifdef ADJUST_BOUNDARY
 !
@@ -1087,6 +1128,25 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
         END IF
+!
+!  Define 3D V-momentum component at specified constant depth slices.
+!
+        IF (Hout(idVzsl,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idVzsl)
+          Vinfo( 2)=Vname(2,idVzsl)
+          Vinfo( 3)=Vname(3,idVzsl)
+          Vinfo(14)=Vname(4,idVzsl)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_v'
+# endif
+          Vinfo(21)=Vname(6,idVzsl)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idVzsl,ng),r8)
+          status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(idVzsl),  &
+     &                   NF_FOUT, nvd4, v3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
 
 # ifdef ADJUST_BOUNDARY
 !
@@ -1127,6 +1187,26 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
+!  Define 3D Eastward momentum component at RHO-point for specified
+!  constant depth slices.
+!
+        IF (Hout(idUzsE,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idUzsE)
+          Vinfo( 2)=Vname(2,idUzsE)
+          Vinfo( 3)=Vname(3,idUzsE)
+          Vinfo(14)=Vname(4,idUzsE)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_rho'
+# endif
+          Vinfo(21)=Vname(6,idUzsE)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idUzsE,ng),r8)
+          status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(idUzsE),  &
+     &                   NF_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
 !  Define 3D Northward momentum at RHO-points, A-grid.
 !
         IF (Hout(idv3dN,ng)) THEN
@@ -1143,6 +1223,26 @@
           Aval(5)=REAL(Iinfo(1,idv3dN,ng),r8)
           status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(idv3dN),  &
      &                   NF_FOUT, nvd4, t3dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define 3D Northward momentum component at RHO-points for specified
+!  constant depth slices.
+!
+        IF (Hout(idVzsN,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idVzsN)
+          Vinfo( 2)=Vname(2,idVzsN)
+          Vinfo( 3)=Vname(3,idVzsN)
+          Vinfo(14)=Vname(4,idVzsN)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_rho'
+# endif
+          Vinfo(21)=Vname(6,idVzsN)
+          Vinfo(22)='coordinates, zslice'
+          Aval(5)=REAL(Iinfo(1,idVzsN,ng),r8)
+          status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(idVzsN),  &
+     &                   NF_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
@@ -1230,6 +1330,35 @@
             Aval(5)=REAL(Iinfo(1,idTvar(itrc),ng),r8)
             status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Tid(itrc),  &
      &                     NF_FOUT, nvd4, t3dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+          END IF
+        END DO
+!
+!  Define tracer type variables at specified depth slices.
+!
+        DO itrc=1,NT(ng)
+          IF (Hout(idzslT(itrc),ng).and.(Nslice.gt.0)) THEN
+            Vinfo( 1)=Vname(1,idzslT(itrc))
+            Vinfo( 2)=Vname(2,idzslT(itrc))
+            Vinfo( 3)=Vname(3,idzslT(itrc))
+            Vinfo(14)=Vname(4,idzslT(itrc))
+            Vinfo(16)=Vname(1,idtime)
+# ifdef SEDIMENT
+            DO i=1,NST
+              IF (itrc.eq.idsed(i)) THEN
+                WRITE (Vinfo(19),50) 1000.0_r8*Sd50(i,ng)
+              END IF
+            END DO
+# endif
+# if defined WRITE_WATER && defined MASKING
+            Vinfo(20)='mask_rho'
+# endif
+            Vinfo(21)=Vname(6,idzslT(itrc))
+            Vinfo(22)='coordinates, z_slice'
+            Aval(5)=REAL(r3dvar,r8)
+            status=def_var(ng, model, HIS(ng)%ncid,                     &
+     &                     HIS(ng)%Vid(idzslT(itrc)),                   &
+     &                     NF_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
         END DO
@@ -2096,6 +2225,12 @@
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVvel))) THEN
             got_var(idVvel)=.TRUE.
             HIS(ng)%Vid(idVvel)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idUzsl))) THEN
+            got_var(idUzsl)=.TRUE.
+            HIS(ng)%Vid(idUzsl)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVzsl))) THEN
+            got_var(idVzsl)=.TRUE.
+            HIS(ng)%Vid(idVzsl)=var_id(i)
 # ifdef ADJUST_BOUNDARY
           ELSE IF (TRIM(var_name(i)).eq.                                &
      &             TRIM(Vname(1,idSbry(isUvel)))) THEN
@@ -2112,6 +2247,12 @@
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idv3dN))) THEN
             got_var(idv3dN)=.TRUE.
             HIS(ng)%Vid(idv3dN)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idUzsE))) THEN
+            got_var(idUzsE)=.TRUE.
+            HIS(ng)%Vid(idUzsE)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVzsN))) THEN
+            got_var(idVzsN)=.TRUE.
+            HIS(ng)%Vid(idVzsN)=var_id(i)
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idWvel))) THEN
             got_var(idWvel)=.TRUE.
             HIS(ng)%Vid(idWvel)=var_id(i)
@@ -2229,6 +2370,12 @@
               got_var(idSbry(isTvar(itrc)))=.TRUE.
               HIS(ng)%Vid(idSbry(isTvar(itrc)))=var_id(i)
 # endif
+            END IF
+          END DO
+          DO itrc=1,NAT
+            IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idzslT(itrc)))) THEN
+              got_var(idzslT(itrc))=.TRUE.
+              HIS(ng)%Vid(idzslT(itrc))=var_id(i)
             END IF
           END DO
           DO itrc=1,NAT
@@ -2445,6 +2592,18 @@
           exit_flag=3
           RETURN
         END IF
+        IF (.not.got_var(idUzsl).and.Hout(idUzsl,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idUzsl)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idVzsl).and.Hout(idVzsl,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idVzsl)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
 # ifdef ADJUST_BOUNDARY
         IF (.not.got_var(idSbry(isUvel))) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idSbry(isUvel))),  &
@@ -2467,6 +2626,18 @@
         END IF
         IF (.not.got_var(idv3dN).and.Hout(idv3dN,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idv3dN)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idUzsE).and.Hout(idUzsE,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idUzsE)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idVzsN).and.Hout(idVzsN,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idVzsN)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
@@ -2681,6 +2852,14 @@
 # endif
         END DO
         DO itrc=1,NAT
+          IF (.not.got_var(idzslT(itrc)).and.Hout(idzslT(itrc),ng)) THEN
+            IF (Master) WRITE (stdout,70) TRIM(Vname(1,idzslT(itrc))),  &
+     &                                    TRIM(ncname)
+            exit_flag=3
+            RETURN
+          END IF
+        END DO
+        DO itrc=1,NAT
           IF (.not.got_var(idTsur(itrc)).and.Hout(idTsur(itrc),ng)) THEN
             IF (Master) WRITE (stdout,70) TRIM(Vname(1,idTsur(itrc))),  &
      &                                    TRIM(ncname)
@@ -2796,7 +2975,8 @@
 #  ifdef SEDIMENT
       integer :: b3dgrd(4)
 #  endif
-      integer :: t3dgrd(4), u3dgrd(4), v3dgrd(4), w3dgrd(4)
+      integer :: t3dgrd(4),  u3dgrd(4),  v3dgrd(4), w3dgrd(4)
+      integer :: t3dzgrd(4), u3dzgrd(4), v3dzgrd(4)
 #  ifdef ADJUST_BOUNDARY
       integer :: t3dobc(5)
 #  endif
@@ -2932,6 +3112,12 @@
      &                 N(ng)+1, DimIDs(10))
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
+        IF (Nslice.gt.0) THEN
+          status=def_dim(ng, model, HIS(ng)%pioFile, ncname, 'z_slice', &
+     &                   Nslice, DimIDs(34))
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+
         status=def_dim(ng, model, HIS(ng)%pioFile, ncname, 'tracer',    &
      &                 NT(ng), DimIDs(11))
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -3029,6 +3215,11 @@
         t3dgrd(2)=DimIDs( 5)
         t3dgrd(3)=DimIDs( 9)
         t3dgrd(4)=DimIDs(12)
+!
+        t3dzgrd(1)=DimIDs( 1)
+        t3dzgrd(2)=DimIDs( 5)
+        t3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        t3dzgrd(4)=DimIDs(12)
 #  endif
 # endif
 # ifdef ADJUST_BOUNDARY
@@ -3071,6 +3262,11 @@
         u3dgrd(2)=DimIDs( 6)
         u3dgrd(3)=DimIDs( 9)
         u3dgrd(4)=DimIDs(12)
+!
+        u3dzgrd(1)=DimIDs( 1)
+        u3dzgrd(2)=DimIDs( 5)
+        u3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        u3dzgrd(4)=DimIDs(12)
 #  endif
 # endif
 !
@@ -3092,6 +3288,11 @@
         v3dgrd(2)=DimIDs( 7)
         v3dgrd(3)=DimIDs( 9)
         v3dgrd(4)=DimIDs(12)
+!
+        v3dzgrd(1)=DimIDs( 1)
+        v3dzgrd(2)=DimIDs( 5)
+        v3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        v3dzgrd(4)=DimIDs(12)
 #  endif
 # endif
 # ifdef SOLVE3D
@@ -3799,6 +4000,29 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #  endif
         END IF
+!
+!  Define 3D U-momentum component at specified constant depth slices.
+!
+        IF (Hout(idUzsl,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idUzsl)
+          Vinfo( 2)=Vname(2,idUzsl)
+          Vinfo( 3)=Vname(3,idUzsl)
+          Vinfo(14)=Vname(4,idUzsl)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_u'
+#  endif
+          Vinfo(21)=Vname(6,idUzsl)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idUzsl,ng),r8)
+          HIS(ng)%pioVar(idUzsl)%dkind=PIO_FOUT
+          HIS(ng)%pioVar(idUzsl)%gtype=u3dvar
+!
+          status=def_var(ng, model, HIS(ng)%pioFile,                    &
+     &                   HIS(ng)%pioVar(idUzsl)%vd,                     &
+     &                   PIO_FOUT, nvd4, u3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
 
 #  ifdef ADJUST_BOUNDARY
 !
@@ -3868,6 +4092,29 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #  endif
         END IF
+!
+!  Define 3D V-momentum component at specified constant depth slices.
+!
+        IF (Hout(idVzsl,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idVzsl)
+          Vinfo( 2)=Vname(2,idVzsl)
+          Vinfo( 3)=Vname(3,idVzsl)
+          Vinfo(14)=Vname(4,idVzsl)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_v'
+#  endif
+          Vinfo(21)=Vname(6,idVzsl)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idVzsl,ng),r8)
+          HIS(ng)%pioVar(idVzsl)%dkind=PIO_FOUT
+          HIS(ng)%pioVar(idVzsl)%gtype=v3dvar
+!
+          status=def_var(ng, model, HIS(ng)%pioFile,                    &
+     &                   HIS(ng)%pioVar(idVzsl)%vd,                     &
+     &                   PIO_FOUT, nvd4, v3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
 
 #  ifdef ADJUST_BOUNDARY
 !
@@ -3916,6 +4163,30 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
+!  Define 3D Eastward momentum component at RHO-points for selected
+!  constant depth slices.
+!
+        IF (Hout(idUzsE,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idUzsE)
+          Vinfo( 2)=Vname(2,idUzsE)
+          Vinfo( 3)=Vname(3,idUzsE)
+          Vinfo(14)=Vname(4,idUzsE)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_rho'
+#  endif
+          Vinfo(21)=Vname(6,idUzsE)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idUzsE,ng),r8)
+          HIS(ng)%pioVar(idUzsE)%dkind=PIO_FOUT
+          HIS(ng)%pioVar(idUzsE)%gtype=r3dvar
+!
+          status=def_var(ng, model, HIS(ng)%pioFile,                    &
+     &                   HIS(ng)%pioVar(idUzsE)%vd,                     &
+     &                   PIO_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
 !  Define 3D Northward momentum at RHO-points, A-grid.
 !
         IF (Hout(idv3dN,ng)) THEN
@@ -3936,6 +4207,30 @@
           status=def_var(ng, model, HIS(ng)%pioFile,                    &
      &                   HIS(ng)%pioVar(idv3dN)%vd,                     &
      &                   PIO_FOUT, nvd4, t3dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define 3D Northward momentum component at RHO-points  for selected
+!  constant depth slices.
+!
+        IF (Hout(idVzsN,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idVzsN)
+          Vinfo( 2)=Vname(2,idVzsN)
+          Vinfo( 3)=Vname(3,idVzsN)
+          Vinfo(14)=Vname(4,idVzsN)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_rho'
+#  endif
+          Vinfo(21)=Vname(6,idVzsN)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idVzsN,ng),r8)
+          HIS(ng)%pioVar(idVzsN)%dkind=PIO_FOUT
+          HIS(ng)%pioVar(idVzsN)%gtype=r3dvar
+!
+          status=def_var(ng, model, HIS(ng)%pioFile,                    &
+     &                   HIS(ng)%pioVar(idVzsN)%vd,                     &
+     &                   PIO_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
@@ -4039,6 +4334,38 @@
             status=def_var(ng, model, HIS(ng)%pioFile,                  &
      &                     HIS(ng)%pioTrc(itrc)%vd,                     &
      &                     PIO_FOUT, nvd4, t3dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+          END IF
+        END DO
+!
+!  Define surface tracer type variables at specified depth slices.
+!
+        DO itrc=1,NT(ng)
+          IF (Hout(idzslT(itrc),ng).and.(Nslice.gt.0)) THEN
+            Vinfo( 1)=Vname(1,idzslT(itrc))
+            Vinfo( 2)=Vname(2,idzslT(itrc))
+            Vinfo( 3)=Vname(3,idzslT(itrc))
+            Vinfo(14)=Vname(4,idzslT(itrc))
+            Vinfo(16)=Vname(1,idtime)
+#  ifdef SEDIMENT
+            DO i=1,NST
+              IF (itrc.eq.idsed(i)) THEN
+                WRITE (Vinfo(19),50) 1000.0_r8*Sd50(i,ng)
+              END IF
+            END DO
+#  endif
+#  if defined WRITE_WATER && defined MASKING
+            Vinfo(20)='mask_rho'
+#  endif
+            Vinfo(21)=Vname(6,idzslT(itrc))
+            Vinfo(22)='coordinates, z_slice'
+            Aval(5)=REAL(r3dvar,r8)
+            HIS(ng)%pioVar(idzslT(itrc))%dkind=PIO_FOUT
+            HIS(ng)%pioVar(idzslT(itrc))%gtype=r2dvar
+!
+            status=def_var(ng, model, HIS(ng)%pioFile,                  &
+     &                     HIS(ng)%pioVar(idzslT(itrc))%vd,             &
+     &                     PIO_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
         END DO
@@ -5085,6 +5412,16 @@
             HIS(ng)%pioVar(idVvel)%vd=var_desc(i)
             HIS(ng)%pioVar(idVvel)%dkind=PIO_FOUT
             HIS(ng)%pioVar(idVvel)%gtype=v3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idUzsl))) THEN
+            got_var(idUzsl)=.TRUE.
+            HIS(ng)%pioVar(idUzsl)%vd=var_desc(i)
+            HIS(ng)%pioVar(idUzsl)%dkind=PIO_FOUT
+            HIS(ng)%pioVar(idUzsl)%gtype=u3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVzsl))) THEN
+            got_var(idVzsl)=.TRUE.
+            HIS(ng)%pioVar(idVzsl)%vd=var_desc(i)
+            HIS(ng)%pioVar(idVzsl)%dkind=PIO_FOUT
+            HIS(ng)%pioVar(idVzsl)%gtype=v3dvar
 #  ifdef ADJUST_BOUNDARY
           ELSE IF (TRIM(var_name(i)).eq.                                &
      &             TRIM(Vname(1,idSbry(isUvel)))) THEN
@@ -5109,6 +5446,16 @@
             HIS(ng)%pioVar(idv3dN)%vd=var_desc(i)
             HIS(ng)%pioVar(idv3dN)%dkind=PIO_FOUT
             HIS(ng)%pioVar(idv3dN)%gtype=r3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idUzsE))) THEN
+            got_var(idUzsE)=.TRUE.
+            HIS(ng)%pioVar(idUzsE)%vd=var_desc(i)
+            HIS(ng)%pioVar(idUzsE)%dkind=PIO_FOUT
+            HIS(ng)%pioVar(idUzsE)%gtype=r3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVzsN))) THEN
+            got_var(idVzsN)=.TRUE.
+            HIS(ng)%pioVar(idVzsN)%vd=var_desc(i)
+            HIS(ng)%pioVar(idVzsN)%dkind=PIO_FOUT
+            HIS(ng)%pioVar(idVzsN)%gtype=r3dvar
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idWvel))) THEN
             got_var(idWvel)=.TRUE.
             HIS(ng)%pioVar(idWvel)%vd=var_desc(i)
@@ -5286,6 +5633,14 @@
               HIS(ng)%pioVar(idSbry(isTvar(itrc)))%dkind=PIO_FOUT
               HIS(ng)%pioVar(idSbry(isTvar(itrc)))%gtype=r3dobc
 #  endif
+            END IF
+          END DO
+          DO itrc=1,NAT
+            IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idzslT(itrc)))) THEN
+              got_var(idzslT(itrc))=.TRUE.
+              HIS(ng)%pioVar(idzslT(itrc))%vd=var_desc(i)
+              HIS(ng)%pioVar(idzslT(itrc))%dkind=PIO_FOUT
+              HIS(ng)%pioVar(idzslT(itrc))%gtype=r3dvar
             END IF
           END DO
           DO itrc=1,NAT
@@ -5506,6 +5861,18 @@
           exit_flag=3
           RETURN
         END IF
+        IF (.not.got_var(idUzsl).and.Hout(idUzsl,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idUzsl)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idVzsl).and.Hout(idVzsl,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idVzsl)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
 #  ifdef ADJUST_BOUNDARY
         IF (.not.got_var(idSbry(isUvel))) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idSbry(isUvel))),  &
@@ -5528,6 +5895,18 @@
         END IF
         IF (.not.got_var(idv3dN).and.Hout(idv3dN,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idv3dN)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idUzsE).and.Hout(idUzsE,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idUzsE)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idVzsN).and.Hout(idVzsN,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idVzsN)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
@@ -5740,6 +6119,14 @@
             RETURN
           END IF
 #  endif
+        END DO
+        DO itrc=1,NAT
+          IF (.not.got_var(idzslT(itrc)).and.Hout(idzslT(itrc),ng)) THEN
+            IF (Master) WRITE (stdout,70) TRIM(Vname(1,idzslT(itrc))),  &
+     &                                    TRIM(ncname)
+            exit_flag=3
+            RETURN
+          END IF
         END DO
         DO itrc=1,NAT
           IF (.not.got_var(idTsur(itrc)).and.Hout(idTsur(itrc),ng)) THEN

--- a/ROMS/Utility/def_info.F
+++ b/ROMS/Utility/def_info.F
@@ -45,6 +45,7 @@
 !    DimIDs(31) => Number of 2D variables time levels (3)              !
 !    DimIDs(32) => Number of sediment tracers                          !
 !    DimIDs(33) => Number of light spectral bands.                     !
+!    DimIDs(34) => Number constant depth slices in 'extract_slice'.    !
 !                                                                      !
 !=======================================================================
 !
@@ -118,7 +119,7 @@
       integer, parameter :: Natt = 25
 
       integer :: brydim, i, ie, is, j, lstr, varid
-      integer :: srdim, stadim, status, swdim, trcdim, usrdim
+      integer :: slicedim, srdim, stadim, status, swdim, trcdim, usrdim
 #ifdef SEDIMENT
       integer :: seddim
 #endif
@@ -170,6 +171,7 @@
       srdim=DimIDs(9)
       swdim=DimIDs(10)
       trcdim=DimIDs(11)
+      slicedim=DimIDs(34)
 #ifdef SEDIMENT
       seddim=DimIDs(32)
 #endif
@@ -3137,6 +3139,19 @@
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #endif
 !
+!  Depth of horizontal slices.
+!
+      IF (Nslice.gt.0) THEN
+        Vinfo( 1)='z_slice'
+        Vinfo( 2)='constant depth of output fields horizontal slices'
+        Vinfo(24)='_FillValue'
+        Aval(6)=spval
+        status=def_var(ng, model, ncid, varid, NF_TYPE,                 &
+     &                 1, (/slicedim/), Aval, Vinfo, ncname,            &
+     &               SetParAccess = .FALSE.)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      END IF
+!
 !  User generic parameters.
 !
       IF (Nuser.gt.0) THEN
@@ -3652,7 +3667,7 @@
       integer, parameter :: Natt = 25
 
       integer :: brydim, FileH, i, ie, is, j, lstr
-      integer :: srdim, stadim, status, swdim, trcdim, usrdim
+      integer :: slicedim, srdim, stadim, status, swdim, trcdim, usrdim
 # ifdef SEDIMENT
       integer :: seddim
 # endif
@@ -3706,6 +3721,7 @@
       srdim=DimIDs(9)
       swdim=DimIDs(10)
       trcdim=DimIDs(11)
+      slicedim=DimIDs(34)
 # ifdef SEDIMENT
       seddim=DimIDs(32)
 # endif
@@ -6611,6 +6627,19 @@
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
 !
+!  Depth of horizontal slices.
+!
+      IF (Nslice.gt.0) THEN
+        Vinfo( 1)='z_slice'
+        Vinfo( 2)='constant depth of output fields horizontal slices'
+        Vinfo(24)='_FillValue'
+        Aval(6)=spval
+        status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,            &
+     &                 1, (/slicedim/), Aval, Vinfo, ncname,            &
+     &                 SetParAccess = .FALSE.)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      END IF
+!
 !  User generic parameters.
 !
       IF (Nuser.gt.0) THEN
@@ -6620,7 +6649,7 @@
         Aval(6)=spval
         status=def_var(ng, model, pioFile, pioVar, PIO_TYPE,            &
      &                 1, (/usrdim/), Aval, Vinfo, ncname,              &
-     &               SetParAccess = .FALSE.)
+     &                 SetParAccess = .FALSE.)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
       END IF
 # ifdef STATIONS

--- a/ROMS/Utility/def_quick.F
+++ b/ROMS/Utility/def_quick.F
@@ -131,16 +131,14 @@
       integer :: IorJdim
 #endif
       integer :: DimIDs(nDimID)
-      integer :: t2dgrd(3), u2dgrd(3), v2dgrd(3)
+      integer :: t2dgrd(3), sp2dgrd(3), u2dgrd(3), v2dgrd(3)
 
 #ifdef SOLVE3D
 # ifdef SEDIMENT
       integer :: b3dgrd(4)
 # endif
-      integer :: t3dgrd(4), u3dgrd(4), v3dgrd(4), w3dgrd(4)
-#endif
-#ifdef WET_DRY
-      integer :: sp2dgrd(3)
+      integer :: t3dgrd(4),  u3dgrd(4),  v3dgrd(4), w3dgrd(4)
+      integer :: t3dzgrd(4), u3dzgrd(4), v3dzgrd(4)
 #endif
 !
       real(r8) :: Aval(6)
@@ -268,6 +266,12 @@
      &                 N(ng)+1, DimIDs(10))
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
+        IF (Nslice.gt.0) THEN
+          status=def_dim(ng, model, QCK(ng)%ncid, ncname, 'z_slice',    &
+     &                   Nslice, DimIDs(34))
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+
         status=def_dim(ng, model, QCK(ng)%ncid, ncname, 'tracer',       &
      &                 NT(ng), DimIDs(11))
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -362,16 +366,19 @@
         t3dgrd(2)=DimIDs( 5)
         t3dgrd(3)=DimIDs( 9)
         t3dgrd(4)=DimIDs(12)
+!
+        t3dzgrd(1)=DimIDs( 1)
+        t3dzgrd(2)=DimIDs( 5)
+        t3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        t3dzgrd(4)=DimIDs(12)
 # endif
 #endif
-#ifdef WET_DRY
 !
 !  Define dimension vectors for staggered type variables at PSI-points.
 !
         sp2dgrd(1)=DimIDs( 4)
         sp2dgrd(2)=DimIDs( 8)
         sp2dgrd(3)=DimIDs(12)
-#endif
 !
 !  Define dimension vectors for staggered u-momentum type variables.
 !
@@ -391,6 +398,11 @@
         u3dgrd(2)=DimIDs( 6)
         u3dgrd(3)=DimIDs( 9)
         u3dgrd(4)=DimIDs(12)
+!
+        u3dzgrd(1)=DimIDs( 2)
+        u3dzgrd(2)=DimIDs( 6)
+        u3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        u3dzgrd(4)=DimIDs(12)
 # endif
 #endif
 !
@@ -412,6 +424,11 @@
         v3dgrd(2)=DimIDs( 7)
         v3dgrd(3)=DimIDs( 9)
         v3dgrd(4)=DimIDs(12)
+!
+        v3dzgrd(1)=DimIDs( 3)
+        v3dzgrd(2)=DimIDs( 7)
+        v3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        v3dzgrd(4)=DimIDs(12)
 # endif
 #endif
 #ifdef SOLVE3D
@@ -813,6 +830,44 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
+!  Define 3D U-momentum component at specified constant depth slices.
+!
+        IF (Qout(idUzsl,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idUzsl)
+          Vinfo( 2)=Vname(2,idUzsl)
+          Vinfo( 3)=Vname(3,idUzsl)
+          Vinfo(14)=Vname(4,idUzsl)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_u'
+# endif
+          Vinfo(21)=Vname(6,idUzsl)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idUzsl,ng),r8)
+          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idUzsl),  &
+     &                   NF_FOUT, nvd4, u3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define 3D V-momentum component at specified constant depth slices.
+!
+        IF (Qout(idVzsl,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idVzsl)
+          Vinfo( 2)=Vname(2,idVzsl)
+          Vinfo( 3)=Vname(3,idVzsl)
+          Vinfo(14)=Vname(4,idVzsl)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_v'
+# endif
+          Vinfo(21)=Vname(6,idVzsl)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idVzsl,ng),r8)
+          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idVzsl),  &
+     &                   NF_FOUT, nvd4, v3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
 !  Define 3D Eastward momentum component at RHO-points.
 !
         IF (Qout(idu3dE,ng)) THEN
@@ -886,6 +941,65 @@
           Aval(5)=REAL(Iinfo(1,idVsuN,ng),r8)
           status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idVsuN),  &
      &                   NF_FOUT, nvd3, t2dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define 3D Eastward momentum component at RHO-point for specified
+!  constant depth slices.
+!
+        IF (Qout(iduzsE,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,iduzsE)
+          Vinfo( 2)=Vname(2,iduzsE)
+          Vinfo( 3)=Vname(3,iduzsE)
+          Vinfo(14)=Vname(4,iduzsE)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_rho'
+# endif
+          Vinfo(21)=Vname(6,iduzsE)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,iduzsE,ng),r8)
+          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(iduzsE),  &
+     &                   NF_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define 3D Northward momentum component at RHO-points for specified
+!  constant depth slices.
+!
+        IF (Qout(idvzsN,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idvzsN)
+          Vinfo( 2)=Vname(2,idvzsN)
+          Vinfo( 3)=Vname(3,idvzsN)
+          Vinfo(14)=Vname(4,idvzsN)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_rho'
+# endif
+          Vinfo(21)=Vname(6,idvzsN)
+          Vinfo(22)='coordinates, zslice'
+          Aval(5)=REAL(Iinfo(1,idvzsN,ng),r8)
+          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idvzsN),  &
+     &                   NF_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define model surface relative vorticity at PSI-points.
+!
+        IF (Qout(idRVsu,ng)) THEN
+          Vinfo( 1)=Vname(1,idRVsu)
+          Vinfo( 2)=Vname(2,idRVsu)
+          Vinfo( 3)=Vname(3,idRVsu)
+          Vinfo(14)=Vname(4,idRVsu)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_psi'
+# endif
+          Vinfo(21)=Vname(6,idRVsu)
+          Vinfo(22)='coordinates'
+          Aval(5)=REAL(Iinfo(1,idRVsu,ng),r8)
+          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idRVsu),  &
+     &                   NF_FOUT, nvd3, sp2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
@@ -980,6 +1094,35 @@
             status=def_var(ng, model, QCK(ng)%ncid,                     &
      &                     QCK(ng)%Vid(idsurT(itrc)),                   &
      &                     NF_FOUT, nvd3, t2dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+          END IF
+        END DO
+!
+!  Define tracer type variables at specified depth slices.
+!
+        DO itrc=1,NT(ng)
+          IF (Qout(idzslT(itrc),ng).and.(Nslice.gt.0)) THEN
+            Vinfo( 1)=Vname(1,idzslT(itrc))
+            Vinfo( 2)=Vname(2,idzslT(itrc))
+            Vinfo( 3)=Vname(3,idzslT(itrc))
+            Vinfo(14)=Vname(4,idzslT(itrc))
+            Vinfo(16)=Vname(1,idtime)
+# ifdef SEDIMENT
+            DO i=1,NST
+              IF (itrc.eq.idsed(i)) THEN
+                WRITE (Vinfo(19),50) 1000.0_r8*Sd50(i,ng)
+              END IF
+            END DO
+# endif
+# if defined WRITE_WATER && defined MASKING
+            Vinfo(20)='mask_rho'
+# endif
+            Vinfo(21)=Vname(6,idzslT(itrc))
+            Vinfo(22)='coordinates, z_slice'
+            Aval(5)=REAL(r3dvar,r8)
+            status=def_var(ng, model, QCK(ng)%ncid,                     &
+     &                     QCK(ng)%Vid(idzslT(itrc)),                   &
+     &                     NF_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
         END DO
@@ -1688,6 +1831,12 @@
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVsur))) THEN
             got_var(idVsur)=.TRUE.
             QCK(ng)%Vid(idVsur)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idUzsl))) THEN
+            got_var(idUzsl)=.TRUE.
+            QCK(ng)%Vid(idUzsl)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVzsl))) THEN
+            got_var(idVzsl)=.TRUE.
+            QCK(ng)%Vid(idVzsl)=var_id(i)
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idu3dE))) THEN
             got_var(idu3dE)=.TRUE.
             QCK(ng)%Vid(idu3dE)=var_id(i)
@@ -1700,6 +1849,15 @@
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVsuN))) THEN
             got_var(idVsuN)=.TRUE.
             QCK(ng)%Vid(idVsuN)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idUzsE))) THEN
+            got_var(idUzsE)=.TRUE.
+            QCK(ng)%Vid(idUzsE)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVzsN))) THEN
+            got_var(idVzsN)=.TRUE.
+            QCK(ng)%Vid(idVzsN)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idRVsu))) THEN
+            got_var(idRVsu)=.TRUE.
+            QCK(ng)%Vid(idRVsu)=var_id(i)
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idWvel))) THEN
             got_var(idWvel)=.TRUE.
             QCK(ng)%Vid(idWvel)=var_id(i)
@@ -1816,6 +1974,12 @@
             IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idTsur(itrc)))) THEN
               got_var(idTsur(itrc))=.TRUE.
               QCK(ng)%Vid(idTsur(itrc))=var_id(i)
+            END IF
+          END DO
+          DO itrc=1,NAT
+            IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idzslT(itrc)))) THEN
+              got_var(idzslT(itrc))=.TRUE.
+              QCK(ng)%Vid(idzslT(itrc))=var_id(i)
             END IF
           END DO
 #endif
@@ -1937,6 +2101,18 @@
           exit_flag=3
           RETURN
         END IF
+        IF (.not.got_var(idUzsl).and.Qout(idUzsl,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idUzsl)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idVzsl).and.Qout(idVzsl,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idVzsl)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
         IF (.not.got_var(idu3dE).and.Qout(idu3dE,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idu3dE)),          &
      &                                  TRIM(ncname)
@@ -1957,6 +2133,24 @@
         END IF
         IF (.not.got_var(idVsuN).and.Qout(idVsuN,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idVsuN)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idUzsE).and.Qout(idUzsE,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idUzsE)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idVzsN).and.Qout(idVzsN,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idVzsN)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idRVsu).and.Qout(idRVsu,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idRVsu)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
@@ -2167,6 +2361,14 @@
             RETURN
           END IF
         END DO
+        DO itrc=1,NAT
+          IF (.not.got_var(idzslT(itrc)).and.Qout(idzslT(itrc),ng)) THEN
+            IF (Master) WRITE (stdout,70) TRIM(Vname(1,idzslT(itrc))),  &
+     &                                    TRIM(ncname)
+            exit_flag=3
+            RETURN
+          END IF
+        END DO
 #endif
 
 #if (defined BBL_MODEL || defined WAVES_OUTPUT) && defined SOLVE3D
@@ -2257,16 +2459,14 @@
       integer :: IorJdim
 # endif
       integer :: DimIDs(nDimID)
-      integer :: t2dgrd(3), u2dgrd(3), v2dgrd(3)
+      integer :: t2dgrd(3), sp2dgrd(3), u2dgrd(3), v2dgrd(3)
 
 # ifdef SOLVE3D
 #  ifdef SEDIMENT
       integer :: b3dgrd(4)
 #  endif
-      integer :: t3dgrd(4), u3dgrd(4), v3dgrd(4), w3dgrd(4)
-# endif
-# ifdef WET_DRY
-      integer :: sp2dgrd(3)
+      integer :: t3dgrd(4),  u3dgrd(4),  v3dgrd(4), w3dgrd(4)
+      integer :: t3dzgrd(4), u3dzgrd(4), v3dzgrd(4)
 # endif
 !
       real(r8) :: Aval(6)
@@ -2394,6 +2594,12 @@
      &                 N(ng)+1, DimIDs(10))
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
+        IF (Nslice.gt.0) THEN
+          status=def_dim(ng, model, QCK(ng)%pioFile, ncname, 'z_slice', &
+     &                   Nslice, DimIDs(34))
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+
         status=def_dim(ng, model, QCK(ng)%pioFile, ncname, 'tracer',    &
      &                 NT(ng), DimIDs(11))
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
@@ -2488,16 +2694,19 @@
         t3dgrd(2)=DimIDs( 5)
         t3dgrd(3)=DimIDs( 9)
         t3dgrd(4)=DimIDs(12)
+!
+        t3dzgrd(1)=DimIDs( 1)
+        t3dzgrd(2)=DimIDs( 5)
+        t3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        t3dzgrd(4)=DimIDs(12)
 #  endif
 # endif
-# ifdef WET_DRY
 !
 !  Define dimension vectors for staggered type variables at PSI-points.
 !
         sp2dgrd(1)=DimIDs( 4)
         sp2dgrd(2)=DimIDs( 8)
         sp2dgrd(3)=DimIDs(12)
-# endif
 !
 !  Define dimension vectors for staggered u-momentum type variables.
 !
@@ -2517,6 +2726,11 @@
         u3dgrd(2)=DimIDs( 6)
         u3dgrd(3)=DimIDs( 9)
         u3dgrd(4)=DimIDs(12)
+!
+        u3dzgrd(1)=DimIDs( 1)
+        u3dzgrd(2)=DimIDs( 5)
+        u3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        u3dzgrd(4)=DimIDs(12)
 #  endif
 # endif
 !
@@ -2538,6 +2752,11 @@
         v3dgrd(2)=DimIDs( 7)
         v3dgrd(3)=DimIDs( 9)
         v3dgrd(4)=DimIDs(12)
+!
+        v3dzgrd(1)=DimIDs( 1)
+        v3dzgrd(2)=DimIDs( 5)
+        v3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        v3dzgrd(4)=DimIDs(12)
 #  endif
 # endif
 # ifdef SOLVE3D
@@ -3011,6 +3230,52 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
+!  Define 3D U-momentum component at specified constant depth slices.
+!
+        IF (Qout(idUzsl,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idUzsl)
+          Vinfo( 2)=Vname(2,idUzsl)
+          Vinfo( 3)=Vname(3,idUzsl)
+          Vinfo(14)=Vname(4,idUzsl)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_u'
+#  endif
+          Vinfo(21)=Vname(6,idUzsl)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idUzsl,ng),r8)
+          QCK(ng)%pioVar(idUzsl)%dkind=PIO_FOUT
+          QCK(ng)%pioVar(idUzsl)%gtype=u3dvar
+!
+          status=def_var(ng, model, QCK(ng)%pioFile,                    &
+     &                   QCK(ng)%pioVar(idUzsl)%vd,                     &
+     &                   PIO_FOUT, nvd4, u3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define 3D V-momentum component at specified constant depth slices.
+!
+        IF (Qout(idVzsl,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idVzsl)
+          Vinfo( 2)=Vname(2,idVzsl)
+          Vinfo( 3)=Vname(3,idVzsl)
+          Vinfo(14)=Vname(4,idVzsl)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_v'
+#  endif
+          Vinfo(21)=Vname(6,idVzsl)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idVzsl,ng),r8)
+          QCK(ng)%pioVar(idVzsl)%dkind=PIO_FOUT
+          QCK(ng)%pioVar(idVzsl)%gtype=v3dvar
+!
+          status=def_var(ng, model, QCK(ng)%pioFile,                    &
+     &                   QCK(ng)%pioVar(idVzsl)%vd,                     &
+     &                   PIO_FOUT, nvd4, v3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
 !  Define 3D Eastward momentum component at RHO-points.
 !
         IF (Qout(idu3dE,ng)) THEN
@@ -3100,6 +3365,77 @@
           status=def_var(ng, model, QCK(ng)%pioFile,                    &
      &                   QCK(ng)%pioVar(idVsuN)%vd,                     &
      &                   PIO_FOUT, nvd3, t2dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define 3D Eastward momentum component at RHO-points for selected
+!  constant depth slices.
+!
+        IF (Qout(iduzsE,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,iduzsE)
+          Vinfo( 2)=Vname(2,iduzsE)
+          Vinfo( 3)=Vname(3,iduzsE)
+          Vinfo(14)=Vname(4,iduzsE)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_rho'
+#  endif
+          Vinfo(21)=Vname(6,iduzsE)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,iduzsE,ng),r8)
+          QCK(ng)%pioVar(iduzsE)%dkind=PIO_FOUT
+          QCK(ng)%pioVar(iduzsE)%gtype=r3dvar
+!
+          status=def_var(ng, model, QCK(ng)%pioFile,                    &
+     &                   QCK(ng)%pioVar(iduzsE)%vd,                     &
+     &                   PIO_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define 3D Northward momentum component at RHO-points  for selected
+!  constant depth slices.
+!
+        IF (Qout(idvzsN,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idvzsN)
+          Vinfo( 2)=Vname(2,idvzsN)
+          Vinfo( 3)=Vname(3,idvzsN)
+          Vinfo(14)=Vname(4,idvzsN)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_rho'
+#  endif
+          Vinfo(21)=Vname(6,idvzsN)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idvzsN,ng),r8)
+          QCK(ng)%pioVar(idvzsN)%dkind=PIO_FOUT
+          QCK(ng)%pioVar(idvzsN)%gtype=r3dvar
+!
+          status=def_var(ng, model, QCK(ng)%pioFile,                    &
+     &                   QCK(ng)%pioVar(idvzsN)%vd,                     &
+     &                   PIO_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define surface relative vorticity at PSI-points.
+!
+        IF (Qout(idRVsu,ng)) THEN
+          Vinfo( 1)=Vname(1,idRVsu)
+          Vinfo( 2)=Vname(2,idRVsu)
+          Vinfo( 3)=Vname(3,idRVsu)
+          Vinfo(14)=Vname(4,idRVsu)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_rho'
+#  endif
+          Vinfo(21)=Vname(6,idRVsu)
+          Vinfo(22)='coordinates'
+          Aval(5)=REAL(Iinfo(1,idRVsu,ng),r8)
+          QCK(ng)%pioVar(idRVsu)%dkind=PIO_FOUT
+          QCK(ng)%pioVar(idRVsu)%gtype=p2dvar
+!
+          status=def_var(ng, model, QCK(ng)%pioFile,                    &
+     &                   QCK(ng)%pioVar(idRVsu)%vd,                     &
+     &                   PIO_FOUT, nvd3, sp2dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
@@ -3209,6 +3545,38 @@
             status=def_var(ng, model, QCK(ng)%pioFile,                  &
      &                     QCK(ng)%pioVar(idsurT(itrc))%vd,             &
      &                     PIO_FOUT, nvd3, t2dgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+          END IF
+        END DO
+!
+!  Define surface tracer type variables at specified depth slices.
+!
+        DO itrc=1,NT(ng)
+          IF (Qout(idzslT(itrc),ng).and.(Nslice.gt.0)) THEN
+            Vinfo( 1)=Vname(1,idzslT(itrc))
+            Vinfo( 2)=Vname(2,idzslT(itrc))
+            Vinfo( 3)=Vname(3,idzslT(itrc))
+            Vinfo(14)=Vname(4,idzslT(itrc))
+            Vinfo(16)=Vname(1,idtime)
+#  ifdef SEDIMENT
+            DO i=1,NST
+              IF (itrc.eq.idsed(i)) THEN
+                WRITE (Vinfo(19),50) 1000.0_r8*Sd50(i,ng)
+              END IF
+            END DO
+#  endif
+#  if defined WRITE_WATER && defined MASKING
+            Vinfo(20)='mask_rho'
+#  endif
+            Vinfo(21)=Vname(6,idzslT(itrc))
+            Vinfo(22)='coordinates, z_slice'
+            Aval(5)=REAL(r3dvar,r8)
+            QCK(ng)%pioVar(idzslT(itrc))%dkind=PIO_FOUT
+            QCK(ng)%pioVar(idzslT(itrc))%gtype=r2dvar
+!
+            status=def_var(ng, model, QCK(ng)%pioFile,                  &
+     &                     QCK(ng)%pioVar(idzslT(itrc))%vd,             &
+     &                     PIO_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
           END IF
         END DO
@@ -4055,6 +4423,16 @@
             QCK(ng)%pioVar(idVsur)%vd=var_desc(i)
             QCK(ng)%pioVar(idVsur)%dkind=PIO_FOUT
             QCK(ng)%pioVar(idVsur)%gtype=v2dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idUzsl))) THEN
+            got_var(idUzsl)=.TRUE.
+            QCK(ng)%pioVar(idUzsl)%vd=var_desc(i)
+            QCK(ng)%pioVar(idUzsl)%dkind=PIO_FOUT
+            QCK(ng)%pioVar(idUzsl)%gtype=u3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVzsl))) THEN
+            got_var(idVzsl)=.TRUE.
+            QCK(ng)%pioVar(idVzsl)%vd=var_desc(i)
+            QCK(ng)%pioVar(idVzsl)%dkind=PIO_FOUT
+            QCK(ng)%pioVar(idVzsl)%gtype=v3dvar
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idu3dE))) THEN
             got_var(idu3dE)=.TRUE.
             QCK(ng)%pioVar(idu3dE)%vd=var_desc(i)
@@ -4075,6 +4453,21 @@
             QCK(ng)%pioVar(idVsuN)%vd=var_desc(i)
             QCK(ng)%pioVar(idVsuN)%dkind=PIO_FOUT
             QCK(ng)%pioVar(idVsuN)%gtype=r2dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,iduzsE))) THEN
+            got_var(iduzsE)=.TRUE.
+            QCK(ng)%pioVar(iduzsE)%vd=var_desc(i)
+            QCK(ng)%pioVar(iduzsE)%dkind=PIO_FOUT
+            QCK(ng)%pioVar(iduzsE)%gtype=r3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idvzsN))) THEN
+            got_var(idvzsN)=.TRUE.
+            QCK(ng)%pioVar(idvzsN)%vd=var_desc(i)
+            QCK(ng)%pioVar(idvzsN)%dkind=PIO_FOUT
+            QCK(ng)%pioVar(idvzsN)%gtype=r3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idRVsu))) THEN
+            got_var(idRVsu)=.TRUE.
+            QCK(ng)%pioVar(idRVsu)%vd=var_desc(i)
+            QCK(ng)%pioVar(idRVsu)%dkind=PIO_FOUT
+            QCK(ng)%pioVar(idRVsu)%gtype=p3dvar
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idWvel))) THEN
             got_var(idWvel)=.TRUE.
             QCK(ng)%pioVar(idWvel)%vd=var_desc(i)
@@ -4253,6 +4646,14 @@
               QCK(ng)%pioVar(idTsur(itrc))%gtype=r2dvar
             END IF
           END DO
+          DO itrc=1,NAT
+            IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idzslT(itrc)))) THEN
+              got_var(idzslT(itrc))=.TRUE.
+              QCK(ng)%pioVar(idzslT(itrc))%vd=var_desc(i)
+              QCK(ng)%pioVar(idzslT(itrc))%dkind=PIO_FOUT
+              QCK(ng)%pioVar(idzslT(itrc))%gtype=r3dvar
+            END IF
+          END DO
 # endif
         END DO
 !
@@ -4372,6 +4773,18 @@
           exit_flag=3
           RETURN
         END IF
+        IF (.not.got_var(idUzsl).and.Qout(idUzsl,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idUzsl)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idVzsl).and.Qout(idVzsl,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idVzsl)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
         IF (.not.got_var(idu3dE).and.Qout(idu3dE,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idu3dE)),          &
      &                                  TRIM(ncname)
@@ -4396,6 +4809,25 @@
           exit_flag=3
           RETURN
         END IF
+        IF (.not.got_var(iduzsE).and.Qout(iduzsE,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,iduzsE)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idvzsN).and.Qout(idvzsN,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idvzsN)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idRVsu).and.Qout(idRVsu,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idRVsu)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+
         IF (.not.got_var(idWvel).and.Qout(idWvel,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idWvel)),          &
      &                                  TRIM(ncname)
@@ -4597,6 +5029,14 @@
         DO itrc=1,NAT
           IF (.not.got_var(idTsur(itrc)).and.Qout(idTsur(itrc),ng)) THEN
             IF (Master) WRITE (stdout,70) TRIM(Vname(1,idTsur(itrc))),  &
+     &                                    TRIM(ncname)
+            exit_flag=3
+            RETURN
+          END IF
+        END DO
+        DO itrc=1,NAT
+          IF (.not.got_var(idzslT(itrc)).and.Qout(idzslT(itrc),ng)) THEN
+            IF (Master) WRITE (stdout,70) TRIM(Vname(1,idzslT(itrc))),  &
      &                                    TRIM(ncname)
             exit_flag=3
             RETURN

--- a/ROMS/Utility/def_quick.F
+++ b/ROMS/Utility/def_quick.F
@@ -131,14 +131,15 @@
       integer :: IorJdim
 #endif
       integer :: DimIDs(nDimID)
-      integer :: t2dgrd(3), sp2dgrd(3), u2dgrd(3), v2dgrd(3)
+      integer :: p2dgrd(3), t2dgrd(3), u2dgrd(3), v2dgrd(3)
 
 #ifdef SOLVE3D
 # ifdef SEDIMENT
       integer :: b3dgrd(4)
 # endif
-      integer :: t3dgrd(4),  u3dgrd(4),  v3dgrd(4), w3dgrd(4)
-      integer :: t3dzgrd(4), u3dzgrd(4), v3dzgrd(4)
+      integer :: p3dgrd(4),  t3dgrd(4),  u3dgrd(4),  v3dgrd(4)
+      integer :: p3dzgrd(4), t3dzgrd(4), u3dzgrd(4), v3dzgrd(4)
+      integer :: w3dgrd(4)
 #endif
 !
       real(r8) :: Aval(6)
@@ -376,9 +377,20 @@
 !
 !  Define dimension vectors for staggered type variables at PSI-points.
 !
-        sp2dgrd(1)=DimIDs( 4)
-        sp2dgrd(2)=DimIDs( 8)
-        sp2dgrd(3)=DimIDs(12)
+        p2dgrd(1)=DimIDs( 4)
+        p2dgrd(2)=DimIDs( 8)
+        p2dgrd(3)=DimIDs(12)
+#ifdef SOLVE3D
+        p3dgrd(1)=DimIDs( 4)
+        p3dgrd(2)=DimIDs( 8)
+        p3dgrd(3)=DimIDs( 9)
+        p3dgrd(4)=DimIDs(12)
+!
+        p3dzgrd(1)=DimIDs( 4)
+        p3dzgrd(2)=DimIDs( 8)
+        p3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        p3dzgrd(4)=DimIDs(12)
+# endif
 !
 !  Define dimension vectors for staggered u-momentum type variables.
 !
@@ -514,7 +526,7 @@
         Vinfo(22)='coordinates'
         Aval(5)=REAL(Iinfo(1,idPwet,ng),r8)
         status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idPwet),    &
-     &                 NF_FOUT, nvd3, sp2dgrd, Aval, Vinfo, ncname,     &
+     &                 NF_FOUT, nvd3, p2dgrd, Aval, Vinfo, ncname,      &
      &                 SetFillVal = .FALSE.)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
@@ -984,22 +996,43 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
-!  Define model surface relative vorticity at PSI-points.
+!  Define model potential vorticity at PSI-points for specified constant
+!  depth slices.
 !
-        IF (Qout(idRVsu,ng)) THEN
-          Vinfo( 1)=Vname(1,idRVsu)
-          Vinfo( 2)=Vname(2,idRVsu)
-          Vinfo( 3)=Vname(3,idRVsu)
-          Vinfo(14)=Vname(4,idRVsu)
+        IF (Qout(idPVzs,ng)) THEN
+          Vinfo( 1)=Vname(1,idPVzs)
+          Vinfo( 2)=Vname(2,idPVzs)
+          Vinfo( 3)=Vname(3,idPVzs)
+          Vinfo(14)=Vname(4,idPVzs)
           Vinfo(16)=Vname(1,idtime)
 # if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_psi'
 # endif
-          Vinfo(21)=Vname(6,idRVsu)
-          Vinfo(22)='coordinates'
-          Aval(5)=REAL(Iinfo(1,idRVsu,ng),r8)
-          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idRVsu),  &
-     &                   NF_FOUT, nvd3, sp2dgrd, Aval, Vinfo, ncname)
+          Vinfo(21)=Vname(6,idPVzs)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idPVzs,ng),r8)
+          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idPVzs),  &
+     &                   NF_FOUT, nvd3, p3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define model relative vorticity at PSI-points for specified constant
+!  depth slices.
+!
+        IF (Qout(idRVzs,ng)) THEN
+          Vinfo( 1)=Vname(1,idRVzs)
+          Vinfo( 2)=Vname(2,idRVzs)
+          Vinfo( 3)=Vname(3,idRVzs)
+          Vinfo(14)=Vname(4,idRVzs)
+          Vinfo(16)=Vname(1,idtime)
+# if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_psi'
+# endif
+          Vinfo(21)=Vname(6,idRVzs)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idRVzs,ng),r8)
+          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idRVzs),  &
+     &                   NF_FOUT, nvd3, p3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
@@ -1855,9 +1888,12 @@
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVzsN))) THEN
             got_var(idVzsN)=.TRUE.
             QCK(ng)%Vid(idVzsN)=var_id(i)
-          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idRVsu))) THEN
-            got_var(idRVsu)=.TRUE.
-            QCK(ng)%Vid(idRVsu)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idPVzs))) THEN
+            got_var(idPVzs)=.TRUE.
+            QCK(ng)%Vid(idPVzs)=var_id(i)
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idRVzs))) THEN
+            got_var(idRVzs)=.TRUE.
+            QCK(ng)%Vid(idRVzs)=var_id(i)
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idWvel))) THEN
             got_var(idWvel)=.TRUE.
             QCK(ng)%Vid(idWvel)=var_id(i)
@@ -2149,8 +2185,14 @@
           exit_flag=3
           RETURN
         END IF
-        IF (.not.got_var(idRVsu).and.Qout(idRVsu,ng)) THEN
-          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idRVsu)),          &
+        IF (.not.got_var(idPVzs).and.Qout(idPVzs,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idPVzs)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
+        IF (.not.got_var(idRVzs).and.Qout(idRVzs,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idRVzs)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
@@ -2459,14 +2501,14 @@
       integer :: IorJdim
 # endif
       integer :: DimIDs(nDimID)
-      integer :: t2dgrd(3), sp2dgrd(3), u2dgrd(3), v2dgrd(3)
-
+      integer :: p2dgrd(3), t2dgrd(3), u2dgrd(3), v2dgrd(3)
 # ifdef SOLVE3D
 #  ifdef SEDIMENT
       integer :: b3dgrd(4)
 #  endif
-      integer :: t3dgrd(4),  u3dgrd(4),  v3dgrd(4), w3dgrd(4)
-      integer :: t3dzgrd(4), u3dzgrd(4), v3dzgrd(4)
+      integer :: p3dgrd(4),  t3dgrd(4),  u3dgrd(4),  v3dgrd(4)
+      integer :: p3dzgrd(4), t3dzgrd(4), u3dzgrd(4), v3dzgrd(4)
+      integer :: w3dgrd(4)
 # endif
 !
       real(r8) :: Aval(6)
@@ -2704,9 +2746,20 @@
 !
 !  Define dimension vectors for staggered type variables at PSI-points.
 !
-        sp2dgrd(1)=DimIDs( 4)
-        sp2dgrd(2)=DimIDs( 8)
-        sp2dgrd(3)=DimIDs(12)
+        p2dgrd(1)=DimIDs( 4)
+        p2dgrd(2)=DimIDs( 8)
+        p2dgrd(3)=DimIDs(12)
+#ifdef SOLVE3D
+        p3dgrd(1)=DimIDs( 4)
+        p3dgrd(2)=DimIDs( 8)
+        p3dgrd(3)=DimIDs( 9)
+        p3dgrd(4)=DimIDs(12)
+!
+        p3dzgrd(1)=DimIDs( 4)
+        p3dzgrd(2)=DimIDs( 8)
+        p3dzgrd(3)=DimIDs(34)          ! selected constant depth slices
+        p3dzgrd(4)=DimIDs(12)
+# endif
 !
 !  Define dimension vectors for staggered u-momentum type variables.
 !
@@ -2850,7 +2903,7 @@
 !
         status=def_var(ng, model, QCK(ng)%pioFile,                      &
      &                 QCK(ng)%pioVar(idPwet)%vd,                       &
-     &                 PIO_FOUT, nvd3, sp2dgrd, Aval, Vinfo, ncname,    &
+     &                 PIO_FOUT, nvd3, p2dgrd, Aval, Vinfo, ncname,     &
      &                 SetFillVal = .FALSE.)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
@@ -3392,7 +3445,7 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
-!  Define 3D Northward momentum component at RHO-points  for selected
+!  Define 3D Northward momentum component at RHO-points for selected
 !  constant depth slices.
 !
         IF (Qout(idVzsN,ng).and.(Nslice.gt.0)) THEN
@@ -3416,26 +3469,51 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
-!  Define surface relative vorticity at PSI-points.
+!  Define model potential vorticity at PSI-points for selected constant
+!  depth slices.
 !
-        IF (Qout(idRVsu,ng)) THEN
-          Vinfo( 1)=Vname(1,idRVsu)
-          Vinfo( 2)=Vname(2,idRVsu)
-          Vinfo( 3)=Vname(3,idRVsu)
-          Vinfo(14)=Vname(4,idRVsu)
+        IF (Qout(idPVzs,ng)) THEN
+          Vinfo( 1)=Vname(1,idPVzs)
+          Vinfo( 2)=Vname(2,idPVzs)
+          Vinfo( 3)=Vname(3,idPVzs)
+          Vinfo(14)=Vname(4,idPVzs)
           Vinfo(16)=Vname(1,idtime)
 #  if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
 #  endif
-          Vinfo(21)=Vname(6,idRVsu)
-          Vinfo(22)='coordinates'
-          Aval(5)=REAL(Iinfo(1,idRVsu,ng),r8)
-          QCK(ng)%pioVar(idRVsu)%dkind=PIO_FOUT
-          QCK(ng)%pioVar(idRVsu)%gtype=p2dvar
+          Vinfo(21)=Vname(6,idPVzs)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idPVzs,ng),r8)
+          QCK(ng)%pioVar(idPVzs)%dkind=PIO_FOUT
+          QCK(ng)%pioVar(idPVzs)%gtype=p3dvar
 !
           status=def_var(ng, model, QCK(ng)%pioFile,                    &
-     &                   QCK(ng)%pioVar(idRVsu)%vd,                     &
-     &                   PIO_FOUT, nvd3, sp2dgrd, Aval, Vinfo, ncname)
+     &                   QCK(ng)%pioVar(idPVzs)%vd,                     &
+     &                   PIO_FOUT, nvd3, p3dzgrd, Aval, Vinfo, ncname)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+!
+!  Define model relative vorticity at PSI-points for selected constant
+!  depth slices.
+!
+        IF (Qout(idRVzs,ng)) THEN
+          Vinfo( 1)=Vname(1,idRVzs)
+          Vinfo( 2)=Vname(2,idRVzs)
+          Vinfo( 3)=Vname(3,idRVzs)
+          Vinfo(14)=Vname(4,idRVzs)
+          Vinfo(16)=Vname(1,idtime)
+#  if defined WRITE_WATER && defined MASKING
+          Vinfo(20)='mask_rho'
+#  endif
+          Vinfo(21)=Vname(6,idRVzs)
+          Vinfo(22)='coordinates, z_slice'
+          Aval(5)=REAL(Iinfo(1,idRVzs,ng),r8)
+          QCK(ng)%pioVar(idRVzs)%dkind=PIO_FOUT
+          QCK(ng)%pioVar(idRVzs)%gtype=p3dvar
+!
+          status=def_var(ng, model, QCK(ng)%pioFile,                    &
+     &                   QCK(ng)%pioVar(idRVzs)%vd,                     &
+     &                   PIO_FOUT, nvd3, p3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
@@ -4463,11 +4541,16 @@
             QCK(ng)%pioVar(idVzsN)%vd=var_desc(i)
             QCK(ng)%pioVar(idVzsN)%dkind=PIO_FOUT
             QCK(ng)%pioVar(idVzsN)%gtype=r3dvar
-          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idRVsu))) THEN
-            got_var(idRVsu)=.TRUE.
-            QCK(ng)%pioVar(idRVsu)%vd=var_desc(i)
-            QCK(ng)%pioVar(idRVsu)%dkind=PIO_FOUT
-            QCK(ng)%pioVar(idRVsu)%gtype=p3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idPVzs))) THEN
+            got_var(idPVzs)=.TRUE.
+            QCK(ng)%pioVar(idPVzs)%vd=var_desc(i)
+            QCK(ng)%pioVar(idPVzs)%dkind=PIO_FOUT
+            QCK(ng)%pioVar(idPVzs)%gtype=p3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idRVzs))) THEN
+            got_var(idRVzs)=.TRUE.
+            QCK(ng)%pioVar(idRVzs)%vd=var_desc(i)
+            QCK(ng)%pioVar(idRVzs)%dkind=PIO_FOUT
+            QCK(ng)%pioVar(idRVzs)%gtype=p3dvar
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idWvel))) THEN
             got_var(idWvel)=.TRUE.
             QCK(ng)%pioVar(idWvel)%vd=var_desc(i)
@@ -4821,13 +4904,18 @@
           exit_flag=3
           RETURN
         END IF
-        IF (.not.got_var(idRVsu).and.Qout(idRVsu,ng)) THEN
-          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idRVsu)),          &
+        IF (.not.got_var(idPVzs).and.Qout(idPVzs,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idPVzs)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
         END IF
-
+        IF (.not.got_var(idRVzs).and.Qout(idRVzs,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idRVzs)),          &
+     &                                  TRIM(ncname)
+          exit_flag=3
+          RETURN
+        END IF
         IF (.not.got_var(idWvel).and.Qout(idWvel,ng)) THEN
           IF (Master) WRITE (stdout,70) TRIM(Vname(1,idWvel)),          &
      &                                  TRIM(ncname)

--- a/ROMS/Utility/def_quick.F
+++ b/ROMS/Utility/def_quick.F
@@ -947,19 +947,19 @@
 !  Define 3D Eastward momentum component at RHO-point for specified
 !  constant depth slices.
 !
-        IF (Qout(iduzsE,ng).and.(Nslice.gt.0)) THEN
-          Vinfo( 1)=Vname(1,iduzsE)
-          Vinfo( 2)=Vname(2,iduzsE)
-          Vinfo( 3)=Vname(3,iduzsE)
-          Vinfo(14)=Vname(4,iduzsE)
+        IF (Qout(idUzsE,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idUzsE)
+          Vinfo( 2)=Vname(2,idUzsE)
+          Vinfo( 3)=Vname(3,idUzsE)
+          Vinfo(14)=Vname(4,idUzsE)
           Vinfo(16)=Vname(1,idtime)
 # if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
 # endif
-          Vinfo(21)=Vname(6,iduzsE)
+          Vinfo(21)=Vname(6,idUzsE)
           Vinfo(22)='coordinates, z_slice'
-          Aval(5)=REAL(Iinfo(1,iduzsE,ng),r8)
-          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(iduzsE),  &
+          Aval(5)=REAL(Iinfo(1,idUzsE,ng),r8)
+          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idUzsE),  &
      &                   NF_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
@@ -967,19 +967,19 @@
 !  Define 3D Northward momentum component at RHO-points for specified
 !  constant depth slices.
 !
-        IF (Qout(idvzsN,ng).and.(Nslice.gt.0)) THEN
-          Vinfo( 1)=Vname(1,idvzsN)
-          Vinfo( 2)=Vname(2,idvzsN)
-          Vinfo( 3)=Vname(3,idvzsN)
-          Vinfo(14)=Vname(4,idvzsN)
+        IF (Qout(idVzsN,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idVzsN)
+          Vinfo( 2)=Vname(2,idVzsN)
+          Vinfo( 3)=Vname(3,idVzsN)
+          Vinfo(14)=Vname(4,idVzsN)
           Vinfo(16)=Vname(1,idtime)
 # if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
 # endif
-          Vinfo(21)=Vname(6,idvzsN)
+          Vinfo(21)=Vname(6,idVzsN)
           Vinfo(22)='coordinates, zslice'
-          Aval(5)=REAL(Iinfo(1,idvzsN,ng),r8)
-          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idvzsN),  &
+          Aval(5)=REAL(Iinfo(1,idVzsN,ng),r8)
+          status=def_var(ng, model, QCK(ng)%ncid, QCK(ng)%Vid(idVzsN),  &
      &                   NF_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
@@ -3371,23 +3371,23 @@
 !  Define 3D Eastward momentum component at RHO-points for selected
 !  constant depth slices.
 !
-        IF (Qout(iduzsE,ng).and.(Nslice.gt.0)) THEN
-          Vinfo( 1)=Vname(1,iduzsE)
-          Vinfo( 2)=Vname(2,iduzsE)
-          Vinfo( 3)=Vname(3,iduzsE)
-          Vinfo(14)=Vname(4,iduzsE)
+        IF (Qout(idUzsE,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idUzsE)
+          Vinfo( 2)=Vname(2,idUzsE)
+          Vinfo( 3)=Vname(3,idUzsE)
+          Vinfo(14)=Vname(4,idUzsE)
           Vinfo(16)=Vname(1,idtime)
 #  if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
 #  endif
-          Vinfo(21)=Vname(6,iduzsE)
+          Vinfo(21)=Vname(6,idUzsE)
           Vinfo(22)='coordinates, z_slice'
-          Aval(5)=REAL(Iinfo(1,iduzsE,ng),r8)
-          QCK(ng)%pioVar(iduzsE)%dkind=PIO_FOUT
-          QCK(ng)%pioVar(iduzsE)%gtype=r3dvar
+          Aval(5)=REAL(Iinfo(1,idUzsE,ng),r8)
+          QCK(ng)%pioVar(idUzsE)%dkind=PIO_FOUT
+          QCK(ng)%pioVar(idUzsE)%gtype=r3dvar
 !
           status=def_var(ng, model, QCK(ng)%pioFile,                    &
-     &                   QCK(ng)%pioVar(iduzsE)%vd,                     &
+     &                   QCK(ng)%pioVar(idUzsE)%vd,                     &
      &                   PIO_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
@@ -3395,23 +3395,23 @@
 !  Define 3D Northward momentum component at RHO-points  for selected
 !  constant depth slices.
 !
-        IF (Qout(idvzsN,ng).and.(Nslice.gt.0)) THEN
-          Vinfo( 1)=Vname(1,idvzsN)
-          Vinfo( 2)=Vname(2,idvzsN)
-          Vinfo( 3)=Vname(3,idvzsN)
-          Vinfo(14)=Vname(4,idvzsN)
+        IF (Qout(idVzsN,ng).and.(Nslice.gt.0)) THEN
+          Vinfo( 1)=Vname(1,idVzsN)
+          Vinfo( 2)=Vname(2,idVzsN)
+          Vinfo( 3)=Vname(3,idVzsN)
+          Vinfo(14)=Vname(4,idVzsN)
           Vinfo(16)=Vname(1,idtime)
 #  if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_rho'
 #  endif
-          Vinfo(21)=Vname(6,idvzsN)
+          Vinfo(21)=Vname(6,idVzsN)
           Vinfo(22)='coordinates, z_slice'
-          Aval(5)=REAL(Iinfo(1,idvzsN,ng),r8)
-          QCK(ng)%pioVar(idvzsN)%dkind=PIO_FOUT
-          QCK(ng)%pioVar(idvzsN)%gtype=r3dvar
+          Aval(5)=REAL(Iinfo(1,idVzsN,ng),r8)
+          QCK(ng)%pioVar(idVzsN)%dkind=PIO_FOUT
+          QCK(ng)%pioVar(idVzsN)%gtype=r3dvar
 !
           status=def_var(ng, model, QCK(ng)%pioFile,                    &
-     &                   QCK(ng)%pioVar(idvzsN)%vd,                     &
+     &                   QCK(ng)%pioVar(idVzsN)%vd,                     &
      &                   PIO_FOUT, nvd4, t3dzgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
@@ -4453,16 +4453,16 @@
             QCK(ng)%pioVar(idVsuN)%vd=var_desc(i)
             QCK(ng)%pioVar(idVsuN)%dkind=PIO_FOUT
             QCK(ng)%pioVar(idVsuN)%gtype=r2dvar
-          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,iduzsE))) THEN
-            got_var(iduzsE)=.TRUE.
-            QCK(ng)%pioVar(iduzsE)%vd=var_desc(i)
-            QCK(ng)%pioVar(iduzsE)%dkind=PIO_FOUT
-            QCK(ng)%pioVar(iduzsE)%gtype=r3dvar
-          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idvzsN))) THEN
-            got_var(idvzsN)=.TRUE.
-            QCK(ng)%pioVar(idvzsN)%vd=var_desc(i)
-            QCK(ng)%pioVar(idvzsN)%dkind=PIO_FOUT
-            QCK(ng)%pioVar(idvzsN)%gtype=r3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idUzsE))) THEN
+            got_var(idUzsE)=.TRUE.
+            QCK(ng)%pioVar(idUzsE)%vd=var_desc(i)
+            QCK(ng)%pioVar(idUzsE)%dkind=PIO_FOUT
+            QCK(ng)%pioVar(idUzsE)%gtype=r3dvar
+          ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idVzsN))) THEN
+            got_var(idVzsN)=.TRUE.
+            QCK(ng)%pioVar(idVzsN)%vd=var_desc(i)
+            QCK(ng)%pioVar(idVzsN)%dkind=PIO_FOUT
+            QCK(ng)%pioVar(idVzsN)%gtype=r3dvar
           ELSE IF (TRIM(var_name(i)).eq.TRIM(Vname(1,idRVsu))) THEN
             got_var(idRVsu)=.TRUE.
             QCK(ng)%pioVar(idRVsu)%vd=var_desc(i)
@@ -4809,14 +4809,14 @@
           exit_flag=3
           RETURN
         END IF
-        IF (.not.got_var(iduzsE).and.Qout(iduzsE,ng)) THEN
-          IF (Master) WRITE (stdout,70) TRIM(Vname(1,iduzsE)),          &
+        IF (.not.got_var(idUzsE).and.Qout(idUzsE,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idUzsE)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
         END IF
-        IF (.not.got_var(idvzsN).and.Qout(idvzsN,ng)) THEN
-          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idvzsN)),          &
+        IF (.not.got_var(idVzsN).and.Qout(idVzsN,ng)) THEN
+          IF (Master) WRITE (stdout,70) TRIM(Vname(1,idVzsN)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN

--- a/ROMS/Utility/def_var.F
+++ b/ROMS/Utility/def_var.F
@@ -126,6 +126,7 @@
 !
 !  Local variable declarations.
 !
+      logical :: has_z_slice
 #ifdef MASKING
       logical :: LandFill
 #endif
@@ -806,12 +807,21 @@
         IF (exit_flag.eq.NoError) THEN
           latt=LEN_TRIM(Vinfo(22))
           IF (latt.gt.0) THEN
+            IF (latt.gt.11) THEN
+              has_z_slice=.TRUE.
+            ELSE
+              has_z_slice=.FALSE.
+            END IF
             IF (spherical) THEN
               IF (INT(Aval(5)).eq.r2dvar) THEN
                 text='lon_rho lat_rho'
                 location='face'
               ELSE IF (INT(Aval(5)).eq.r3dvar) THEN
-                text='lon_rho lat_rho s_rho'
+                IF (has_z_slice) THEN
+                  text='lon_rho lat_rho z_slice'
+                ELSE
+                  text='lon_rho lat_rho s_rho'
+                END IF
                 location='face'
               ELSE IF (INT(Aval(5)).eq.w3dvar) THEN
                 text='lon_rho lat_rho s_w'
@@ -823,7 +833,11 @@
                 text='lon_u lat_u'
                 location='edge1'
               ELSE IF (INT(Aval(5)).eq.u3dvar) THEN
-                text='lon_u lat_u s_rho'
+                IF (has_z_slice) THEN
+                  text='lon_u lat_u z_slice'
+                ELSE
+                  text='lon_u lat_u s_rho'
+                END IF
                 location='edge1'
               ELSE IF (INT(Aval(5)).eq.-u3dvar) THEN
                 text='lon_u lat_u s_w'
@@ -832,7 +846,11 @@
                 text='lon_v lat_v'
                 location='edge2'
               ELSE IF (INT(Aval(5)).eq.v3dvar) THEN
-                text='lon_v lat_v s_rho'
+                IF (has_z_slice) THEN
+                  text='lon_v lat_v z_slice'
+                ELSE
+                  text='lon_v lat_v s_rho'
+                END IF
                 location='edge2'
               ELSE IF (INT(Aval(5)).eq.-v3dvar) THEN
                 text='lon_v lat_v s_w'
@@ -841,7 +859,11 @@
                 text='lon_psi lat_psi'
                 location='node'
               ELSE IF (INT(Aval(5)).eq.p3dvar) THEN
-                text='lon_psi lat_psi s_rho'
+                IF (has_z_slice) THEN
+                  text='lon_psi lat_psi z_slice'
+                ELSE
+                  text='lon_psi lat_psi s_rho'
+                END IF
                 location='node'
               ELSE IF (INT(Aval(5)).eq.l3dvar) THEN
                 text='lon_rho lat_rho light'
@@ -855,7 +877,11 @@
                 text='x_rho y_rho'
                 location='face'
               ELSE IF (INT(Aval(5)).eq.r3dvar) THEN
-                text='x_rho y_rho s_rho'
+                IF (has_z_slice) THEN
+                  text='x_rho y_rho z_slice'
+                ELSE
+                  text='x_rho y_rho s_rho'
+                END IF
                 location='face'
               ELSE IF (INT(Aval(5)).eq.w3dvar) THEN
                 text='x_rho y_rho s_w'
@@ -867,7 +893,11 @@
                 text='x_u y_u'
                 location='edge1'
               ELSE IF (INT(Aval(5)).eq.u3dvar) THEN
-                text='x_u y_u s_rho'
+                IF (has_z_slice) THEN
+                  text='x_u y_u z_slice'
+                ELSE
+                  text='x_u y_u s_rho'
+                END IF
                 location='edge1'
               ELSE IF (INT(Aval(5)).eq.-u3dvar) THEN
                 text='x_u y_u s_w'
@@ -876,7 +906,11 @@
                 text='x_v y_v'
                 location='edge2'
               ELSE IF (INT(Aval(5)).eq.v3dvar) THEN
-                text='x_v y_v s_rho'
+                IF (has_z_slice) THEN
+                  text='x_v y_v z_slice'
+                ELSE
+                  text='x_v y_v s_rho'
+                END IF
                 location='edge2'
               ELSE IF (INT(Aval(5)).eq.-v3dvar) THEN
                 text='x_v y_v s_w'
@@ -885,7 +919,11 @@
                 text='x_psi y_psi'
                 location='node'
               ELSE IF (INT(Aval(5)).eq.p3dvar) THEN
-                text='x_psi y_psi s_rho'
+                IF (has_z_slice) THEN
+                  text='x_psi y_psi z_slice'
+                ELSE
+                  text='x_psi y_psi s_rho'
+                END IF
                 location='node'
               ELSE IF (INT(Aval(5)).eq.l3dvar) THEN
                 text='x_rho y_rho Nbands'
@@ -922,7 +960,7 @@
               text=text(1:latt)//' ocean_time'
               latt=LEN_TRIM(text)
             END IF
-            status=nf90_put_att(ncid, Vid, TRIM(Vinfo(22)),             &
+            status=nf90_put_att(ncid, Vid, 'coordinates',               &
      &                          text(1:latt))
             IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
               IF (Master) WRITE (stdout,30) 'coordinates',              &
@@ -1093,6 +1131,7 @@
 !
 !  Local variable declarations.
 !
+      logical :: has_z_slice
 #ifdef MASKING
       logical :: LandFill
 #endif
@@ -1753,12 +1792,21 @@
       IF (exit_flag.eq.NoError) THEN
         latt=LEN_TRIM(Vinfo(22))
         IF (latt.gt.0) THEN
+          IF (latt.gt.11) THEN
+            has_z_slice=.TRUE.
+          ELSE
+            has_z_slice=.FALSE.
+          END IF
           IF (spherical) THEN
             IF (INT(Aval(5)).eq.r2dvar) THEN
               text='lon_rho lat_rho'
               location='face'
             ELSE IF (INT(Aval(5)).eq.r3dvar) THEN
-              text='lon_rho lat_rho s_rho'
+              IF (has_z_slice) THEN
+                text='lon_rho lat_rho z_slice'
+              ELSE
+                text='lon_rho lat_rho s_rho'
+              END IF
               location='face'
             ELSE IF (INT(Aval(5)).eq.w3dvar) THEN
               text='lon_rho lat_rho s_w'
@@ -1770,7 +1818,11 @@
               text='lon_u lat_u'
               location='edge1'
             ELSE IF (INT(Aval(5)).eq.u3dvar) THEN
-              text='lon_u lat_u s_rho'
+              IF (has_z_slice) THEN
+                text='lon_u lat_u z_slice'
+              ELSE
+                text='lon_u lat_u s_rho'
+              END IF
               location='edge1'
             ELSE IF (INT(Aval(5)).eq.-u3dvar) THEN
               text='lon_u lat_u s_w'
@@ -1779,7 +1831,11 @@
               text='lon_v lat_v'
               location='edge2'
             ELSE IF (INT(Aval(5)).eq.v3dvar) THEN
-              text='lon_v lat_v s_rho'
+              IF (has_z_slice) THEN
+                text='lon_v lat_v z_slice'
+              ELSE
+                text='lon_v lat_v s_rho'
+              END IF
               location='edge2'
             ELSE IF (INT(Aval(5)).eq.-v3dvar) THEN
               text='lon_v lat_v s_w'
@@ -1788,7 +1844,11 @@
               text='lon_psi lat_psi'
               location='node'
             ELSE IF (INT(Aval(5)).eq.p3dvar) THEN
-              text='lon_psi lat_psi s_rho'
+              IF (has_z_slice) THEN
+                text='lon_psi lat_psi z_slice'
+              ELSE
+                text='lon_psi lat_psi s_rho'
+              END IF
               location='node'
             ELSE IF (INT(Aval(5)).eq.l3dvar) THEN
               text='lon_rho lat_rho light'
@@ -1802,7 +1862,11 @@
               text='x_rho y_rho'
               location='face'
             ELSE IF (INT(Aval(5)).eq.r3dvar) THEN
-              text='x_rho y_rho s_rho'
+              IF (has_z_slice) THEN
+                text='x_rho y_rho z_slice'
+              ELSE
+                text='x_rho y_rho s_rho'
+              END IF
               location='face'
             ELSE IF (INT(Aval(5)).eq.w3dvar) THEN
               text='x_rho y_rho s_w'
@@ -1814,7 +1878,11 @@
               text='x_u y_u'
               location='edge1'
             ELSE IF (INT(Aval(5)).eq.u3dvar) THEN
-              text='x_u y_u s_rho'
+              IF (has_z_slice) THEN
+                text='x_u y_u z_slice'
+              ELSE
+                text='x_u y_u s_rho'
+              END IF
               location='edge1'
             ELSE IF (INT(Aval(5)).eq.-u3dvar) THEN
               text='x_u y_u s_w'
@@ -1823,7 +1891,11 @@
               text='x_v y_v'
               location='edge2'
             ELSE IF (INT(Aval(5)).eq.v3dvar) THEN
-              text='x_v y_v s_rho'
+              IF (has_z_slice) THEN
+                text='x_v y_v z_slice'
+              ELSE
+                text='x_v y_v s_rho'
+              END IF
               location='edge2'
             ELSE IF (INT(Aval(5)).eq.-v3dvar) THEN
               text='x_v y_v s_w'
@@ -1832,7 +1904,11 @@
               text='x_psi y_psi'
               location='node'
             ELSE IF (INT(Aval(5)).eq.p3dvar) THEN
-              text='x_psi y_psi s_rho'
+              IF (has_z_slice) THEN
+                text='x_psi y_psi z_slice'
+              ELSE
+                text='x_psi y_psi s_rho'
+              END IF
               location='node'
             ELSE IF (INT(Aval(5)).eq.l3dvar) THEN
               text='x_rho y_rho Nbands'
@@ -1869,7 +1945,7 @@
             text=text(1:latt)//' ocean_time'
             latt=LEN_TRIM(text)
           END IF
-          status=PIO_put_att(pioFile, pioVar, TRIM(Vinfo(22)),          &
+          status=PIO_put_att(pioFile, pioVar, 'coordinates',            &
      &                       text(1:latt))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) WRITE (stdout,30) 'coordinates',                &

--- a/ROMS/Utility/extract_slice.F
+++ b/ROMS/Utility/extract_slice.F
@@ -1,0 +1,172 @@
+#include "cppdefs.h"
+      MODULE extract_slice_mod
+#ifdef SOLVE3D
+!
+!git $Id$
+!================================================== Hernan G. Arango ===
+!  Copyright (c) 2002-2025 The ROMS Group                              !
+!    Licensed under a MIT/X style license                              !
+!    See License_ROMS.md                                               !
+!=======================================================================
+!                                                                      !
+!  This routine extracts a slice of a 3D ROMS at requested constant    !
+!  depths, like z=-100m, using vertical linear interpolation, It is    !
+!  done for output puposes.                                            !
+!                                                                      !
+!  On Input:                                                           !
+!                                                                      !
+!     ng         Nested grid number (integer)                          !
+!     model      Calling model identifier (integer)                    !
+!     tile       Domain partition (integer)                            !
+!     LBi        I-dimension Lower bound (integer)                     !
+!     UBi        I-dimension Upper bound (integer)                     !
+!     LBj        J-dimension Lower bound (integer)                     !
+!     UBj        J-dimension Upper bound (integer)                     !
+!     LBk        K-dimension Lower bound (integer)                     !
+!     UBk        K-dimension Upper bound (integer)                     !
+!     Adata      3D field (real)                                       !
+!     Adepth     3D field terrain following depths (real; negative, m) !
+!     Amask      Land/sea masking (real)                               !
+!     z_slice    Depths of requested slices (real; negative, m)        !
+!                                                                      !
+!  On Output:                                                          !
+!                                                                      !
+!     Aslice      Extracted field constant depth slices (real)         !
+!                                                                      !
+!=======================================================================
+!
+      USE mod_param
+      USE mod_scalars
+!
+      implicit none
+!
+      PUBLIC  :: extract_slice
+      PRIVATE
+!
+      CONTAINS
+!
+!***********************************************************************
+      SUBROUTINE extract_slice (ng, model, tile, gtype,                 &
+     &                          LBi, UBi, LBj, UBj, LBk, UBk,           &
+     &                          Adata, Adepth,                          &
+# ifdef MASKING
+     &                          Amask,                                  &
+# endif
+     &                          z_slice, Aslice)
+!***********************************************************************
+!
+!  Imported variable declarations.
+!
+      integer,  intent(in)  :: ng, model, tile, gtype
+      integer,  intent(in)  :: LBi, UBi, LBj, UBj, LBk, UBk
+      real(r8), intent(in)  :: z_slice(:)
+!
+# ifdef ASSUMED_SHAPE
+      real(r8), intent(in)  :: Adata (LBi:,LBj:,LBk:)
+      real(r8), intent(in)  :: Adepth(LBi:,LBj:,LBk:)
+#  ifdef MASKING
+      real(r8), intent(in)  :: Amask (LBi:,LBj:)
+#  endif
+      real(r8), intent(out) :: Aslice(LBi:,LBj:,LBk:)
+# else
+      real(r8), intent(in)  :: Adata (LBi:UBi,LBj:UBj,LBk:UBk)
+      real(r8), intent(in)  :: Adepth(LBi:UBi,LBj:UBj,LBk:UBk)
+#  ifdef MASKING
+      real(r8), intent(in)  :: Amask (LBi:UBi,LBj:UBj)
+#  endif
+      real(r8), intent(out) :: Aslice(LBi:UBi,LBj:UBj,:)
+# endif
+!
+!  Local variable declarations.
+!
+      integer :: i, iz, j, k, k1, k2
+      integer :: Imin, Imax, Jmin, Jmax
+      integer :: mslice
+!
+      real(r8) :: my_mask
+      real(r8) :: dz, r1, r2, zbot, ztop
+!
+!-----------------------------------------------------------------------
+!  Extract field slice(s) from 3D field using linear interpolation.
+!-----------------------------------------------------------------------
+!
+!  Select tile data bounds acordin to staggered C-grid type.
+!
+      SELECT CASE (gtype)
+        CASE (p3dvar)
+          Imin=BOUNDS(ng)%Istr (tile)
+          Imax=BOUNDS(ng)%Iend (tile)
+          Jmin=BOUNDS(ng)%Jstr (tile)
+          Jmax=BOUNDS(ng)%Jend (tile)
+        CASE (r3dvar, w3dvar)
+          Imin=BOUNDS(ng)%IstrR(tile)
+          Imax=BOUNDS(ng)%IendR(tile)
+          Jmin=BOUNDS(ng)%JstrR(tile)
+          Jmax=BOUNDS(ng)%JendR(tile)
+        CASE (u3dvar)
+          Imin=BOUNDS(ng)%Istr (tile)
+          Imax=BOUNDS(ng)%IendR(tile)
+          Jmin=BOUNDS(ng)%JstrR(tile)
+          Jmax=BOUNDS(ng)%JendR(tile)
+        CASE (v3dvar)
+          Imin=BOUNDS(ng)%IstrR(tile)
+          Imax=BOUNDS(ng)%IendR(tile)
+          Jmin=BOUNDS(ng)%Jstr (tile)
+          Jmax=BOUNDS(ng)%JendR(tile)
+      END SELECT
+!
+!  Determine number of slice depths (negative, m) to extract.
+!
+      mslice = SIZE(z_slice)      
+!
+!  Extract horizontal slices via linear interpolation.
+!
+      DO j=Jmin,Jmax
+        DO i=Imin,Imax
+# ifdef MASKING
+          my_mask=Amask(i,j)
+# else
+          my_mask=1.0_r8
+# endif
+          DO iz=1,mslice
+            IF (my_mask.gt.0.5_r8) THEN
+              Ztop=Adepth(i,j,UBK)
+              Zbot=Adepth(i,j,LBK)
+              IF (z_slice(iz).ge.Ztop) THEN    ! shallower than top grid
+                k1=UBk                         ! cell. The slice is in 
+                k2=UBK                         ! the upper cell half
+                r1=1.0_r8                      ! shallower than top grid
+                r2=0.0_r8                      ! above its middle depth
+              ELSE IF (Zbot.ge.z_slice(iz)) THEN
+                r1=0.0_r8                      ! If deeper, ignore
+                r2=0.0_r8
+              ELSE
+                DO k=UBk,LBk+1,-1              ! Otherwise, interpolate
+                  Ztop=Adepth(i,j,k  )         ! field at slice depth
+                  Zbot=Adepth(i,j,k-1)
+                  IF ((Ztop.gt.z_slice(iz)).and.(z_slice(iz).ge.Zbot)) THEN
+                    k1=k-1
+                    k2=k
+                  END IF
+                END DO
+                dz=Adepth(i,j,k2)-Adepth(i,j,k1)
+                r2=(z_slice(iz)-Adepth(i,j,k1))/dz
+                r1=1.0_r8-r2
+              END IF
+              IF ((r1+r2).gt.0.0_r8) THEN
+                Aslice(i,j,iz)=r1*Adata(i,j,k1) + r2*Adata(i,j,k2)
+              ELSE
+                Aslice(i,j,iz)=spval           ! unbounded slice depth
+              END IF
+            ELSE
+              Aslice(i,j,iz)=0.0_r8            ! land masked value
+            END IF 
+          END DO
+        END DO
+      END DO
+!
+      RETURN
+      END SUBROUTINE extract_slice
+#endif
+      END MODULE extract_slice_mod
+

--- a/ROMS/Utility/read_phypar.F
+++ b/ROMS/Utility/read_phypar.F
@@ -2305,6 +2305,14 @@
               END IF
               Npts=load_l(Nval, Cval, Ngrids, Lswitch)
               Qout(idVsuN,1:Ngrids)=Lswitch(1:Ngrids)
+            CASE ('Qout(idRVsu)')
+              IF (idRVsu.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idRVsu'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Qout(idRVsu,1:Ngrids)=Lswitch(1:Ngrids)
 #ifdef SOLVE3D
             CASE ('Qout(idsurT)')
               IF (MAXVAL(idsurT).eq.0) THEN
@@ -2316,6 +2324,53 @@
               DO ng=1,Ngrids
                 DO itrc=1,NAT
                   i=idsurT(itrc)
+                  Qout(i,ng)=Ltracer(itrc,ng)
+                END DO
+              END DO
+#endif
+            CASE ('Qout(idUzsl)')
+              IF (idUzsl.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idUzsl'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Qout(idUzsl,1:Ngrids)=Lswitch(1:Ngrids)
+            CASE ('Qout(idVzsl)')
+              IF (idVzsl.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idVzsl'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Qout(idVzsl,1:Ngrids)=Lswitch(1:Ngrids)
+            CASE ('Qout(idUzsE)')
+              IF (idUzsE.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idUzsE'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Qout(idUzsE,1:Ngrids)=Lswitch(1:Ngrids)
+            CASE ('Qout(idVzsN)')
+              IF (idVzsN.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idVzsN'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Qout(idVzsN,1:Ngrids)=Lswitch(1:Ngrids)
+#ifdef SOLVE3D
+            CASE ('Qout(idzslT)')
+              IF (MAXVAL(idzslT).eq.0) THEN
+                IF (Master) WRITE (out,280) 'idzslT'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, NAT+NPT, Ngrids, Ltracer)
+              DO ng=1,Ngrids
+                DO itrc=1,NAT
+                  i=idzslT(itrc)
                   Qout(i,ng)=Ltracer(itrc,ng)
                 END DO
               END DO
@@ -3807,6 +3862,19 @@
 # endif
               END DO
 #endif
+            CASE ('NSLICE')
+              Npts=load_i(Nval, Rval, 1, Ivalue)
+              Nslice=Ivalue(1)
+              IF (Nslice.gt.0) THEN
+                IF (allocated(Zslice)) deallocate (Zslice)
+                allocate ( Zslice(Nslice) )
+                Zslice=spval
+              END IF
+            CASE ('Z_SLICE')
+              IF (Nslice.gt.0) THEN
+                Npts=load_r(Nval, Rval, Nslice, Zslice)
+                Zslice=-ABS(Zslice)
+              END IF
             CASE ('NUSER')
               Npts=load_i(Nval, Rval, 1, Ivalue)
               Nuser=Ivalue(1)
@@ -6285,18 +6353,30 @@
             IF (Qout(idVsur,ng)) WRITE (out,170) Qout(idVsur,ng),       &
      &         'Qout(idVsur)',                                          &
      &         'Write out surface V-momentum component.'
+            IF (Qout(idUzsl,ng)) WRITE (out,170) Qout(idUzsl,ng),       &
+     &         'Qout(idUzsl)',                                          &
+     &         'Write out 3D U-momentum component depth slices.'
+            IF (Qout(idVzsl,ng)) WRITE (out,170) Qout(idVzsl,ng),       &
+     &         'Qout(idVzsl)',                                          &
+     &         'Write out 3D V-momentum component depth slices.'
             IF (Qout(idu3dE,ng)) WRITE (out,170) Qout(idu3dE,ng),       &
      &         'Qout(idu3dE)',                                          &
-     &         'Write out 3D U-wastward  component at RHO-points.'
+     &         'Write out 3D U-eastward  component at RHO-points.'
             IF (Qout(idv3dN,ng)) WRITE (out,170) Qout(idv3dN,ng),       &
      &         'Qout(idv3dN)',                                          &
      &         'Write out 3D V-northward component at RHO-points.'
-            IF (Qout(idu3dE,ng)) WRITE (out,170) Qout(idu3dE,ng),       &
-     &         'Qout(idu3dE)',                                          &
-     &         'Write out surface U-wastward  component at RHO-points.'
-            IF (Qout(idv3dN,ng)) WRITE (out,170) Qout(idv3dN,ng),       &
-     &         'Qout(idv3dN)',                                          &
+            IF (Qout(idUsuE,ng)) WRITE (out,170) Qout(idUsuE,ng),       &
+     &         'Qout(idUsuE)',                                          &
+     &         'Write out surface U-eastward  component at RHO-points.'
+            IF (Qout(idVsuN,ng)) WRITE (out,170) Qout(idVsuN,ng),       &
+     &         'Qout(idVsuN)',                                          &
      &         'Write out surface V-northward component at RHO-points.'
+            IF (Qout(idUzsE,ng)) WRITE (out,170) Qout(idUzsE,ng),       &
+     &         'Qout(idUzlE)',                                          &
+     &         'Write out 3D U-eastward  component depth slices.'
+            IF (Qout(idVzsN,ng)) WRITE (out,170) Qout(idVzsN,ng),       &
+     &         'Qout(idVzsN)',                                          &
+     &         'Write out 3D V-northward component depth slices.'
             IF (Qout(idWvel,ng)) WRITE (out,170) Qout(idWvel,ng),       &
      &         'Qout(idWvel)',                                          &
      &         'Write out W-momentum component.'
@@ -6313,6 +6393,12 @@
      &            Qout(idsurT(itrc),ng), 'Qout(idsurT)',                &
      &            'Write out surface tracer ', itrc,                    &
      &            TRIM(Vname(1,idsurT(itrc)))
+            END DO
+            DO itrc=1,NAT
+              IF (Qout(idzslT(itrc),ng)) WRITE (out,180)                &
+     &            Qout(idzslT(itrc),ng), 'Qout(idzslT)',                &
+     &            'Write out tracer depth slices ', itrc,               &
+     &            TRIM(Vname(1,idzslT(itrc)))
             END DO
             IF (Qout(idpthR,ng)) WRITE (out,170) Qout(idpthR,ng),       &
      &         'Qout(idpthR)',                                          &
@@ -7748,12 +7834,25 @@
       END IF
 !
 !-----------------------------------------------------------------------
+!  Report depths for horizontal slices.
+!-----------------------------------------------------------------------
+!
+      IF (Nslice.gt.0) THEN
+        IF (Master.and.Lwrite) THEN
+          WRITE (out,'(/,a,/)') ' Horizontal slice Parameters:'
+          DO i=1,Nslice
+            WRITE (out,240) Zslice(i), i, i
+          END DO
+        END IF
+      END IF
+!
+!-----------------------------------------------------------------------
 !  Report generic USER parameters.
 !-----------------------------------------------------------------------
 !
       IF (Nuser.gt.0) THEN
         IF (Master.and.Lwrite) THEN
-          WRITE (out,240)
+          WRITE (out,'(/,a,/)') ' Generic User Parameters:'
           DO i=1,Nuser
             WRITE (out,250) user(i), i, i
           END DO
@@ -7962,7 +8061,8 @@
  210  FORMAT (1p,e11.4,2x,a,t32,a,/,t34,a)
  220  FORMAT (/,' Output/Input Files:',/)
  230  FORMAT (2x,a,a)
- 240  FORMAT (/,' Generic User Parameters:',/)
+ 240  FORMAT (1p,e11.4,2x,'Zslice(',i2.2,')',t32,                       &
+     &        'Depth parameter ',i2.2,'.')
  250  FORMAT (1p,e11.4,2x,'user(',i2.2,')',t32,                         &
      &        'User parameter ',i2.2,'.')
  260  FORMAT (/,' READ_PHYPAR - Invalid input parameter, ',a,           &

--- a/ROMS/Utility/read_phypar.F
+++ b/ROMS/Utility/read_phypar.F
@@ -1607,7 +1607,7 @@
                 RETURN
               END IF
               Npts=load_l(Nval, Cval, Ngrids, Lswitch)
-              Qout(idVzsN,1:Ngrids)=Lswitch(1:Ngrids)
+              Hout(idVzsN,1:Ngrids)=Lswitch(1:Ngrids)
 #ifdef SOLVE3D
             CASE ('Hout(idzslT)')
               IF (MAXVAL(idzslT).eq.0) THEN

--- a/ROMS/Utility/read_phypar.F
+++ b/ROMS/Utility/read_phypar.F
@@ -1529,6 +1529,38 @@
               END IF
               Npts=load_l(Nval, Cval, Ngrids, Lswitch)
               Hout(idv3dN,1:Ngrids)=Lswitch(1:Ngrids)
+            CASE ('Hout(id3dPV)')
+              IF (id3dPV.eq.0) THEN
+                IF (Master) WRITE (out,280) 'id3dPV'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Hout(id3dPV,1:Ngrids)=Lswitch(1:Ngrids)
+            CASE ('Hout(idPVzs)')
+              IF (idPVzs.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idPVzs'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Hout(idPVzs,1:Ngrids)=Lswitch(1:Ngrids)
+            CASE ('Hout(id3dRV)')
+              IF (id3dRV.eq.0) THEN
+                IF (Master) WRITE (out,280) 'id3dRV'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Hout(id3dRV,1:Ngrids)=Lswitch(1:Ngrids)
+            CASE ('Hout(idRVzs)')
+              IF (idRVzs.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idRVzs'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Hout(idRVzs,1:Ngrids)=Lswitch(1:Ngrids)
 #ifdef SOLVE3D
             CASE ('Hout(idTvar)')
               IF (MAXVAL(idTvar).eq.0) THEN
@@ -2352,14 +2384,22 @@
               END IF
               Npts=load_l(Nval, Cval, Ngrids, Lswitch)
               Qout(idVsuN,1:Ngrids)=Lswitch(1:Ngrids)
-            CASE ('Qout(idRVsu)')
-              IF (idRVsu.eq.0) THEN
-                IF (Master) WRITE (out,280) 'idRVsu'
+            CASE ('Qout(idPVzs)')
+              IF (idPVzs.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idPVzs'
                 exit_flag=5
                 RETURN
               END IF
               Npts=load_l(Nval, Cval, Ngrids, Lswitch)
-              Qout(idRVsu,1:Ngrids)=Lswitch(1:Ngrids)
+              Qout(idPVzs,1:Ngrids)=Lswitch(1:Ngrids)
+            CASE ('Qout(idRVzs)')
+              IF (idRVzs.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idRVzs'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Qout(idRVzs,1:Ngrids)=Lswitch(1:Ngrids)
 #ifdef SOLVE3D
             CASE ('Qout(idsurT)')
               IF (MAXVAL(idsurT).eq.0) THEN
@@ -6039,6 +6079,18 @@
             IF (Hout(idv3dN,ng)) WRITE (out,170) Hout(idv3dN,ng),       &
      &         'Hout(idv3dN)',                                          &
      &         'Write out 3D V-northward component at RHO-points.'
+            IF (Hout(id3dPV,ng)) WRITE (out,170) Hout(id3dPV,ng),       &
+     &         'Hout(id3dPV)',                                          &
+     &         'Write out 3D potential vorticity.'
+            IF (Hout(idPVzs,ng)) WRITE (out,170) Hout(idPVzs,ng),       &
+     &         'Hout(idPVzs)',                                          &
+     &         'Write out potential vorticity depth slices.'
+            IF (Hout(id3dRV,ng)) WRITE (out,170) Hout(id3dRV,ng),       &
+     &         'Hout(id3dRV)',                                          &
+     &         'Write out 3D relative vorticity.'
+            IF (Hout(idRVzs,ng)) WRITE (out,170) Hout(idRVzs,ng),       &
+     &         'Hout(idRVzs)',                                          &
+     &         'Write out relative vorticity depth slices.'
             IF (Hout(idWvel,ng)) WRITE (out,170) Hout(idWvel,ng),       &
      &         'Hout(idWvel)',                                          &
      &         'Write out W-momentum component.'
@@ -6455,6 +6507,12 @@
             IF (Qout(idVzsN,ng)) WRITE (out,170) Qout(idVzsN,ng),       &
      &         'Qout(idVzsN)',                                          &
      &         'Write out 3D V-northward component depth slices.'
+            IF (Qout(idPVzs,ng)) WRITE (out,170) Qout(idPVzs,ng),       &
+     &         'Qout(idPVzs)',                                          &
+     &         'Write out potential vorticity depth slices.'
+            IF (Qout(idRVzs,ng)) WRITE (out,170) Qout(idRVzs,ng),       &
+     &         'Qout(idRVzs)',                                          &
+     &         'Write out relative vorticity depth slices.'
             IF (Qout(idWvel,ng)) WRITE (out,170) Qout(idWvel,ng),       &
      &         'Qout(idWvel)',                                          &
      &         'Write out W-momentum component.'

--- a/ROMS/Utility/read_phypar.F
+++ b/ROMS/Utility/read_phypar.F
@@ -1544,6 +1544,53 @@
                 END DO
               END DO
 #endif
+            CASE ('Hout(idUzsl)')
+              IF (idUzsl.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idUzsl'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Hout(idUzsl,1:Ngrids)=Lswitch(1:Ngrids)
+            CASE ('Hout(idVzsl)')
+              IF (idVzsl.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idVzsl'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Hout(idVzsl,1:Ngrids)=Lswitch(1:Ngrids)
+            CASE ('Hout(idUzsE)')
+              IF (idUzsE.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idUzsE'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Hout(idUzsE,1:Ngrids)=Lswitch(1:Ngrids)
+            CASE ('Hout(idVzsN)')
+              IF (idVzsN.eq.0) THEN
+                IF (Master) WRITE (out,280) 'idVzsN'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, Ngrids, Lswitch)
+              Qout(idVzsN,1:Ngrids)=Lswitch(1:Ngrids)
+#ifdef SOLVE3D
+            CASE ('Hout(idzslT)')
+              IF (MAXVAL(idzslT).eq.0) THEN
+                IF (Master) WRITE (out,280) 'idzslT'
+                exit_flag=5
+                RETURN
+              END IF
+              Npts=load_l(Nval, Cval, NAT+NPT, Ngrids, Ltracer)
+              DO ng=1,Ngrids
+                DO itrc=1,NAT
+                  i=idzslT(itrc)
+                  Hout(i,ng)=Ltracer(itrc,ng)
+                END DO
+              END DO
+#endif
             CASE ('Hout(idpthR)')
               IF (idpthR.eq.0) THEN
                 IF (Master) WRITE (out,280) 'idpthR'
@@ -2363,7 +2410,8 @@
 #ifdef SOLVE3D
             CASE ('Qout(idzslT)')
               IF (MAXVAL(idzslT).eq.0) THEN
-                IF (Master) WRITE (out,280) 'idzslT'
+
+                 IF (Master) WRITE (out,280) 'idzslT'
                 exit_flag=5
                 RETURN
               END IF
@@ -3874,6 +3922,11 @@
               IF (Nslice.gt.0) THEN
                 Npts=load_r(Nval, Rval, Nslice, Zslice)
                 Zslice=-ABS(Zslice)
+                DO i=1,Nslice
+                  IF (Zslice(i).gt.0.0_r8) THEN
+                    Zslice(i)=-Zslice(i)
+                  END IF
+                END DO
               END IF
             CASE ('NUSER')
               Npts=load_i(Nval, Rval, 1, Ivalue)
@@ -6002,6 +6055,30 @@
      &            Hout(idTvar(itrc),ng), 'Hout(idTvar)',                &
      &            'Write out tracer ', itrc, TRIM(Vname(1,idTvar(itrc)))
             END DO
+            IF (Hout(idUzsl,ng)) WRITE (out,170) Hout(idUzsl,ng),       &
+     &         'Hout(idUzsl)',                                          &
+     &         'Write out 3D U-momentum component depth slices.'
+            IF (Hout(idVzsl,ng)) WRITE (out,170) Hout(idVzsl,ng),       &
+     &         'Hout(idVzsl)',                                          &
+     &         'Write out 3D V-momentum component depth slices.'
+            IF (Hout(idUzsE,ng)) WRITE (out,170) Hout(idUzsE,ng),       &
+     &         'Hout(idUzlE)',                                          &
+     &         'Write out 3D U-eastward  component depth slices.'
+            IF (Hout(idVzsN,ng)) WRITE (out,170) Hout(idVzsN,ng),       &
+     &         'Hout(idVzsN)',                                          &
+     &         'Write out 3D V-northward component depth slices.'
+            DO itrc=1,NAT
+              IF (Qout(idzslT(itrc),ng)) WRITE (out,180)                &
+     &            Qout(idzslT(itrc),ng), 'Qout(idzslT)',                &
+     &            'Write out tracer depth slices ', itrc,               &
+     &            TRIM(Vname(1,idzslT(itrc)))
+            END DO
+            DO itrc=1,NAT
+              IF (Hout(idzslT(itrc),ng)) WRITE (out,180)                &
+     &            Hout(idzslT(itrc),ng), 'Hout(idzslT)',                &
+     &            'Write out tracer depth slices ', itrc,               &
+     &            TRIM(Vname(1,idzslT(itrc)))
+            END DO
             IF (Hout(idpthR,ng)) WRITE (out,170) Hout(idpthR,ng),       &
      &         'Hout(idpthR)',                                          &
      &         'Write out time-varying dephts of RHO-points.'
@@ -6353,6 +6430,7 @@
             IF (Qout(idVsur,ng)) WRITE (out,170) Qout(idVsur,ng),       &
      &         'Qout(idVsur)',                                          &
      &         'Write out surface V-momentum component.'
+
             IF (Qout(idUzsl,ng)) WRITE (out,170) Qout(idUzsl,ng),       &
      &         'Qout(idUzsl)',                                          &
      &         'Write out 3D U-momentum component depth slices.'
@@ -8062,7 +8140,7 @@
  220  FORMAT (/,' Output/Input Files:',/)
  230  FORMAT (2x,a,a)
  240  FORMAT (1p,e11.4,2x,'Zslice(',i2.2,')',t32,                       &
-     &        'Depth parameter ',i2.2,'.')
+     &        'Slice depth ',i2.2,'.')
  250  FORMAT (1p,e11.4,2x,'user(',i2.2,')',t32,                         &
      &        'User parameter ',i2.2,'.')
  260  FORMAT (/,' READ_PHYPAR - Invalid input parameter, ',a,           &

--- a/ROMS/Utility/set_pio.F
+++ b/ROMS/Utility/set_pio.F
@@ -372,6 +372,11 @@
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_u3dvar(ng))
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_v3dvar(ng))
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_w3dvar(ng))
+
+            CALL PIO_freedecomp (pioSystem(i,ng), ioDesZ_sp_p3dvar(ng))
+            CALL PIO_freedecomp (pioSystem(i,ng), ioDesZ_sp_r3dvar(ng))
+            CALL PIO_freedecomp (pioSystem(i,ng), ioDesZ_sp_u3dvar(ng))
+            CALL PIO_freedecomp (pioSystem(i,ng), ioDesZ_sp_v3dvar(ng))
 # endif
           END DO
         END DO
@@ -410,6 +415,11 @@
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_u3dvar(ng))
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_v3dvar(ng))
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_w3dvar(ng))
+
+            CALL PIO_freedecomp (pioSystem(i,ng), ioDesZ_dp_p3dvar(ng))
+            CALL PIO_freedecomp (pioSystem(i,ng), ioDesZ_dp_r3dvar(ng))
+            CALL PIO_freedecomp (pioSystem(i,ng), ioDesZ_dp_u3dvar(ng))
+            CALL PIO_freedecomp (pioSystem(i,ng), ioDesZ_dp_v3dvar(ng))
 # endif
           END DO
         END DO
@@ -815,6 +825,13 @@
       allocate ( ioDesc_sp_u3dvar(Ngrids) )
       allocate ( ioDesc_sp_v3dvar(Ngrids) )
       allocate ( ioDesc_sp_w3dvar(Ngrids) )
+
+      IF (Nslice.gt.0) THEN                   ! output at depth slices
+        allocate ( ioDesZ_sp_p3dvar(Ngrids) )
+        allocate ( ioDesZ_sp_r3dvar(Ngrids) )
+        allocate ( ioDesZ_sp_u3dvar(Ngrids) )
+        allocate ( ioDesZ_sp_v3dvar(Ngrids) )
+      END IF
 # endif
 !
 ! I/O decomposition descriptors for double precision data.
@@ -856,6 +873,13 @@
       allocate ( ioDesc_dp_u3dvar(Ngrids) )
       allocate ( ioDesc_dp_v3dvar(Ngrids) )
       allocate ( ioDesc_dp_w3dvar(Ngrids) )
+
+      IF (Nslice.gt.0) THEN                   ! output at depth slices
+        allocate ( ioDesZ_dp_p3dvar(Ngrids) )
+        allocate ( ioDesZ_dp_r3dvar(Ngrids) )
+        allocate ( ioDesZ_dp_u3dvar(Ngrids) )
+        allocate ( ioDesZ_dp_v3dvar(Ngrids) )
+      END IF
 # endif
 !
 !  I/O decomposition descriptors for special single precision
@@ -990,6 +1014,21 @@
         CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_real,      &
      &                       ioDesc_sp_w3dvar(ng),                      &
      &                       w3dvar, 3, 0, N(ng))
+!
+        IF (Nslice.gt.0) THEN
+          CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_real,    &
+     &                         ioDesZ_sp_p3dvar(ng),                    &
+     &                         p3dvar, 3, 1, Nslice)
+          CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_real,    &
+     &                         ioDesZ_sp_r3dvar(ng),                    &
+     &                         r3dvar, 3, 1, Nslice)
+          CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_real,    &
+     &                         ioDesZ_sp_u3dvar(ng),                    &
+     &                         u3dvar, 3, 1, Nslice)
+          CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_real,    &
+     &                         ioDesZ_sp_v3dvar(ng),                    &
+     &                         v3dvar, 3, 1, Nslice)
+        END IF
 # endif
 # if defined ADJUST_STFLUX && defined DISTRIBUTE
         CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_real,      &
@@ -1077,6 +1116,21 @@
         CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,    &
      &                       ioDesc_dp_w3dvar(ng),                      &
      &                       w3dvar, 3, 0, N(ng))
+!
+        IF (Nslice.gt.0) THEN
+          CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,  &
+     &                         ioDesZ_dp_p3dvar(ng),                    &
+     &                         p3dvar, 3, 1, Nslice)
+          CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,  &
+     &                         ioDesZ_dp_r3dvar(ng),                    &
+     &                         r3dvar, 3, 1, Nslice)
+          CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,  &
+     &                         ioDesZ_dp_u3dvar(ng),                    &
+     &                         u3dvar, 3, 1, Nslice)
+          CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,  &
+     &                         ioDesZ_dp_v3dvar(ng),                    &
+     &                         v3dvar, 3, 1, Nslice)
+        END IF
 # endif
 # if defined ADJUST_STFLUX && defined DISTRIBUTE
         CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,    &

--- a/ROMS/Utility/vorticity.F
+++ b/ROMS/Utility/vorticity.F
@@ -41,22 +41,147 @@
 !                                                                      !
 !=======================================================================
 !
+      USE mod_param
+      USE mod_average
+      USE mod_param
+      USE mod_grid
+      USE mod_ncparam
+      USE mod_ocean
+      USE mod_scalars
+!
+      USE exchange_2d_mod, ONLY : exchange_p2d_tile
+# ifdef SOLVE3D
+      USE exchange_3d_mod, ONLY : exchange_p3d_tile
+# endif
+# ifdef DISTRIBUTE
+      USE mp_exchange_mod, ONLY : mp_exchange2d
+#  ifdef SOLVE3D
+      USE mp_exchange_mod, ONLY : mp_exchange3d
+#  endif
+# endif
+!
       implicit none
 !
+      PUBLIC  :: pvorticity2d
       PUBLIC  :: rvorticity2d
 #ifdef SOLVE3D
+      PUBLIC  :: pvorticity3d
       PUBLIC  :: rvorticity3d
 #endif
 #if defined AVERAGES    || \
    (defined AD_AVERAGES && defined ADJOINT) || \
    (defined RP_AVERAGES && defined TL_IOMS) || \
    (defined TL_AVERAGES && defined TANGENT)
-      PUBLIC  :: vorticity
-      PUBLIC  :: vorticity_tile
+      PUBLIC  :: vorticity_avg
+      PUBLIC  :: vorticity_avg_tile
 #endif
       PRIVATE
 !
       CONTAINS
+!
+!***********************************************************************
+      SUBROUTINE pvorticity2d (ng, model, tile,                         &
+     &                         LBi, UBi, LBj, UBj,                      &
+     &                         kout,                                    &
+#ifdef MASKING
+     &                         pmask,                                   &
+#endif
+     &                         f, h, om_u, on_v, pm, pn,                &
+     &                         ubar, vbar, zeta,                        &
+     &                         pvor2d)
+!***********************************************************************
+!
+!  Imported variable declarations.
+!
+      integer,  intent(in)  :: ng, model, tile
+      integer,  intent(in)  :: LBi, UBi, LBj, UBj
+      integer,  intent(in)  :: kout
+!
+#ifdef ASSUMED_SHAPE
+# ifdef MASKING
+      real(r8), intent(in)  :: pmask(LBi:,LBj:)
+# endif
+      real(r8), intent(in)  :: f(LBi:,LBj:)
+      real(r8), intent(in)  :: h(LBi:,LBj:)
+      real(r8), intent(in)  :: om_u(LBi:,LBj:)
+      real(r8), intent(in)  :: on_v(LBi:,LBj:)
+      real(r8), intent(in)  :: pm(LBi:,LBj:)
+      real(r8), intent(in)  :: pn(LBi:,LBj:)
+      real(r8), intent(in)  :: ubar(LBi:,LBj:,:)
+      real(r8), intent(in)  :: vbar(LBi:,LBj:,:)
+      real(r8), intent(in)  :: zeta(LBi:,LBj:,:)
+      real(r8), intent(out) :: pvor2d(LBi:,LBj:)
+
+#else
+
+# ifdef MASKING
+      real(r8), intent(in)  :: pmask(LBi:UBi,LBj:UBj)
+# endif
+      real(r8), intent(in)  :: f(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: h(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: om_u(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: on_v(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: pm(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: pn(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: ubar(LBi:UBi,LBj:UBj,:)
+      real(r8), intent(in)  :: vbar(LBi:UBi,LBj:UBj,:)
+      real(r8), intent(in)  :: zeta(LBi:UBi,LBj:UBj,:)
+      real(r8), intent(out) :: pvor2d(LBi:UBi,LBj:UBj)
+#endif
+!
+!  Local variable declarations.
+!
+      integer  :: i, j
+      real(r8) :: cff, fomn_p, dUde_p, dVdx_p
+
+#include "set_bounds.h"
+!
+!-----------------------------------------------------------------------
+!  Compute 2D potential vorticity.
+!-----------------------------------------------------------------------
+!
+!  Potential vorticity (meter-1 second-1) at PSI-points.
+!
+      DO j=Jstr,JendR
+        DO i=Istr,IendR
+          cff=0.0625_r8*                                                &
+     &        (pm(i-1,j-1)+pm(i-1,j)+pm(i,j-1)+pm(i,j))*                &
+     &        (pn(i-1,j-1)+pn(i-1,j)+pn(i,j-1)+pn(i,j))
+          fomn_p=0.25_r8*(f(i-1,j-1)+f(i-1,j)+f(i,j-1)+f(i,j))/cff
+          cff=pm(i,j)*pn(i,j)
+          dVdx_p=on_v(i  ,j)*vbar(i  ,j,kout)-                          &
+     &           on_v(i-1,j)*vbar(i-1,j,kout)
+#ifdef MASKING
+          dVdx_p=dVdx_p*pmask(i,j)
+#endif
+          dUde_p=om_u(i,j  )*ubar(i,j  ,kout)-                          &
+     &           om_u(i,j-1)*ubar(i,j-1,kout)
+#ifdef MASKING
+          dUde_p=dUde_p*pmask(i,j)
+#endif
+          pvor2d(i,j)=cff*((fomn_p+dVdx_p-dUde_p)/                      &
+     &                     (h(i,j)+zeta(i,j,kout)))
+        END DO
+      END DO
+!
+!  Exchange boundary information.
+!
+      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
+        CALL exchange_p2d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          pvor2d)
+      END IF
+
+#ifdef DISTRIBUTE
+! 
+      CALL mp_exchange2d (ng, tile, model, 1,                           &
+     &                    LBi, UBi, LBj, UBj,                           &
+     &                    NghostPoints, EWperiodic(ng), NSperiodic(ng), &
+     &                    pvor2d)
+#endif
+!
+      RETURN
+      END SUBROUTINE pvorticity2d
 !
 !***********************************************************************
       SUBROUTINE rvorticity2d (ng, model, tile,                         &
@@ -70,20 +195,12 @@
      &                         rvor2d)
 !***********************************************************************
 !
-      USE mod_param
-      USE mod_scalars
-!
-      USE exchange_2d_mod, ONLY : exchange_p2d_tile
-#ifdef DISTRIBUTE
-      USE mp_exchange_mod, ONLY : mp_exchange2d
-#endif
-!
 !  Imported variable declarations.
 !
       integer, intent(in)   :: ng, model, tile
       integer, intent(in)   :: LBi, UBi, LBj, UBj
       integer, intent(in)   :: kout
-
+!
 #ifdef ASSUMED_SHAPE
 # ifdef MASKING
       real(r8), intent(in)  :: pmask(LBi:,LBj:)
@@ -156,12 +273,228 @@
      &                    LBi, UBi, LBj, UBj,                           &
      &                    NghostPoints, EWperiodic(ng), NSperiodic(ng), &
      &                    rvor2d)
-# endif
+#endif
 !
       RETURN
       END SUBROUTINE rvorticity2d
 
 #ifdef SOLVE3D
+!
+!***********************************************************************
+      SUBROUTINE pvorticity3d (ng, model, tile,                         &
+     &                         LBi, UBi, LBj, UBj,                      &
+     &                         IminS, ImaxS, JminS, JmaxS,              &
+     &                         nout,                                    &
+# ifdef MASKING
+     &                         pmask, umask, vmask,                     &
+# endif
+     &                         f, om_u, on_v, pm, pn, z_r,              &
+     &                         pden, u, v,                              &
+     &                         pvor3d)
+!***********************************************************************
+!
+!  Imported variable declarations.
+!
+      integer,  intent(in)  :: ng, model, tile
+      integer,  intent(in)  :: LBi, UBi, LBj, UBj
+      integer,  intent(in)  :: IminS, ImaxS, JminS, JmaxS
+      integer,  intent(in)  :: nout
+!
+# ifdef ASSUMED_SHAPE
+#  ifdef MASKING
+      real(r8), intent(in)  :: pmask(LBi:,LBj:)
+      real(r8), intent(in)  :: umask(LBi:,LBj:)
+      real(r8), intent(in)  :: vmask(LBi:,LBj:)
+#  endif
+      real(r8), intent(in)  :: f(LBi:,LBj:)
+      real(r8), intent(in)  :: om_u(LBi:,LBj:)
+      real(r8), intent(in)  :: on_v(LBi:,LBj:)
+      real(r8), intent(in)  :: pm(LBi:,LBj:)
+      real(r8), intent(in)  :: pn(LBi:,LBj:)
+      real(r8), intent(in)  :: z_r(LBi:,LBj:,:)
+      real(r8), intent(in)  :: pden(LBi:,LBj:,:)
+      real(r8), intent(in)  :: u(LBi:,LBj:,:,:)
+      real(r8), intent(in)  :: v(LBi:,LBj:,:,:)
+      real(r8), intent(out) :: pvor3d(LBi:,LBj:,:)
+
+# else
+
+#  ifdef MASKING
+      real(r8), intent(in)  :: pmask(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: umask(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: vmask(LBi:UBi,LBj:UBj)
+#  endif
+      real(r8), intent(in)  :: f(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: om_u(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: on_v(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: pm(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: pn(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: z_r(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(in)  :: pden(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(in)  :: u(LBi:UBi,LBj:UBj,N(ng),2)
+      real(r8), intent(in)  :: v(LBi:UBi,LBj:UBj,N(ng),2)
+      real(r8), intent(out) :: rvor3d(LBi:UBi,LBj:UBj,N(ng))
+# endif
+!
+!  Local variable declarations.
+!
+      integer  :: i, j, k, k1, k2
+!
+      real(r8) :: cff, fomn_p, orho0
+      real(r8) :: dRde_pr, dRdx_pr, dRdz_pr, dUdz_pr, dVdz_pr
+
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: dRde
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: dRdx
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: dUde
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: dVdx
+
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS,2) :: dRdz
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS,2) :: dUdz
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS,2) :: dVdz
+
+# include "set_bounds.h"
+!
+!-----------------------------------------------------------------------
+!  Compute 3D potential vorticity.
+!-----------------------------------------------------------------------
+!
+!  Compute horizontal and vertical gradients.  Notice the recursive
+!  blocking sequence for vertical placement of the gradients is:
+!
+!      dRdz,dUdz,dVdz(:,:,k1) k-1/2   W-points
+!      dRdz,dUdz,dVdz(:,:,k2) k+1/2   W-points
+!
+      orho0=1.0_r8/rho0
+
+      k2=1
+      K_LOOP : DO k=0,N(ng)
+        k1=k2
+        k2=3-k1
+        IF (k.gt.0) THEN
+          DO j=Jstr-1,JendR
+            DO i=Istr,IendR
+              cff=0.5_r8*(pm(i,j)+pm(i-1,j))
+# ifdef MASKING
+              cff=cff*umask(i,j)
+# endif
+              dRdx(i,j)=cff*(pden(i  ,j,k)-                             &
+     &                       pden(i-1,j,k))
+            END DO
+          END DO
+          DO j=Jstr,JendR
+            DO i=Istr-1,IendR
+              cff=0.5_r8*(pn(i,j)+pn(i,j-1))
+# ifdef MASKING
+              cff=cff*vmask(i,j)
+# endif
+              dRde(i,j)=cff*(pden(i,j  ,k)-                             &
+     &                       pden(i,j-1,k))
+            END DO
+          END DO
+          DO j=Jstr,JendR
+            DO i=Istr,IendR
+              dUde(i,j)=om_u(i,j  )*u(i,j  ,k,nout)-                    &
+     &                  om_u(i,j-1)*u(i,j-1,k,nout)
+# ifdef MASKING
+              dUde(i,j)=dUde(i,j)*pmask(i,j)
+# endif
+              dVdx(i,j)=on_v(i  ,j)*v(i  ,j,k,nout)-                    &
+     &                  on_v(i-1,j)*v(i-1,j,k,nout)
+# ifdef MASKING
+              dVdx(i,j)=dVdx(i,j)*pmask(i,j)
+# endif
+            END DO
+          END DO
+        END IF
+        IF ((k.eq.0).or.(k.eq.N(ng))) THEN
+          DO j=Jstr-1,JendR
+            DO i=Istr-1,IendR
+              dRdz(i,j,k2)=0.0_r8
+            END DO
+          END DO
+          DO j=Jstr-1,JendR
+            DO i=Istr,IendR
+              dUdz(i,j,k2)=0.0_r8
+            END DO
+          END DO
+          DO j=Jstr,JendR
+            DO i=Istr-1,IendR
+              dVdz(i,j,k2)=0.0_r8
+            END DO
+          END DO
+        ELSE
+          DO j=Jstr-1,JendR
+            DO i=Istr-1,IendR
+              cff=1.0_r8/(z_r(i,j,k+1)-z_r(i,j,k))
+              dRdz(i,j,k2)=cff*(pden(i,j,k+1)-                          &
+     &                          pden(i,j,k  ))
+            END DO
+          END DO
+          DO j=Jstr-1,JendR
+            DO i=Istr,IendR
+              cff=1.0_r8/(0.5_r8*(z_r(i-1,j,k+1)-z_r(i-1,j,k)+          &
+     &                            z_r(i  ,j,k+1)-z_r(i  ,j,k)))
+              dUdz(i,j,k2)=cff*(u(i,j,k+1,nout)-                        &
+     &                          u(i,j,k  ,nout))
+            END DO
+          END DO
+          DO j=Jstr,JendR
+            DO i=Istr-1,IendR
+              cff=1.0_r8/(0.5_r8*(z_r(i,j-1,k+1)-z_r(i,j-1,k)+          &
+     &                            z_r(i,j  ,k+1)-z_r(i,j  ,k)))
+              dVdz(i,j,k2)=cff*(v(i,j,k+1,nout)-                        &
+     &                          v(i,j,k  ,nout))
+            END DO
+          END DO
+        END IF
+!
+!  Compute potential vorticity (meter-1 second-1) at horizontal
+!  PSI-points and vertical RHO-points.
+!
+        IF (k.gt.0) THEN
+          DO j=Jstr,JendR
+            DO i=Istr,IendR
+              cff=0.0625_r8*                                            &
+     &            (pm(i-1,j-1)+pm(i-1,j)+pm(i,j-1)+pm(i,j))*            &
+     &            (pn(i-1,j-1)+pn(i-1,j)+pn(i,j-1)+pn(i,j))
+              fomn_p=0.25_r8*(f(i-1,j-1)+f(i-1,j)+f(i,j-1)+f(i,j))/cff
+              dRde_pr=dRde(i-1,j  )+dRde(i,j)
+              dRdx_pr=dRdx(i  ,j-1)+dRdx(i,j)
+              dRdz_pr=0.125_r8*(dRdz(i-1,j-1,k1)+dRdz(i-1,j-1,k2)+      &
+     &                          dRdz(i  ,j-1,k1)+dRdz(i  ,j-1,k2)+      &
+     &                          dRdz(i-1,j  ,k1)+dRdz(i-1,j  ,k2)+      &
+     &                          dRdz(i  ,j  ,k1)+dRdz(i  ,j  ,k2))
+              dUdz_pr=dUdz(i  ,j-1,k1)+dUdz(i  ,j-1,k2)+                &
+     &                dUdz(i  ,j  ,k1)+dUdz(i  ,j  ,k2)
+              dVdz_pr=dVdz(i-1,j  ,k1)+dVdz(i-1,j  ,k2)+                &
+     &                dVdz(i  ,j  ,k1)+dVdz(i  ,j  ,k2)
+              pvor3d(i,j,k)=orho0*                                      &
+     &                      (cff*dRdz_pr*(fomn_p+                       &
+     &                                    dVdx(i,j)-dUde(i,j))+         &
+     &                       0.125_r8*(dUdz_pr*dRde_pr-dVdz_pr*dRdx_pr))
+            END DO
+          END DO
+        END IF
+      END DO K_LOOP
+!
+!  Exchange boundary data.
+!
+      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
+        CALL exchange_p3d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
+     &                          pvor3d)
+      END IF
+
+# ifdef DISTRIBUTE
+!
+      CALL mp_exchange3d (ng, tile, model, 1,                           &
+     &                    LBi, UBi, LBj, UBj, 1, N(ng),                 &
+     &                    NghostPoints, EWperiodic(ng), NSperiodic(ng), &
+     &                    pvor3d)
+# endif
+!
+      RETURN
+      END SUBROUTINE pvorticity3d
 !
 !***********************************************************************
       SUBROUTINE rvorticity3d (ng, model, tile,                         &
@@ -175,19 +508,11 @@
      &                         rvor3d)
 !***********************************************************************
 !
-      USE mod_param
-      USE mod_scalars
-!
-      USE exchange_3d_mod, ONLY : exchange_p3d_tile
-# ifdef DISTRIBUTE
-      USE mp_exchange_mod, ONLY : mp_exchange3d
-# endif
-!
 !  Imported variable declarations.
 !
-      integer, intent(in)   :: ng, model, tile
-      integer, intent(in)   :: LBi, UBi, LBj, UBj
-      integer, intent(in)   :: nout
+      integer,  intent(in)  :: ng, model, tile
+      integer,  intent(in)  :: LBi, UBi, LBj, UBj
+      integer,  intent(in)  :: nout
 
 # ifdef ASSUMED_SHAPE
 #  ifdef MASKING
@@ -260,7 +585,7 @@
 
 # ifdef DISTRIBUTE
 !
-      CALL mp_exchange3d (ng, tile, iNLM, 1,                            &
+      CALL mp_exchange3d (ng, tile, model, 1,                           &
      &                    LBi, UBi, LBj, UBj, 1, N(ng),                 &
      &                    NghostPoints, EWperiodic(ng), NSperiodic(ng), &
      &                    rvor3d)
@@ -276,18 +601,14 @@
    (defined TL_AVERAGES && defined TANGENT)
 !
 !***********************************************************************
-      SUBROUTINE vorticity (ng, tile)
+      SUBROUTINE vorticity_avg (ng, model, tile)
 !***********************************************************************
 !
-      USE mod_param
-      USE mod_average
-      USE mod_grid
-      USE mod_ocean
       USE mod_stepping
 !
 !  Imported variable declarations.
 !
-      integer, intent(in) :: ng, tile
+      integer, intent(in) :: ng, model, tile
 !
 !  Local variable declarations.
 !
@@ -297,120 +618,105 @@
 # include "tile.h"
 !
 # ifdef PROFILE
-      CALL wclock_on (ng, iNLM, 5, __LINE__, MyFile)
+      CALL wclock_on (ng, model, 5, __LINE__, MyFile)
 # endif
-      CALL vorticity_tile (ng, tile,                                    &
-     &                     LBi, UBi, LBj, UBj,                          &
-     &                     IminS, ImaxS, JminS, JmaxS,                  &
+      CALL vorticity_avg_tile (ng, model, tile,                         &
+     &                         LBi, UBi, LBj, UBj,                      &
+     &                         IminS, ImaxS, JminS, JmaxS,              &
 # ifdef SOLVE3D
-     &                     KOUT, NOUT,                                  &
+     &                         KOUT, NOUT,                              &
 # else
-     &                     KOUT,                                        &
+     &                         KOUT,                                    &
 # endif
 # ifdef MASKING
-     &                     GRID(ng) % pmask,                            &
-     &                     GRID(ng) % umask,                            &
-     &                     GRID(ng) % vmask,                            &
+     &                         GRID(ng) % pmask,                        &
+     &                         GRID(ng) % umask,                        &
+     &                         GRID(ng) % vmask,                        &
 # endif
-     &                     GRID(ng) % f,                                &
-     &                     GRID(ng) % h,                                &
-     &                     GRID(ng) % om_u,                             &
-     &                     GRID(ng) % on_v,                             &
-     &                     GRID(ng) % pm,                               &
-     &                     GRID(ng) % pn,                               &
+     &                         GRID(ng) % f,                            &
+     &                         GRID(ng) % h,                            &
+     &                         GRID(ng) % om_u,                         &
+     &                         GRID(ng) % on_v,                         &
+     &                         GRID(ng) % pm,                           &
+     &                         GRID(ng) % pn,                           &
 # ifdef SOLVE3D
-     &                     GRID(ng) % z_r,                              &
-     &                     OCEAN(ng) % pden,                            &
-     &                     OCEAN(ng) % u,                               &
-     &                     OCEAN(ng) % v,                               &
+     &                         GRID(ng) % z_r,                          &
+     &                         OCEAN(ng) % pden,                        &
+     &                         OCEAN(ng) % u,                           &
+     &                         OCEAN(ng) % v,                           &
 # endif
-     &                     OCEAN(ng) % ubar,                            &
-     &                     OCEAN(ng) % vbar,                            &
-     &                     OCEAN(ng) % zeta,                            &
+     &                         OCEAN(ng) % ubar,                        &
+     &                         OCEAN(ng) % vbar,                        &
+     &                         OCEAN(ng) % zeta,                        &
 # ifdef SOLVE3D
-     &                     AVERAGE(ng) % avgpvor3d,                     &
-     &                     AVERAGE(ng) % avgrvor3d,                     &
+     &                         AVERAGE(ng) % avgpvor3d,                 &
+     &                         AVERAGE(ng) % avgrvor3d,                 &
 # endif
-     &                     AVERAGE(ng) % avgpvor2d,                     &
-     &                     AVERAGE(ng) % avgrvor2d)
+     &                         AVERAGE(ng) % avgpvor2d,                 &
+     &                         AVERAGE(ng) % avgrvor2d)
 
 # ifdef PROFILE
-      CALL wclock_off (ng, iNLM, 5, __LINE__, MyFile)
+      CALL wclock_off (ng, model, 5, __LINE__, MyFile)
 # endif
 !
       RETURN
-      END SUBROUTINE vorticity
+      END SUBROUTINE vorticity_avg
 !
 !***********************************************************************
-      SUBROUTINE vorticity_tile (ng, tile,                              &
-     &                           LBi, UBi, LBj, UBj,                    &
-     &                           IminS, ImaxS, JminS, JmaxS,            &
+      SUBROUTINE vorticity_avg_tile (ng, model, tile,                   &
+     &                               LBi, UBi, LBj, UBj,                &
+     &                               IminS, ImaxS, JminS, JmaxS,        &
 # ifdef SOLVE3D
-     &                           kout, nout,                            &
+     &                               kout, nout,                        &
 # else
-     &                           kout,                                  &
+     &                               kout,                              &
 # endif
 # ifdef MASKING
-     &                           pmask, umask, vmask,                   &
+     &                               pmask, umask, vmask,               &
 # endif
-     &                           f, h, om_u, on_v, pm, pn,              &
+     &                               f, h, om_u, on_v, pm, pn,          &
 # ifdef SOLVE3D
-     &                           z_r, pden, u, v,                       &
+     &                               z_r, pden, u, v,                   &
 # endif
-     &                           ubar, vbar, zeta,                      &
+     &                               ubar, vbar, zeta,                  &
 # ifdef SOLVE3D
-     &                           pvor, rvor,                            &
+     &                               pvor, rvor,                        &
 # endif
-     &                           pvor_bar, rvor_bar)
+     &                               pvor_bar, rvor_bar)
 !***********************************************************************
-!
-      USE mod_param
-      USE mod_ncparam
-      USE mod_scalars
-!
-      USE exchange_2d_mod, ONLY : exchange_p2d_tile
-# ifdef SOLVE3D
-      USE exchange_3d_mod, ONLY : exchange_p3d_tile
-# endif
-# ifdef DISTRIBUTE
-      USE mp_exchange_mod, ONLY : mp_exchange2d
-#  ifdef SOLVE3D
-      USE mp_exchange_mod, ONLY : mp_exchange3d
-#  endif
-# endif
 !
 !  Imported variable declarations.
 !
-      integer, intent(in) :: ng, tile
-      integer, intent(in) :: LBi, UBi, LBj, UBj
-      integer, intent(in) :: IminS, ImaxS, JminS, JmaxS
+      integer,  intent(in)  :: ng, model, tile
+      integer,  intent(in)  :: LBi, UBi, LBj, UBj
+      integer,  intent(in)  :: IminS, ImaxS, JminS, JmaxS
 # ifdef SOLVE3D
-      integer, intent(in) :: kout, nout
+      integer,  intent(in)  :: kout, nout
 # else
-      integer, intent(in) :: kout
+      integer,  intent(in)  :: kout
 # endif
-
+!
 # ifdef ASSUMED_SHAPE
 #  ifdef MASKING
-      real(r8), intent(in) :: pmask(LBi:,LBj:)
-      real(r8), intent(in) :: umask(LBi:,LBj:)
-      real(r8), intent(in) :: vmask(LBi:,LBj:)
+      real(r8), intent(in)  :: pmask(LBi:,LBj:)
+      real(r8), intent(in)  :: umask(LBi:,LBj:)
+      real(r8), intent(in)  :: vmask(LBi:,LBj:)
 #  endif
-      real(r8), intent(in) :: f(LBi:,LBj:)
-      real(r8), intent(in) :: h(LBi:,LBj:)
-      real(r8), intent(in) :: om_u(LBi:,LBj:)
-      real(r8), intent(in) :: on_v(LBi:,LBj:)
-      real(r8), intent(in) :: pm(LBi:,LBj:)
-      real(r8), intent(in) :: pn(LBi:,LBj:)
+      real(r8), intent(in)  :: f(LBi:,LBj:)
+      real(r8), intent(in)  :: h(LBi:,LBj:)
+      real(r8), intent(in)  :: om_u(LBi:,LBj:)
+      real(r8), intent(in)  :: on_v(LBi:,LBj:)
+      real(r8), intent(in)  :: pm(LBi:,LBj:)
+      real(r8), intent(in)  :: pn(LBi:,LBj:)
 #  ifdef SOLVE3D
-      real(r8), intent(in) :: z_r(LBi:,LBj:,:)
-      real(r8), intent(in) :: pden(LBi:,LBj:,:)
-      real(r8), intent(in) :: u(LBi:,LBj:,:,:)
-      real(r8), intent(in) :: v(LBi:,LBj:,:,:)
+      real(r8), intent(in)  :: z_r(LBi:,LBj:,:)
+      real(r8), intent(in)  :: pden(LBi:,LBj:,:)
+      real(r8), intent(in)  :: u(LBi:,LBj:,:,:)
+      real(r8), intent(in)  :: v(LBi:,LBj:,:,:)
 #  endif
-      real(r8), intent(in) :: ubar(LBi:,LBj:,:)
-      real(r8), intent(in) :: vbar(LBi:,LBj:,:)
-      real(r8), intent(in) :: zeta(LBi:,LBj:,:)
+      real(r8), intent(in)  :: ubar(LBi:,LBj:,:)
+      real(r8), intent(in)  :: vbar(LBi:,LBj:,:)
+      real(r8), intent(in)  :: zeta(LBi:,LBj:,:)
 
       real(r8), intent(out) :: pvor_bar(LBi:,LBj:)
       real(r8), intent(out) :: rvor_bar(LBi:,LBj:)
@@ -422,25 +728,25 @@
 # else
 
 #  ifdef MASKING
-      real(r8), intent(in) :: pmask(LBi:UBi,LBj:UBj)
-      real(r8), intent(in) :: umask(LBi:UBi,LBj:UBj)
-      real(r8), intent(in) :: vmask(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: pmask(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: umask(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: vmask(LBi:UBi,LBj:UBj)
 #  endif
-      real(r8), intent(in) :: f(LBi:UBi,LBj:UBj)
-      real(r8), intent(in) :: h(LBi:UBi,LBj:UBj)
-      real(r8), intent(in) :: om_u(LBi:UBi,LBj:UBj)
-      real(r8), intent(in) :: on_v(LBi:UBi,LBj:UBj)
-      real(r8), intent(in) :: pm(LBi:UBi,LBj:UBj)
-      real(r8), intent(in) :: pn(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: f(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: h(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: om_u(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: on_v(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: pm(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: pn(LBi:UBi,LBj:UBj)
 #  ifdef SOLVE3D
-      real(r8), intent(in) :: z_r(LBi:UBi,LBj:UBj,N(ng))
-      real(r8), intent(in) :: pden(LBi:UBi,LBj:UBj,N(ng))
-      real(r8), intent(in) :: u(LBi:UBi,LBj:UBj,N(ng),2)
-      real(r8), intent(in) :: v(LBi:UBi,LBj:UBj,N(ng),2)
+      real(r8), intent(in)  :: z_r(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(in)  :: pden(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(in)  :: u(LBi:UBi,LBj:UBj,N(ng),2)
+      real(r8), intent(in)  :: v(LBi:UBi,LBj:UBj,N(ng),2)
 #  endif
-      real(r8), intent(in) :: ubar(LBi:UBi,LBj:UBj,:)
-      real(r8), intent(in) :: vbar(LBi:UBi,LBj:UBj,:)
-      real(r8), intent(in) :: zeta(LBi:UBi,LBj:UBj,:)
+      real(r8), intent(in)  :: ubar(LBi:UBi,LBj:UBj,:)
+      real(r8), intent(in)  :: vbar(LBi:UBi,LBj:UBj,:)
+      real(r8), intent(in)  :: zeta(LBi:UBi,LBj:UBj,:)
 
       real(r8), intent(out) :: pvor_bar(LBi:UBi,LBj:UBj)
       real(r8), intent(out) :: rvor_bar(LBi:UBi,LBj:UBj)
@@ -670,6 +976,6 @@
 # endif
 !
       RETURN
-      END SUBROUTINE vorticity_tile
+      END SUBROUTINE vorticity_avg_tile
 #endif
       END MODULE vorticity_mod

--- a/ROMS/Utility/vorticity.F
+++ b/ROMS/Utility/vorticity.F
@@ -1,10 +1,5 @@
 #include "cppdefs.h"
       MODULE vorticity_mod
-
-#if defined AVERAGES    || \
-   (defined AD_AVERAGES && defined ADJOINT) || \
-   (defined RP_AVERAGES && defined TL_IOMS) || \
-   (defined TL_AVERAGES && defined TANGENT)
 !
 !git $Id$
 !=======================================================================
@@ -48,11 +43,237 @@
 !
       implicit none
 !
-      PRIVATE
+      PUBLIC  :: rvorticity2d
+#ifdef SOLVE3D
+      PUBLIC  :: rvorticity3d
+#endif
+#if defined AVERAGES    || \
+   (defined AD_AVERAGES && defined ADJOINT) || \
+   (defined RP_AVERAGES && defined TL_IOMS) || \
+   (defined TL_AVERAGES && defined TANGENT)
       PUBLIC  :: vorticity
       PUBLIC  :: vorticity_tile
+#endif
+      PRIVATE
 !
       CONTAINS
+!
+!***********************************************************************
+      SUBROUTINE rvorticity2d (ng, model, tile,                         &
+     &                         LBi, UBi, LBj, UBj,                      &
+     &                         kout,                                    &
+#ifdef MASKING
+     &                         pmask,                                   &
+#endif
+     &                         om_u, on_v, pm, pn,                      &
+     &                         ubar, vbar,                              &
+     &                         rvor2d)
+!***********************************************************************
+!
+      USE mod_param
+      USE mod_scalars
+!
+      USE exchange_2d_mod, ONLY : exchange_p2d_tile
+#ifdef DISTRIBUTE
+      USE mp_exchange_mod, ONLY : mp_exchange2d
+#endif
+!
+!  Imported variable declarations.
+!
+      integer, intent(in)   :: ng, model, tile
+      integer, intent(in)   :: LBi, UBi, LBj, UBj
+      integer, intent(in)   :: kout
+
+#ifdef ASSUMED_SHAPE
+# ifdef MASKING
+      real(r8), intent(in)  :: pmask(LBi:,LBj:)
+# endif
+      real(r8), intent(in)  :: om_u(LBi:,LBj:)
+      real(r8), intent(in)  :: on_v(LBi:,LBj:)
+      real(r8), intent(in)  :: pm(LBi:,LBj:)
+      real(r8), intent(in)  :: pn(LBi:,LBj:)
+      real(r8), intent(in)  :: ubar(LBi:,LBj:,:)
+      real(r8), intent(in)  :: vbar(LBi:,LBj:,:)
+      real(r8), intent(out) :: rvor2d(LBi:,LBj:)
+
+#else
+
+# ifdef MASKING
+      real(r8), intent(in)  :: pmask(LBi:UBi,LBj:UBj)
+# endif
+      real(r8), intent(in)  :: om_u(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: on_v(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: pm(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: pn(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: ubar(LBi:UBi,LBj:UBj,:)
+      real(r8), intent(in)  :: vbar(LBi:UBi,LBj:UBj,:)
+      real(r8), intent(out) :: rvor2d(LBi:UBi,LBj:UBj)
+#endif
+!
+!  Local variable declarations.
+!
+      integer  :: i, j
+      real(r8) :: cff, dUde_p, dVdx_p
+
+#include "set_bounds.h"
+!
+!-----------------------------------------------------------------------
+!  Compute 2D relative vorticity.
+!-----------------------------------------------------------------------
+!
+!  Compute barotropic relative vorticity (second-1) at horizontal
+!  PSI-points.
+!
+      DO j=Jstr,JendR
+        DO i=Istr,IendR
+          cff=0.0625_r8*                                                &
+     &        (pm(i-1,j-1)+pm(i-1,j)+pm(i,j-1)+pm(i,j))*                &
+     &        (pn(i-1,j-1)+pn(i-1,j)+pn(i,j-1)+pn(i,j))
+          dVdx_p=on_v(i  ,j)*vbar(i  ,j,kout)-                          &
+     &           on_v(i-1,j)*vbar(i-1,j,kout)
+#ifdef MASKING
+          dVdx_p=dVdx_p*pmask(i,j)
+#endif
+          dUde_p=om_u(i,j  )*ubar(i,j  ,kout)-                          &
+     &           om_u(i,j-1)*ubar(i,j-1,kout)
+#ifdef MASKING
+          dUde_p=dUde_p*pmask(i,j)
+#endif
+          rvor2d(i,j)=cff*(dVdx_p-dUde_p)
+        END DO
+      END DO
+!
+!  Exchange boundary information.
+!
+      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
+        CALL exchange_p2d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          rvor2d)
+      END IF
+
+#ifdef DISTRIBUTE
+      CALL mp_exchange2d (ng, tile, model, 1,                           &
+     &                    LBi, UBi, LBj, UBj,                           &
+     &                    NghostPoints, EWperiodic(ng), NSperiodic(ng), &
+     &                    rvor2d)
+# endif
+!
+      RETURN
+      END SUBROUTINE rvorticity2d
+
+#ifdef SOLVE3D
+!
+!***********************************************************************
+      SUBROUTINE rvorticity3d (ng, model, tile,                         &
+     &                         LBi, UBi, LBj, UBj,                      &
+     &                         nout,                                    &
+# ifdef MASKING
+     &                         pmask,                                   &
+# endif
+     &                         om_u, on_v, pm, pn,                      &
+     &                         u, v,                                    &
+     &                         rvor3d)
+!***********************************************************************
+!
+      USE mod_param
+      USE mod_scalars
+!
+      USE exchange_3d_mod, ONLY : exchange_p3d_tile
+# ifdef DISTRIBUTE
+      USE mp_exchange_mod, ONLY : mp_exchange3d
+# endif
+!
+!  Imported variable declarations.
+!
+      integer, intent(in)   :: ng, model, tile
+      integer, intent(in)   :: LBi, UBi, LBj, UBj
+      integer, intent(in)   :: nout
+
+# ifdef ASSUMED_SHAPE
+#  ifdef MASKING
+      real(r8), intent(in)  :: pmask(LBi:,LBj:)
+#  endif
+      real(r8), intent(in)  :: om_u(LBi:,LBj:)
+      real(r8), intent(in)  :: on_v(LBi:,LBj:)
+      real(r8), intent(in)  :: pm(LBi:,LBj:)
+      real(r8), intent(in)  :: pn(LBi:,LBj:)
+      real(r8), intent(in)  :: u(LBi:,LBj:,:,:)
+      real(r8), intent(in)  :: v(LBi:,LBj:,:,:)
+      real(r8), intent(out) :: rvor3d(LBi:,LBj:,:)
+
+# else
+
+#  ifdef MASKING
+      real(r8), intent(in)  :: pmask(LBi:UBi,LBj:UBj)
+#  endif
+      real(r8), intent(in)  :: om_u(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: on_v(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: pm(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: pn(LBi:UBi,LBj:UBj)
+      real(r8), intent(in)  :: u(LBi:UBi,LBj:UBj,N(ng),2)
+      real(r8), intent(in)  :: v(LBi:UBi,LBj:UBj,N(ng),2)
+      real(r8), intent(out) :: rvor3d(LBi:UBi,LBj:UBj,N(ng))
+# endif
+!
+!  Local variable declarations.
+!
+      integer  :: i, j, k
+      real(r8) :: cff, dUde_p, dVdx_p
+
+# include "set_bounds.h"
+!
+!-----------------------------------------------------------------------
+!  Compute 3D relative vorticity.
+!-----------------------------------------------------------------------
+!
+!  Compute relative vorticity (second-1) at horizontal PSI-points and
+!  vertical RHO-points.
+!
+      DO k=1,N(ng)
+        DO j=Jstr,JendR
+          DO i=Istr,IendR
+            cff=0.0625_r8*                                              &
+     &          (pm(i-1,j-1)+pm(i-1,j)+pm(i,j-1)+pm(i,j))*              &
+     &          (pn(i-1,j-1)+pn(i-1,j)+pn(i,j-1)+pn(i,j))
+            dUde_p=om_u(i,j  )*u(i,j  ,k,nout)-                         &
+     &             om_u(i,j-1)*u(i,j-1,k,nout)
+# ifdef MASKING
+            dUde_p=dUde_p*pmask(i,j)
+# endif
+            dVdx_p=on_v(i  ,j)*v(i  ,j,k,nout)-                         &
+     &             on_v(i-1,j)*v(i-1,j,k,nout)
+# ifdef MASKING
+            dVdx_p=dVdx_p*pmask(i,j)
+# endif
+            rvor3d(i,j,k)=cff*(dVdx_p-dUde_p)
+          END DO
+        END DO
+      END DO
+!
+!  Exchange boundary data.
+!
+      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
+        CALL exchange_p3d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
+     &                          rvor3d)
+      END IF
+
+# ifdef DISTRIBUTE
+!
+      CALL mp_exchange3d (ng, tile, iNLM, 1,                            &
+     &                    LBi, UBi, LBj, UBj, 1, N(ng),                 &
+     &                    NghostPoints, EWperiodic(ng), NSperiodic(ng), &
+     &                    rvor3d)
+# endif
+!
+      RETURN
+      END SUBROUTINE rvorticity3d
+#endif
+
+#if defined AVERAGES    || \
+   (defined AD_AVERAGES && defined ADJOINT) || \
+   (defined RP_AVERAGES && defined TL_IOMS) || \
+   (defined TL_AVERAGES && defined TANGENT)
 !
 !***********************************************************************
       SUBROUTINE vorticity (ng, tile)

--- a/ROMS/Utility/wrt_his.F
+++ b/ROMS/Utility/wrt_his.F
@@ -77,6 +77,9 @@
 #ifdef SOLVE3D
       USE uv_rotate_mod,       ONLY : uv_rotate3d
 #endif
+#ifdef SOLVE3D
+      USE vorticity_mod,       ONLY : pvorticity3d, rvorticity3d
+#endif
 #if defined WEC_VF && defined SOLVE3D
       USE wec_output_mod,      ONLY : wec_wrt_nf90
 # if defined PIO_LIB && defined DISTRIBUTE
@@ -108,6 +111,7 @@
       integer :: LBij, UBij
 #endif
       integer :: LBi, UBi, LBj, UBj
+      integer :: IminS, ImaxS, JminS, JmaxS
 !
       character (len=*), parameter :: MyFile =                          &
      &  __FILE__
@@ -125,13 +129,19 @@
       LBj=BOUNDS(ng)%LBj(tile)
       UBj=BOUNDS(ng)%UBj(tile)
 !
+      IminS=BOUNDS(ng)%Istr(tile)-3
+      ImaxS=BOUNDS(ng)%Iend(tile)+3
+      JminS=BOUNDS(ng)%Jstr(tile)-3
+      JmaxS=BOUNDS(ng)%Jend(tile)+3
+!
       SELECT CASE (HIS(ng)%IOtype)
         CASE (io_nf90)
           CALL wrt_his_nf90 (ng, iNLM, tile,                            &
 #ifdef ADJUST_BOUNDARY
      &                       LBij, UBij,                                &
 #endif
-     &                       LBi, UBi, LBj, UBj)
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       IminS, ImaxS, JminS, JmaxS)
 
 #if defined PIO_LIB && defined DISTRIBUTE
         CASE (io_pio)
@@ -139,7 +149,8 @@
 # ifdef ADJUST_BOUNDARY
      &                      LBij, UBij,                                 &
 # endif
-     &                      LBi, UBi, LBj, UBj)
+     &                      LBi, UBi, LBj, UBj,                         &
+     &                      IminS, ImaxS, JminS, JmaxS)
 #endif
         CASE DEFAULT
           IF (Master) WRITE (stdout,10) HIS(ng)%IOtype
@@ -158,7 +169,8 @@
 #ifdef ADJUST_BOUNDARY
      &                         LBij, UBij,                              &
 #endif
-     &                         LBi, UBi, LBj, UBj)
+     &                         LBi, UBi, LBj, UBj,                      &
+     &                         IminS, ImaxS, JminS, JmaxS)
 !***********************************************************************
 !
       USE mod_netcdf
@@ -170,6 +182,7 @@
       integer, intent(in) :: LBij, UBij
 #endif
       integer, intent(in) :: LBi, UBi, LBj, UBj
+      integer, intent(in) :: IminS, ImaxS, JminS, JmaxS
 !
 !  Local variable declarations.
 !
@@ -183,6 +196,7 @@
       real(r8), allocatable :: Ur2d(:,:)
       real(r8), allocatable :: Vr2d(:,:)
 #ifdef SOLVE3D
+      real(r8), allocatable :: Fr3d(:,:,:)
       real(r8), allocatable :: Wr3d(:,:,:)
 #endif
 !
@@ -1100,6 +1114,7 @@
           ioerror=status
           RETURN
         END IF
+        deallocate (Wr3d)
       END IF
 !
 !  Write out 3D Northward momentum (m/s) at RHO-points, A-grid.
@@ -1161,6 +1176,184 @@
         deallocate (Wr3d)
       END IF
 !
+!  Write out potential vorticity (m-1 s-1) at PSI-points at full column
+!  or specified constant depth slices.
+!
+      IF (Hout(id3dPV,ng).or.(Hout(idPVzs,ng).and.(Nslice.gt.0))) THEN
+        IF (.not.allocated(Fr3d)) THEN
+          allocate ( Fr3d(LBi:UBi,LBj:UBj,N(ng)) )
+          Fr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+        END IF
+        scale=1.0_dp
+        gtype=gfactor*p3dvar
+!
+        CALL pvorticity3d (ng, model, tile,                             &
+                           LBi, UBi, LBj, UBj,                          &
+     &                     IminS, ImaxS, JminS, JmaxS, NOUT,            &
+# ifdef MASKING
+     &                     GRID(ng) % pmask,                            &
+     &                     GRID(ng) % umask,   GRID(ng) % vmask,        &
+# endif
+                           GRID(ng) % f,                                &
+                           GRID(ng) % om_u,    GRID(ng) % on_v,         &
+                           GRID(ng) % pm,      GRID(ng) % pn,           &
+                           GRID(ng) % z_r,     OCEAN(ng) % pden,        &
+                           OCEAN(ng) % u,      OCEAN(ng) % v,           &
+                           Fr3d)
+!
+        IF (Hout(id3dPV,ng)) THEN
+          status=nf_fwrite3d(ng, model, HIS(ng)%ncid, id3dPV,           &
+     &                       HIS(ng)%Vid(id3dPV),                       &
+     &                       HIS(ng)%Rindex, gtype,                     &
+     &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
+# ifdef MASKING
+     &                       GRID(ng) % pmask,                          &
+# endif
+     &                       Fr3d)
+          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+            IF (Master) THEN
+              WRITE (stdout,20) TRIM(Vname(1,id3dPV)), HIS(ng)%Rindex
+            END IF
+            exit_flag=3
+            ioerror=status
+            RETURN
+          END IF
+        END IF
+!
+        IF (Hout(idPVzs,ng).and.(Nslice.gt.0)) THEN
+          IF (.not.allocated(Wr3d)) THEN
+            allocate ( Wr3d(LBi:UBi,LBj:UBj,N(ng)) )
+            Wr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+          END IF
+!
+          DO k=1,N(ng)
+            DO j=Jstr-1,Jend+1
+              DO i=Istr-1,Iend+1
+                GRID(ng)%z_v(i,j,k)=0.25_r8*(GRID(ng)%z_r(i-1,j-1,k)+   &
+     &                                       GRID(ng)%z_r(i-1,j  ,k)+   &
+     &                                       GRID(ng)%z_r(i  ,j-1,k)+   &
+     &                                       GRID(ng)%z_r(i ,j  ,k))
+              END DO
+            END DO
+          END DO
+!
+          CALL extract_slice (ng, model, tile, p3dvar,                &
+     &                        LBi, UBi, LBj, UBj, 1, N(ng),           &
+     &                        Fr3d,                                   &
+     &                        GRID(ng) % z_v,                         &
+# ifdef MASKING
+     &                        GRID(ng) % pmask,                       &
+# endif
+     &                        Zslice, Wr3d)
+!
+          status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idPVzs,         &
+     &                       HIS(ng)%Vid(idPVzs),                     &
+     &                       HIS(ng)%Rindex, gtype,                   &
+     &                       LBi, UBi, LBj, UBj, 1, Nslice, scale,    &
+# ifdef MASKING
+     &                       GRID(ng) % pmask,                        &
+# endif
+     &                       Wr3d)
+          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+            IF (Master) THEN
+              WRITE (stdout,20) TRIM(Vname(1,idPVzs)), HIS(ng)%Rindex
+            END IF
+            exit_flag=3
+            ioerror=status
+            RETURN
+          END IF
+          deallocate (Wr3d)
+        END IF
+        deallocate (Fr3d)
+      END IF
+!
+!  Write out relative vorticity (s-1) at PSI-points at full column
+!  or specified constant depth slices.
+!
+      IF (Hout(id3dRV,ng).or.(Hout(idRVzs,ng).and.(Nslice.gt.0))) THEN
+        IF (.not.allocated(Fr3d)) THEN
+          allocate ( Fr3d(LBi:UBi,LBj:UBj,N(ng)) )
+          Fr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+        END IF
+        scale=1.0_dp
+        gtype=gfactor*p3dvar
+!
+        CALL rvorticity3d (ng, model, tile,                             &
+                           LBi, UBi, LBj, UBj, NOUT,                    &
+# ifdef MASKING
+     &                     GRID(ng) % pmask,                            &
+# endif
+                           GRID(ng) % om_u, GRID(ng) % on_v,            &
+                           GRID(ng) % pm,   GRID(ng) % pn,              &
+                           OCEAN(ng) % u,   OCEAN(ng) % v,              &
+                           Fr3d)
+!
+        IF (Hout(id3dRV,ng)) THEN
+          status=nf_fwrite3d(ng, model, HIS(ng)%ncid, id3dRV,           &
+     &                       HIS(ng)%Vid(id3dRV),                       &
+     &                       HIS(ng)%Rindex, gtype,                     &
+     &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
+# ifdef MASKING
+     &                       GRID(ng) % pmask,                          &
+# endif
+     &                       Fr3d)
+          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+            IF (Master) THEN
+              WRITE (stdout,20) TRIM(Vname(1,id3dRV)), HIS(ng)%Rindex
+            END IF
+            exit_flag=3
+            ioerror=status
+            RETURN
+          END IF
+        END IF
+!
+        IF (Hout(idRVzs,ng).and.(Nslice.gt.0)) THEN
+          IF (.not.allocated(Wr3d)) THEN
+            allocate ( Wr3d(LBi:UBi,LBj:UBj,N(ng)) )
+            Wr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+          END IF
+!
+          DO k=1,N(ng)
+            DO j=Jstr-1,Jend+1
+              DO i=Istr-1,Iend+1
+                GRID(ng)%z_v(i,j,k)=0.25_r8*(GRID(ng)%z_r(i-1,j-1,k)+   &
+     &                                       GRID(ng)%z_r(i-1,j  ,k)+   &
+     &                                       GRID(ng)%z_r(i  ,j-1,k)+   &
+     &                                       GRID(ng)%z_r(i ,j  ,k))
+              END DO
+            END DO
+          END DO
+!
+          CALL extract_slice (ng, model, tile, p3dvar,                &
+     &                        LBi, UBi, LBj, UBj, 1, N(ng),           &
+     &                        Fr3d,                                   &
+     &                        GRID(ng) % z_v,                         &
+# ifdef MASKING
+     &                        GRID(ng) % pmask,                       &
+# endif
+     &                        Zslice, Wr3d)
+!
+          status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idRVzs,         &
+     &                       HIS(ng)%Vid(idRVzs),                     &
+     &                       HIS(ng)%Rindex, gtype,                   &
+     &                       LBi, UBi, LBj, UBj, 1, Nslice, scale,    &
+# ifdef MASKING
+     &                       GRID(ng) % pmask,                        &
+# endif
+     &                       Wr3d)
+          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+            IF (Master) THEN
+              WRITE (stdout,20) TRIM(Vname(1,idRVzs)), HIS(ng)%Rindex
+            END IF
+            exit_flag=3
+            ioerror=status
+            RETURN
+          END IF
+          deallocate (Wr3d)
+        END IF
+        deallocate (Fr3d)
+      END IF
+!
 !  Write out S-coordinate omega vertical velocity (m/s).
 !
       IF (Hout(idOvel,ng)) THEN
@@ -1174,7 +1367,7 @@
      &                    GRID(ng) % pm,                                &
      &                    GRID(ng) % pn,                                &
      &                    OCEAN(ng) % W,                                &
-     &                    Wr3d(LBi:,LBj:,0:))
+     &                    Wr3d)
         status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idOvel,             &
      &                     HIS(ng)%Vid(idOvel),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
@@ -1182,7 +1375,7 @@
 # ifdef MASKING
      &                     GRID(ng) % rmask,                            &
 # endif
-     &                     Wr3d(LBi:,LBj:,0:))
+     &                     Wr3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
             WRITE (stdout,20) TRIM(Vname(1,idOvel)), HIS(ng)%Rindex
@@ -2179,7 +2372,8 @@
 # ifdef ADJUST_BOUNDARY
      &                        LBij, UBij,                               &
 # endif
-     &                        LBi, UBi, LBj, UBj)
+     &                        LBi, UBi, LBj, UBj,                       &
+     &                        IminS, ImaxS, JminS, JmaxS)
 !***********************************************************************
 !
       USE mod_pio_netcdf
@@ -2191,6 +2385,7 @@
       integer, intent(in) :: LBij, UBij
 # endif
       integer, intent(in) :: LBi, UBi, LBj, UBj
+      integer, intent(in) :: IminS, ImaxS, JminS, JmaxS
 !
 !  Local variable declarations.
 !
@@ -2204,6 +2399,7 @@
       real(r8), allocatable :: Ur2d(:,:)
       real(r8), allocatable :: Vr2d(:,:)
 # ifdef SOLVE3D
+      real(r8), allocatable :: Fr3d(:,:,:)
       real(r8), allocatable :: Wr3d(:,:,:)
 # endif
 !
@@ -3372,9 +3568,9 @@
      &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
      &                      OCEAN(ng) % va,                             &
      &                      GRID(ng) % z_r,                             &
-# ifdef MASKING
+#  ifdef MASKING
      &                      GRID(ng) % rmask_full,                      &
-# endif
+#  endif
      &                      Zslice, Wr3d)
 !
         scale=1.0_dp
@@ -3401,6 +3597,206 @@
           RETURN
         END IF
         deallocate (Wr3d)
+      END IF
+!
+!  Write out potential vorticity (m-1 s-1) at PSI-points at full column
+!  or specified constant depth slices.
+!
+      IF (Hout(id3dPV,ng).or.(Hout(idPVzs,ng).and.(Nslice.gt.0))) THEN
+        IF (.not.allocated(Fr3d)) THEN
+          allocate ( Fr3d(LBi:UBi,LBj:UBj,N(ng)) )
+          Fr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+        END IF
+        scale=1.0_dp
+!
+        CALL pvorticity3d (ng, model, tile,                             &
+                           LBi, UBi, LBj, UBj,                          &
+     &                     IminS, ImaxS, JminS, JmaxS, NOUT,            &
+#  ifdef MASKING
+     &                     GRID(ng) % pmask,                            &
+     &                     GRID(ng) % umask,   GRID(ng) % vmask,        &
+#  endif
+                           GRID(ng) % f,                                &
+                           GRID(ng) % om_u,    GRID(ng) % on_v,         &
+                           GRID(ng) % pm,      GRID(ng) % pn,           &
+                           GRID(ng) % z_r,     OCEAN(ng) % pden,        &
+                           OCEAN(ng) % u,      OCEAN(ng) % v,           &
+                           Fr3d)
+!
+        IF (Hout(id3dPV,ng)) THEN
+          IF (HIS(ng)%pioVar(id3dPV)%dkind.eq.PIO_double) THEN
+            ioDesc => ioDesc_dp_p3dvar(ng)
+          ELSE
+            ioDesc => ioDesc_sp_p3dvar(ng)
+          END IF
+          status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, id3dPV,        &
+     &                       HIS(ng)%pioVar(id3dPV),                    &
+     &                       HIS(ng)%Rindex,                            &
+     &                       ioDesc,                                    &
+     &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
+#  ifdef MASKING
+     &                       GRID(ng) % pmask,                          &
+#  endif
+     &                       Fr3d)
+          IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+            IF (Master) THEN
+              WRITE (stdout,20) TRIM(Vname(1,id3dPV)), HIS(ng)%Rindex
+            END IF
+            exit_flag=3
+            ioerror=status
+            RETURN
+          END IF
+        END IF
+!
+        IF (Hout(idPVzs,ng).and.(Nslice.gt.0)) THEN
+          IF (.not.allocated(Wr3d)) THEN
+            allocate ( Wr3d(LBi:UBi,LBj:UBj,N(ng)) )
+            Wr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+          END IF
+!
+          DO k=1,N(ng)
+            DO j=Jstr-1,Jend+1
+              DO i=Istr-1,Iend+1
+                GRID(ng)%z_v(i,j,k)=0.25_r8*(GRID(ng)%z_r(i-1,j-1,k)+   &
+     &                                       GRID(ng)%z_r(i-1,j  ,k)+   &
+     &                                       GRID(ng)%z_r(i  ,j-1,k)+   &
+     &                                       GRID(ng)%z_r(i ,j  ,k))
+              END DO
+            END DO
+          END DO
+!
+          CALL extract_slice (ng, model, tile, p3dvar,                &
+     &                        LBi, UBi, LBj, UBj, 1, N(ng),           &
+     &                        Fr3d,                                   &
+     &                        GRID(ng) % z_v,                         &
+#  ifdef MASKING
+     &                        GRID(ng) % pmask,                       &
+#  endif
+     &                        Zslice, Wr3d)
+!
+          IF (HIS(ng)%pioVar(idPVzs)%dkind.eq.PIO_double) THEN
+            ioDesc => ioDesZ_dp_p3dvar(ng)
+          ELSE
+            ioDesc => ioDesZ_sp_p3dvar(ng)
+          END IF
+          status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idPVzs,        &
+     &                       HIS(ng)%pioVar(idPVzs),                    &
+     &                       HIS(ng)%Rindex,                            &
+     &                       ioDesc,                                    &
+     &                       LBi, UBi, LBj, UBj, 1, Nslice, scale,      &
+#  ifdef MASKING
+     &                       GRID(ng) % pmask,                          &
+#  endif
+     &                       Wr3d)
+          IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+            IF (Master) THEN
+              WRITE (stdout,20) TRIM(Vname(1,idPVzs)), HIS(ng)%Rindex
+            END IF
+            exit_flag=3
+            ioerror=status
+            RETURN
+          END IF
+          deallocate (Wr3d)
+        END IF
+        deallocate (Fr3d)
+      END IF
+!
+!  Write out relative vorticity (s-1) at PSI-points at full column
+!  or specified constant depth slices.
+!
+      IF (Hout(id3dRV,ng).or.(Hout(idRVzs,ng).and.(Nslice.gt.0))) THEN
+        IF (.not.allocated(Fr3d)) THEN
+          allocate ( Fr3d(LBi:UBi,LBj:UBj,N(ng)) )
+          Fr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+        END IF
+        scale=1.0_dp
+!
+        CALL rvorticity3d (ng, model, tile,                             &
+                           LBi, UBi, LBj, UBj, NOUT,                    &
+# ifdef MASKING
+     &                     GRID(ng) % pmask,                            &
+# endif
+                           GRID(ng) % om_u, GRID(ng) % on_v,            &
+                           GRID(ng) % pm,   GRID(ng) % pn,              &
+                           OCEAN(ng) % u,   OCEAN(ng) % v,              &
+                           Fr3d)
+!
+        IF (Hout(id3dRV,ng)) THEN
+          IF (HIS(ng)%pioVar(id3dRV)%dkind.eq.PIO_double) THEN
+            ioDesc => ioDesc_dp_p3dvar(ng)
+          ELSE
+            ioDesc => ioDesc_sp_p3dvar(ng)
+          END IF
+          status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, id3dRV,        &
+     &                       HIS(ng)%pioVar(id3dRV),                    &
+     &                       HIS(ng)%Rindex,                            &
+     &                       ioDesc,                                    &
+     &                       LBi, UBi, LBj, UBj, 1, N(ng), scale,       &
+#  ifdef MASKING
+     &                       GRID(ng) % pmask,                          &
+#  endif
+     &                       Fr3d)
+          IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+            IF (Master) THEN
+              WRITE (stdout,20) TRIM(Vname(1,id3dRV)), HIS(ng)%Rindex
+            END IF
+            exit_flag=3
+            ioerror=status
+            RETURN
+          END IF
+        END IF
+!
+        IF (Hout(idRVzs,ng).and.(Nslice.gt.0)) THEN
+          IF (.not.allocated(Wr3d)) THEN
+            allocate ( Wr3d(LBi:UBi,LBj:UBj,N(ng)) )
+            Wr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+          END IF
+!
+          DO k=1,N(ng)
+            DO j=Jstr-1,Jend+1
+              DO i=Istr-1,Iend+1
+                GRID(ng)%z_v(i,j,k)=0.25_r8*(GRID(ng)%z_r(i-1,j-1,k)+   &
+     &                                       GRID(ng)%z_r(i-1,j  ,k)+   &
+     &                                       GRID(ng)%z_r(i  ,j-1,k)+   &
+     &                                       GRID(ng)%z_r(i ,j  ,k))
+              END DO
+            END DO
+          END DO
+!
+          CALL extract_slice (ng, model, tile, p3dvar,                &
+     &                        LBi, UBi, LBj, UBj, 1, N(ng),           &
+     &                        Fr3d,                                   &
+     &                        GRID(ng) % z_v,                         &
+#  ifdef MASKING
+     &                        GRID(ng) % pmask,                       &
+#  endif
+     &                        Zslice, Wr3d)
+!
+          IF (HIS(ng)%pioVar(idRVzs)%dkind.eq.PIO_double) THEN
+            ioDesc => ioDesZ_dp_p3dvar(ng)
+          ELSE
+            ioDesc => ioDesZ_sp_p3dvar(ng)
+          END IF
+          status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idRVzs,        &
+     &                       HIS(ng)%pioVar(idRVzs),                    &
+     &                       HIS(ng)%Rindex,                            &
+     &                       ioDesc,                                    &
+     &                       LBi, UBi, LBj, UBj, 1, Nslice, scale,      &
+#  ifdef MASKING
+     &                       GRID(ng) % pmask,                          &
+#  endif
+     &                       Wr3d)
+          IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+            IF (Master) THEN
+              WRITE (stdout,20) TRIM(Vname(1,idRVzs)), HIS(ng)%Rindex
+            END IF
+            exit_flag=3
+            ioerror=status
+            RETURN
+          END IF
+          deallocate (Wr3d)
+        END IF
+        deallocate (Fr3d)
       END IF
 !
 !  Write out S-coordinate omega vertical velocity (m/s).
@@ -3430,7 +3826,7 @@
 #  ifdef MASKING
      &                     GRID(ng) % rmask,                            &
 #  endif
-     &                     Wr3d(LBi:,LBj:,0:))
+     &                     Wr3d)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
             WRITE (stdout,20) TRIM(Vname(1,idOvel)), HIS(ng)%Rindex
@@ -3471,7 +3867,7 @@
 #   ifdef MASKING
      &                     GRID(ng) % rmask,                            &
 #   endif
-     &                     Wr3d(LBi:,LBj:,0:))
+     &                     Wr3d)
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
             WRITE (stdout,20) TRIM(Vname(1,idOvil)), HIS(ng)%Rindex

--- a/ROMS/Utility/wrt_his.F
+++ b/ROMS/Utility/wrt_his.F
@@ -48,6 +48,7 @@
       USE bbl_output_mod,      ONLY : bbl_wrt_pio
 # endif
 #endif
+      USE extract_slice_mod,   ONLY : extract_slice
 #if defined ICE_MODEL && defined SOLVE3D
       USE ice_output_mod,      ONLY : ice_wrt_nf90
 # if defined PIO_LIB && defined DISTRIBUTE
@@ -855,6 +856,54 @@
         END IF
 # endif
       END IF
+!
+!  Write out 3D U-momentum component (m/s) at specified constant depth
+!  slices.
+!
+      IF (Hout(idUzsl,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+        scale=1.0_dp
+        gtype=gfactor*u3dvar
+!
+        DO k=1,N(ng)
+          DO j=Jstr-1,Jend+1
+            DO i=IstrU-1,Iend+1
+              GRID(ng)%z_v(i,j,k)=0.5_r8*(GRID(ng)%z_r(i-1,j,k)+        &
+     &                                    GRID(ng)%z_r(i  ,j,k))
+            END DO
+          END DO
+        END DO
+        CALL extract_slice (ng, model, tile, gtype,                     &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % u(:,:,:,NOUT),                  &
+     &                      GRID(ng) % z_v,                             &
+# ifdef MASKING
+     &                      GRID(ng) % umask_full,                      &
+# endif
+     &                      Zslice, Wr3d)
+!
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idUzsl,             &
+     &                     HIS(ng)%Vid(idUzsl),                         &
+     &                     HIS(ng)%Rindex, gtype,                       &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+# ifdef MASKING
+     &                     GRID(ng) % umask_full,                       &
+# endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idUzsl)), HIS(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
+
 # ifdef ADJUST_BOUNDARY
 !
 !  Write out 3D U-momentum component open boundaries.
@@ -920,6 +969,54 @@
         END IF
 # endif
       END IF
+!
+!  Write out 3D V-momentum component (m/s) at specified constant depth
+!  slices.
+!
+      IF (Hout(idVzsl,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+        scale=1.0_dp
+        gtype=gfactor*v3dvar
+!
+        DO k=1,N(ng)
+          DO j=JstrV-1,Jend+1
+            DO i=Istr-1,Iend+1
+              GRID(ng)%z_v(i,j,k)=0.5_r8*(GRID(ng)%z_r(i,j-1,k)+        &
+     &                                    GRID(ng)%z_r(i,j  ,k))
+            END DO
+          END DO
+        END DO
+        CALL extract_slice (ng, model, tile, gtype,                     &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % v(:,:,:,NOUT),                  &
+     &                      GRID(ng) % z_v,                             &
+# ifdef MASKING
+     &                      GRID(ng) % vmask_full,                      &
+# endif
+     &                      Zslice, Wr3d)
+!
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idVzsl,             &
+     &                     HIS(ng)%Vid(idVzsl),                         &
+     &                     HIS(ng)%Rindex, gtype,                       &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+# ifdef MASKING
+     &                     GRID(ng) % vmask_full,                       &
+# endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idVvel)), HIS(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
+
 # ifdef ADJUST_BOUNDARY
 !
 !  Write out 3D V-momentum component open boundaries.
@@ -968,6 +1065,43 @@
         END IF
       END IF
 !
+!  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid, at
+!  specified constant depth slices.
+!
+      IF (Hout(idUzsE,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+        scale=1.0_dp
+        gtype=gfactor*r3dvar
+        CALL extract_slice (ng, model, tile, gtype,                     &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % ua,                             &
+     &                      GRID(ng) % z_r,                             &
+# ifdef MASKING
+     &                      GRID(ng) % rmask,                           &
+# endif
+     &                      Zslice, Wr3d)
+!
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idUzsE,             &
+     &                     HIS(ng)%Vid(idUzsE),                         &
+     &                     HIS(ng)%Rindex, gtype,                       &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+# ifdef MASKING
+     &                     GRID(ng) % rmask_full,                       &
+# endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idu3dE)), HIS(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+      END IF
+!
 !  Write out 3D Northward momentum (m/s) at RHO-points, A-grid.
 !
       IF (Hout(idv3dN,ng)) THEN
@@ -989,11 +1123,49 @@
         END IF
       END IF
 !
+!  Write out 3D Northward momentum (m/s) at RHO-points, A-grid, at
+!  specified constant depth slices.
+!
+      IF (Hout(idVzsN,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+        scale=1.0_dp
+        gtype=gfactor*r3dvar
+        CALL extract_slice (ng, model, tile, gtype,                     &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % va,                             &
+     &                      GRID(ng) % z_r,                             &
+# ifdef MASKING
+     &                      GRID(ng) % rmask,                           &
+# endif
+     &                      Zslice, Wr3d)
+!
+        status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idVzsN,             &
+     &                     HIS(ng)%Vid(idVzsN),                         &
+     &                     HIS(ng)%Rindex, gtype,                       &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+# ifdef MASKING
+     &                     GRID(ng) % rmask_full,                       &
+# endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idv3dN)), HIS(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
+!
 !  Write out S-coordinate omega vertical velocity (m/s).
 !
       IF (Hout(idOvel,ng)) THEN
         IF (.not.allocated(Wr3d)) THEN
-          allocate (Wr3d(LBi:UBi,LBj:UBj,0:N(ng)))
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,0:N(ng)) )
           Wr3d(LBi:UBi,LBj:UBj,0:N(ng))=0.0_r8
         END IF
         scale=1.0_dp
@@ -1002,7 +1174,7 @@
      &                    GRID(ng) % pm,                                &
      &                    GRID(ng) % pn,                                &
      &                    OCEAN(ng) % W,                                &
-     &                    Wr3d)
+     &                    Wr3d(LBi:,LBj:,0:))
         status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idOvel,             &
      &                     HIS(ng)%Vid(idOvel),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
@@ -1010,7 +1182,7 @@
 # ifdef MASKING
      &                     GRID(ng) % rmask,                            &
 # endif
-     &                     Wr3d)
+     &                     Wr3d(LBi:,LBj:,0:))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
             WRITE (stdout,20) TRIM(Vname(1,idOvel)), HIS(ng)%Rindex
@@ -1028,7 +1200,7 @@
 !
       IF (Hout(idOvil,ng)) THEN
         IF (.not.allocated(Wr3d)) THEN
-          allocate (Wr3d(LBi:UBi,LBj:UBj,0:N(ng)))
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,0:N(ng)) )
           Wr3d(LBi:UBi,LBj:UBj,0:N(ng))=0.0_r8
         END IF
         scale=1.0_dp
@@ -1037,7 +1209,7 @@
      &                    GRID(ng) % pm,                                &
      &                    GRID(ng) % pn,                                &
      &                    OCEAN(ng) % Wi,                               &
-     &                    Wr3d)
+     &                    Wr3d(LBi:,LBj:,0:))
         status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idOvil,             &
      &                     HIS(ng)%Vid(idOvil),                         &
      &                     HIS(ng)%Rindex, gtype,                       &
@@ -1045,7 +1217,7 @@
 # ifdef MASKING
      &                     GRID(ng) % rmask,                            &
 # endif
-     &                     Wr3d)
+     &                     Wr3d(LBi:,LBj:,0:))
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
             WRITE (stdout,20) TRIM(Vname(1,idOvil)), HIS(ng)%Rindex
@@ -1104,6 +1276,46 @@
             ioerror=status
             RETURN
           END IF
+        END IF
+      END DO
+!
+!  Write out tracer type variables at specified constant depth slices.
+!
+      DO itrc=1,NT(ng)
+        IF (Hout(idzslT(itrc),ng).and.(Nslice.gt.0)) THEN
+          IF (.not.allocated(Wr3d)) THEN
+            allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+            Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+          END IF
+          scale=1.0_dp
+          gtype=gfactor*r3dvar
+          CALL extract_slice (ng, model, tile, gtype,                   &
+     &                        LBi, UBi, LBj, UBj, 1, N(ng),             &
+     &                        OCEAN(ng) % t(:,:,:,NOUT,itrc),           &
+     &                        GRID(ng) % z_r,                           &
+# ifdef MASKING
+     &                        GRID(ng) % rmask,                         &
+# endif
+     &                        Zslice, Wr3d)
+!
+          status=nf_fwrite3d(ng, model, HIS(ng)%ncid, idzslT(itrc),     &
+     &                       HIS(ng)%Vid(idzslT(itrc)),                 &
+     &                       HIS(ng)%Rindex, gtype,                     &
+     &                       LBi, UBi, LBj, UBj, 1, Nslice, scale,      &
+# ifdef MASKING
+     &                       GRID(ng) % rmask,                          &
+# endif
+     &                       Wr3d)
+          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+            IF (Master) THEN
+              WRITE (stdout,20) TRIM(Vname(1,idzslT(itrc))),            &
+     &                          HIS(ng)%Rindex
+            END IF
+            exit_flag=3
+            ioerror=status
+            RETURN
+          END IF
+          IF (itrc.eq.NT(ng)) deallocate (Wr3d)
         END IF
       END DO
 
@@ -2827,6 +3039,58 @@
         END IF
 #  endif
       END IF
+!
+!  Write out 3D U-momentum component (m/s) at specified constant depth
+!  slices.
+!
+      IF (Hout(idUzsl,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+!
+        DO k=1,N(ng)
+          DO j=Jstr-1,Jend+1
+            DO i=IstrU-1,Iend+1
+              GRID(ng)%z_v(i,j,k)=0.5_r8*(GRID(ng)%z_r(i-1,j,k)+        &
+     &                                    GRID(ng)%z_r(i  ,j,k))
+            END DO
+          END DO
+        END DO
+        CALL extract_slice (ng, model, tile, u3dvar,                    &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % u(:,:,:,NOUT),                  &
+     &                      GRID(ng) % z_v,                             &
+# ifdef MASKING
+     &                      GRID(ng) % umask_full,                      &
+# endif
+     &                      Zslice, Wr3d)
+!
+        scale=1.0_dp
+        IF (HIS(ng)%pioVar(idUzsl)%dkind.eq.PIO_double) THEN
+          ioDesc => ioDesZ_dp_u3dvar(ng)
+        ELSE
+          ioDesc => ioDesZ_sp_u3dvar(ng)
+        END IF
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idUvel,          &
+     &                     HIS(ng)%pioVar(idUzsl),                      &
+     &                     HIS(ng)%Rindex,                              &
+     &                     ioDesc,                                      &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+#  ifdef MASKING
+     &                     GRID(ng) % umask_full,                       &
+#  endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idUzsl)), HIS(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
 
 #  ifdef ADJUST_BOUNDARY
 !
@@ -2913,6 +3177,58 @@
         END IF
 #  endif
       END IF
+!
+!  Write out 3D V-momentum component (m/s) at specified constant depth
+!  slices.
+!
+      IF (Hout(idVzsl,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+!
+        DO k=1,N(ng)
+          DO j=JstrV-1,Jend+1
+            DO i=Istr-1,Iend+1
+              GRID(ng)%z_v(i,j,k)=0.5_r8*(GRID(ng)%z_r(i,j-1,k)+        &
+     &                                    GRID(ng)%z_r(i,j  ,k))
+            END DO
+          END DO
+        END DO
+        CALL extract_slice (ng, model, tile, v3dvar,                    &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % v(:,:,:,NOUT),                  &
+     &                      GRID(ng) % z_v,                             &
+# ifdef MASKING
+     &                      GRID(ng) % vmask_full,                      &
+# endif
+     &                      Zslice, Wr3d)
+!
+        scale=1.0_dp
+        IF (HIS(ng)%pioVar(idVzsl)%dkind.eq.PIO_double) THEN
+          ioDesc => ioDesZ_dp_v3dvar(ng)
+        ELSE
+          ioDesc => ioDesZ_sp_v3dvar(ng)
+        END IF
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idVzsl,          &
+     &                     HIS(ng)%pioVar(idVzsl),                      &
+     &                     HIS(ng)%Rindex,                              &
+     &                     ioDesc,                                      &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+#  ifdef MASKING
+     &                     GRID(ng) % vmask_full,                       &
+#  endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idVzsl)), HIS(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
 
 #  ifdef ADJUST_BOUNDARY
 !
@@ -2974,7 +3290,50 @@
         END IF
       END IF
 !
-!  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid
+!  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid, at
+!  specified constant depth slices.
+!
+      IF (Hout(idUzsE,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+        CALL extract_slice (ng, model, tile, r3dvar,                    &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % ua,                             &
+     &                      GRID(ng) % z_r,                             &
+# ifdef MASKING
+     &                      GRID(ng) % rmask_full,                      &
+# endif
+     &                      Zslice, Wr3d)
+!
+        scale=1.0_dp
+        IF (HIS(ng)%pioVar(idUzsE)%dkind.eq.PIO_double) THEN
+          ioDesc => ioDesZ_dp_r3dvar(ng)
+        ELSE
+          ioDesc => ioDesZ_sp_r3dvar(ng)
+        END IF
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idUzsE,          &
+     &                     HIS(ng)%pioVar(idUzsE),                      &
+     &                     HIS(ng)%Rindex,                              &
+     &                     ioDesc,                                      &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+#  ifdef MASKING
+     &                     GRID(ng) % rmask_full,                       &
+#  endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idUzsE)), HIS(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
+!
+!  Write out 3D Nothward momentum (m/s) at RHO-points, A-grid
 !
       IF (Hout(idv3dN,ng)) THEN
         IF (HIS(ng)%pioVar(idV3dN)%dkind.eq.PIO_double) THEN
@@ -3001,11 +3360,54 @@
         END IF
       END IF
 !
+!  Write out 3D Northward momentum (m/s) at RHO-points, A-grid, at
+!  specified constant depth slices.
+!
+      IF (Hout(idVzsN,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+        CALL extract_slice (ng, model, tile, r3dvar,                    &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % va,                             &
+     &                      GRID(ng) % z_r,                             &
+# ifdef MASKING
+     &                      GRID(ng) % rmask_full,                      &
+# endif
+     &                      Zslice, Wr3d)
+!
+        scale=1.0_dp
+        IF (HIS(ng)%pioVar(idv3dN)%dkind.eq.PIO_double) THEN
+          ioDesc => ioDesZ_dp_r3dvar(ng)
+        ELSE
+          ioDesc => ioDesZ_sp_r3dvar(ng)
+        END IF
+        status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idVzsN,          &
+     &                     HIS(ng)%pioVar(idVzsN),                      &
+     &                     HIS(ng)%Rindex,                              &
+     &                     ioDesc,                                      &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+#  ifdef MASKING
+     &                     GRID(ng) % rmask_full,                       &
+#  endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idVzsN)), HIS(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
+!
 !  Write out S-coordinate omega vertical velocity (m/s).
 !
       IF (Hout(idOvel,ng)) THEN
         IF (.not.allocated(Wr3d)) THEN
-          allocate (Wr3d(LBi:UBi,LBj:UBj,0:N(ng)))
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,0:N(ng)) )
           Wr3d(LBi:UBi,LBj:UBj,0:N(ng))=0.0_r8
         END IF
         scale=1.0_dp
@@ -3013,7 +3415,7 @@
      &                    GRID(ng) % pm,                                &
      &                    GRID(ng) % pn,                                &
      &                    OCEAN(ng) % W,                                &
-     &                    Wr3d)
+     &                    Wr3d(LBi:,LBj:,0:))
 !
         IF (HIS(ng)%pioVar(idOvel)%dkind.eq.PIO_double) THEN
           ioDesc => ioDesc_dp_w3dvar(ng)
@@ -3028,7 +3430,7 @@
 #  ifdef MASKING
      &                     GRID(ng) % rmask,                            &
 #  endif
-     &                     Wr3d)
+     &                     Wr3d(LBi:,LBj:,0:))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
             WRITE (stdout,20) TRIM(Vname(1,idOvel)), HIS(ng)%Rindex
@@ -3046,7 +3448,7 @@
 !
       IF (Hout(idOvil,ng)) THEN
         IF (.not.allocated(Wr3d)) THEN
-          allocate (Wr3d(LBi:UBi,LBj:UBj,0:N(ng)))
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,0:N(ng)) )
           Wr3d(LBi:UBi,LBj:UBj,0:N(ng))=0.0_r8
         END IF
         scale=1.0_dp
@@ -3054,7 +3456,7 @@
      &                    GRID(ng) % pm,                                &
      &                    GRID(ng) % pn,                                &
      &                    OCEAN(ng) % Wi,                               &
-     &                    Wr3d)
+     &                    Wr3d(LBi:,LBj:,0:))
 !
         IF (HIS(ng)%pioVar(idOvil)%dkind.eq.PIO_double) THEN
           ioDesc => ioDesc_dp_w3dvar(ng)
@@ -3069,7 +3471,7 @@
 #   ifdef MASKING
      &                     GRID(ng) % rmask,                            &
 #   endif
-     &                     Wr3d)
+     &                     Wr3d(LBi:,LBj:,0:))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
             WRITE (stdout,20) TRIM(Vname(1,idOvil)), HIS(ng)%Rindex
@@ -3138,6 +3540,51 @@
             ioerror=status
             RETURN
           END IF
+        END IF
+      END DO
+!
+!  Write out tracer type variables at specified constant depth slices.
+!
+      DO itrc=1,NT(ng)
+        IF (Hout(idzslT(itrc),ng).and.(Nslice.gt.0)) THEN
+          IF (.not.allocated(Wr3d)) THEN
+            allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+            Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+          END IF
+          CALL extract_slice (ng, model, tile, r3dvar,                  &
+     &                        LBi, UBi, LBj, UBj, 1, N(ng),             &
+     &                        OCEAN(ng) % t(:,:,:,NOUT,itrc),           &
+     &                        GRID(ng) % z_r,                           &
+# ifdef MASKING
+     &                        GRID(ng) % rmask,                         &
+# endif
+     &                        Zslice, Wr3d)
+!
+          scale=1.0_dp
+          IF (HIS(ng)%pioVar(idzslT(itrc))%dkind.eq.PIO_double) THEN
+            ioDesc => ioDesZ_dp_r3dvar(ng)
+          ELSE
+            ioDesc => ioDesZ_sp_r3dvar(ng)
+          END IF
+          status=nf_fwrite3d(ng, model, HIS(ng)%pioFile, idzslT(itrc),  &
+     &                       HIS(ng)%pioVar(idzslT(itrc)),              &
+     &                       HIS(ng)%Rindex,                            &
+     &                       ioDesc,                                    &
+     &                       LBi, UBi, LBj, UBj, 1, Nslice, scale,      &
+#  ifdef MASKING
+     &                       GRID(ng) % rmask,                          &
+#  endif
+     &                       Wr3d)
+          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+            IF (Master) THEN
+              WRITE (stdout,20) TRIM(Vname(1,idzslT(itrc))),            &
+     &                          HIS(ng)%Rindex
+            END IF
+            exit_flag=3
+            ioerror=status
+            RETURN
+          END IF
+          IF (itrc.eq.NT(ng)) deallocate (Wr3d)
         END IF
       END DO
 

--- a/ROMS/Utility/wrt_info.F
+++ b/ROMS/Utility/wrt_info.F
@@ -1470,6 +1470,15 @@
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #endif
 !
+!  Depths of horizontal slices.
+!
+      IF (Nslice.gt.0) THEN
+        CALL netcdf_put_fvar (ng, model, ncname, 'z_slice',             &
+     &                        Zslice, (/1/), (/Nslice/),                &
+     &                        ncid = ncid)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      END IF
+!
 !  User generic parameters.
 !
       IF (Nuser.gt.0) THEN
@@ -4810,6 +4819,15 @@
      &                          pioFile = pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
+!
+!  Depths of horizontal slices.
+!
+      IF (Nslice.gt.0) THEN
+        CALL pio_netcdf_put_fvar (ng, model, ncname, 'z_slice',         &
+     &                            Zslice, (/1/), (/Nslice/),            &
+     &                            pioFile = pioFile)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      END IF
 !
 !  User generic parameters.
 !

--- a/ROMS/Utility/wrt_quick.F
+++ b/ROMS/Utility/wrt_quick.F
@@ -67,7 +67,9 @@
 #ifdef SOLVE3D
       USE uv_rotate_mod,       ONLY : uv_rotate3d
 #endif
-      USE vorticity_mod,       ONLY : rvorticity3d
+#ifdef SOLVE3D
+      USE vorticity_mod,       ONLY : pvorticity3d, rvorticity3d
+#endif
 #if defined WEC_VF && defined SOLVE3D
       USE wec_output_mod,      ONLY : wec_wrt_nf90
 # if defined PIO_LIB && defined DISTRIBUTE
@@ -96,6 +98,7 @@
 !  Local variable declarations.
 !
       integer :: LBi, UBi, LBj, UBj
+      integer :: IminS, ImaxS, JminS, JmaxS
 !
       character (len=*), parameter :: MyFile =                          &
      &  __FILE__
@@ -109,15 +112,22 @@
       LBj=BOUNDS(ng)%LBj(tile)
       UBj=BOUNDS(ng)%UBj(tile)
 !
+      IminS=BOUNDS(ng)%Istr(tile)-3
+      ImaxS=BOUNDS(ng)%Iend(tile)+3
+      JminS=BOUNDS(ng)%Jstr(tile)-3
+      JmaxS=BOUNDS(ng)%Jend(tile)+3
+!
       SELECT CASE (QCK(ng)%IOtype)
         CASE (io_nf90)
           CALL wrt_quick_nf90 (ng, iNLM, tile,                          &
-     &                         LBi, UBi, LBj, UBj)
+     &                         LBi, UBi, LBj, UBj,                      &
+     &                         IminS, ImaxS, JminS, JmaxS)
 
 #if defined PIO_LIB && defined DISTRIBUTE
         CASE (io_pio)
           CALL wrt_quick_pio (ng, iNLM, tile,                           &
-     &                        LBi, UBi, LBj, UBj)
+     &                        LBi, UBi, LBj, UBj,                       &
+     &                        IminS, ImaxS, JminS, JmaxS)
 #endif
         CASE DEFAULT
           IF (Master) THEN
@@ -135,7 +145,8 @@
 !
 !***********************************************************************
       SUBROUTINE wrt_quick_nf90 (ng, model, tile,                       &
-     &                           LBi, UBi, LBj, UBj)
+     &                           LBi, UBi, LBj, UBj,                    &
+     &                           IminS, ImaxS, JminS, JmaxS)
 !***********************************************************************
 !
       USE mod_netcdf
@@ -144,6 +155,7 @@
 !
       integer, intent(in) :: ng, model, tile
       integer, intent(in) :: LBi, UBi, LBj, UBj
+      integer, intent(in) :: IminS, ImaxS, JminS, JmaxS
 !
 !  Local variable declarations.
 !
@@ -157,6 +169,7 @@
       real(r8), allocatable :: Ur2d(:,:)
       real(r8), allocatable :: Vr2d(:,:)
 #ifdef SOLVE3D
+      real(r8), allocatable :: Fr3d(:,:,:)
       real(r8), allocatable :: Wr3d(:,:,:)
 #endif
 !
@@ -863,15 +876,99 @@
         deallocate (Wr3d)
       END IF
 !
-!  Write out surface relative vorticity (1/s) at PSI-points.
+!  Write out potential vorticity (m-1 s-1) at PSI-points at specified
+!  constant depth slices.
 !
-      IF (Qout(idRVsu,ng)) THEN
+      IF (Qout(idPVzs,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Fr3d)) THEN
+          allocate ( Fr3d(LBi:UBi,LBj:UBj,N(ng)) )
+          Fr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+        END IF
         IF (.not.allocated(Wr3d)) THEN
           allocate ( Wr3d(LBi:UBi,LBj:UBj,N(ng)) )
           Wr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
         END IF
+!
+        DO k=1,N(ng)
+          DO j=Jstr-1,Jend+1
+            DO i=Istr-1,Iend+1
+              GRID(ng)%z_v(i,j,k)=0.25_r8*(GRID(ng)%z_r(i-1,j-1,k)+     &
+     &                                     GRID(ng)%z_r(i-1,j  ,k)+     &
+     &                                     GRID(ng)%z_r(i  ,j-1,k)+     &
+     &                                     GRID(ng)%z_r(i ,j  ,k))
+            END DO
+          END DO
+        END DO
+!
+        CALL pvorticity3d (ng, model, tile,                             &
+                           LBi, UBi, LBj, UBj,                          &
+     &                     IminS, ImaxS, JminS, JmaxS, NOUT,            &
+# ifdef MASKING
+     &                     GRID(ng) % pmask,                            &
+     &                     GRID(ng) % umask,   GRID(ng) % vmask,        &
+# endif
+                           GRID(ng) % f,                                &
+                           GRID(ng) % om_u,    GRID(ng) % on_v,         &
+                           GRID(ng) % pm,      GRID(ng) % pn,           &
+                           GRID(ng) % z_r,     OCEAN(ng) % pden,        &
+                           OCEAN(ng) % u,      OCEAN(ng) % v,           &
+                           Fr3d)
+!
+        CALL extract_slice (ng, model, tile, p3dvar,                    &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      Fr3d,                                       &
+     &                      GRID(ng) % z_v,                             &
+# ifdef MASKING
+     &                      GRID(ng) % pmask,                           &
+# endif
+     &                      Zslice, Wr3d)
+!
         scale=1.0_dp
-        gtype=gfactor*p2dvar
+        gtype=gfactor*p3dvar
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idPVzs,             &
+     &                     QCK(ng)%Vid(idPVzs),                         &
+     &                     QCK(ng)%Rindex, gtype,                       &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+# ifdef MASKING
+     &                     GRID(ng) % pmask,                            &
+# endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idPVzs)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Fr3d)
+        deallocate (Wr3d)
+      END IF
+!
+!  Write out relative vorticity (s-1) at PSI-points at specified
+!  constant depth slices.
+!
+      IF (Qout(idRVzs,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Fr3d)) THEN
+          allocate ( Fr3d(LBi:UBi,LBj:UBj,N(ng)) )
+          Fr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+        END IF
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,N(ng)) )
+          Wr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+        END IF
+!
+        DO k=1,N(ng)
+          DO j=Jstr-1,Jend+1
+            DO i=Istr-1,Iend+1
+              GRID(ng)%z_v(i,j,k)=0.25_r8*(GRID(ng)%z_r(i-1,j-1,k)+     &
+     &                                     GRID(ng)%z_r(i-1,j  ,k)+     &
+     &                                     GRID(ng)%z_r(i  ,j-1,k)+     &
+     &                                     GRID(ng)%z_r(i ,j  ,k))
+            END DO
+          END DO
+        END DO
+!
         CALL rvorticity3d (ng, model, tile,                             &
                            LBi, UBi, LBj, UBj, NOUT,                    &
 # ifdef MASKING
@@ -880,23 +977,36 @@
                            GRID(ng) % om_u, GRID(ng) % on_v,            &
                            GRID(ng) % pm,   GRID(ng) % pn,              &
                            OCEAN(ng) % u,   OCEAN(ng) % v,              &
-                           Wr3d)
-        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idRVsu,             &
-     &                     QCK(ng)%Vid(idRVsu),                         &
+                           Fr3d)
+!
+        CALL extract_slice (ng, model, tile, p3dvar,                    &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      Fr3d,                                       &
+     &                      GRID(ng) % z_v,                             &
+# ifdef MASKING
+     &                      GRID(ng) % pmask,                           &
+# endif
+     &                      Zslice, Wr3d)
+!
+        scale=1.0_dp
+        gtype=gfactor*p3dvar
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idRVzs,             &
+     &                     QCK(ng)%Vid(idRVzs),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
-     &                     LBi, UBi, LBj, UBj, scale,                   &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
 # ifdef MASKING
      &                     GRID(ng) % pmask,                            &
 # endif
-     &                     Wr3d(:,:,N(ng)))
+     &                     Wr3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,20) TRIM(Vname(1,idRVsu)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRVzs)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
+        deallocate (Fr3d)
         deallocate (Wr3d)
       END IF
 !
@@ -1783,7 +1893,8 @@
 !
 !***********************************************************************
       SUBROUTINE wrt_quick_pio (ng, model, tile,                        &
-     &                          LBi, UBi, LBj, UBj)
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          IminS, ImaxS, JminS, JmaxS)
 !***********************************************************************
 !
       USE mod_pio_netcdf
@@ -1792,6 +1903,7 @@
 !
       integer, intent(in) :: ng, model, tile
       integer, intent(in) :: LBi, UBi, LBj, UBj
+      integer, intent(in) :: IminS, ImaxS, JminS, JmaxS
 !
 !  Local variable declarations.
 !
@@ -1805,6 +1917,7 @@
       real(r8), allocatable :: Ur2d(:,:)
       real(r8), allocatable :: Vr2d(:,:)
 # ifdef SOLVE3D
+      real(r8), allocatable :: Fr3d(:,:,:)
       real(r8), allocatable :: Wr3d(:,:,:)
 # endif
 !
@@ -2677,14 +2790,104 @@
         deallocate (Wr3d)
       END IF
 !
-!  Write out surface relative vorticity (1/s) at PSI-points.
+!  Write out potential vorticity (1/s) at PSI-points at specified
+!  constant depth slices.
 !
-      IF (Qout(idRVsu,ng)) THEN
+      IF (Qout(idPVzs,ng)) THEN
+        IF (.not.allocated(Fr3d)) THEN
+          allocate ( Fr3d(LBi:UBi,LBj:UBj,N(ng)) )
+          Fr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+        END IF
         IF (.not.allocated(Wr3d)) THEN
           allocate ( Wr3d(LBi:UBi,LBj:UBj,N(ng)) )
           Wr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
         END IF
+!
+        DO k=1,N(ng)
+          DO j=Jstr-1,Jend+1
+            DO i=Istr-1,Iend+1
+              GRID(ng)%z_v(i,j,k)=0.25_r8*(GRID(ng)%z_r(i-1,j-1,k)+     &
+     &                                     GRID(ng)%z_r(i-1,j  ,k)+     &
+     &                                     GRID(ng)%z_r(i  ,j-1,k)+     &
+     &                                     GRID(ng)%z_r(i ,j  ,k))
+            END DO
+          END DO
+        END DO
+!
+        CALL pvorticity3d (ng, model, tile,                             &
+                           LBi, UBi, LBj, UBj,                          &
+     &                     IminS, ImaxS, JminS, JmaxS, NOUT,            &
+# ifdef MASKING
+     &                     GRID(ng) % pmask,                            &
+     &                     GRID(ng) % umask,   GRID(ng) % vmask,        &
+# endif
+                           GRID(ng) % f,                                &
+                           GRID(ng) % om_u,    GRID(ng) % on_v,         &
+                           GRID(ng) % pm,      GRID(ng) % pn,           &
+                           GRID(ng) % z_r,     OCEAN(ng) % pden,        &
+                           OCEAN(ng) % u,      OCEAN(ng) % v,           &
+                           Fr3d)
+!
+        CALL extract_slice (ng, model, tile, p3dvar,                    &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      Fr3d,                                       &
+     &                      GRID(ng) % z_v,                             &
+# ifdef MASKING
+     &                      GRID(ng) % pmask,                           &
+# endif
+     &                      Zslice, Wr3d)
+!
         scale=1.0_dp
+        IF (QCK(ng)%pioVar(idPVzs)%dkind.eq.PIO_double) THEN
+          ioDesc => ioDesZ_dp_p3dvar(ng)
+        ELSE
+          ioDesc => ioDesZ_sp_p3dvar(ng)
+        END IF
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idPVzs,          &
+     &                     QCK(ng)%pioVar(idPVzs),                      &
+     &                     QCK(ng)%Rindex,                              &
+     &                     ioDesc,                                      &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+#  ifdef MASKING
+     &                     GRID(ng) % pmask,                            &
+#  endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idPVzs)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Fr3d)
+        deallocate (Wr3d)
+      END IF
+!
+!  Write out relative vorticity (s-1) at PSI-points at specified
+!  constant depth slices.
+!
+      IF (Qout(idRVzs,ng)) THEN
+        IF (.not.allocated(Fr3d)) THEN
+          allocate ( Fr3d(LBi:UBi,LBj:UBj,N(ng)) )
+          Fr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+        END IF
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,N(ng)) )
+          Wr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+        END IF
+!
+        DO k=1,N(ng)
+          DO j=Jstr-1,Jend+1
+            DO i=Istr-1,Iend+1
+              GRID(ng)%z_v(i,j,k)=0.25_r8*(GRID(ng)%z_r(i-1,j-1,k)+     &
+     &                                     GRID(ng)%z_r(i-1,j  ,k)+     &
+     &                                     GRID(ng)%z_r(i  ,j-1,k)+     &
+     &                                     GRID(ng)%z_r(i ,j  ,k))
+            END DO
+          END DO
+        END DO
+!
         CALL rvorticity3d (ng, model, tile,                             &
      &                     LBi, UBi, LBj, UBj, NOUT,                    &
 #  ifdef MASKING
@@ -2693,30 +2896,41 @@
                            GRID(ng) % om_u, GRID(ng) % on_v,            &
                            GRID(ng) % pm,   GRID(ng) % pn,              &
                            OCEAN(ng) % u,   OCEAN(ng) % v,              &
-                           Wr3d)
+                           Fr3d)
 !
-        IF (QCK(ng)%pioVar(idRVsu)%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_p2dvar(ng)
+        CALL extract_slice (ng, model, tile, p3dvar,                    &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      Fr3d,                                       &
+     &                      GRID(ng) % z_v,                             &
+# ifdef MASKING
+     &                      GRID(ng) % pmask,                           &
+# endif
+     &                      Zslice, Wr3d)
+!
+        scale=1.0_dp
+        IF (QCK(ng)%pioVar(idRVzs)%dkind.eq.PIO_double) THEN
+          ioDesc => ioDesZ_dp_p3dvar(ng)
         ELSE
-          ioDesc => ioDesc_sp_p2dvar(ng)
+          ioDesc => ioDesZ_sp_p3dvar(ng)
         END IF
-        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idRVsu,          &
-     &                     QCK(ng)%pioVar(idRVsu),                      &
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idRVzs,          &
+     &                     QCK(ng)%pioVar(idRVzs),                      &
      &                     QCK(ng)%Rindex,                              &
      &                     ioDesc,                                      &
-     &                     LBi, UBi, LBj, UBj, scale,                   &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
 #  ifdef MASKING
      &                     GRID(ng) % pmask,                            &
 #  endif
-     &                     Wr3d(:,:,N(ng)))
+     &                     Wr3d)
         IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
           IF (Master) THEN
-            WRITE (stdout,20) TRIM(Vname(1,idRVsu)), QCK(ng)%Rindex
+            WRITE (stdout,20) TRIM(Vname(1,idRVzs)), QCK(ng)%Rindex
           END IF
           exit_flag=3
           ioerror=status
           RETURN
         END IF
+        deallocate (Fr3d)
         deallocate (Wr3d)
       END IF
 !

--- a/ROMS/Utility/wrt_quick.F
+++ b/ROMS/Utility/wrt_quick.F
@@ -607,7 +607,7 @@
 !
       IF (Qout(idUzsl,ng).and.(Nslice.gt.0)) THEN
         IF (.not.allocated(Wr3d)) THEN
-          allocate (Wr3d(LBi:UBi,LBj:UBj,Nslice))
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
           Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
         END IF
         scale=1.0_dp
@@ -654,7 +654,7 @@
 !
       IF (Qout(idVzsl,ng).and.(Nslice.gt.0)) THEN
         IF (.not.allocated(Wr3d)) THEN
-          allocate (Wr3d(LBi:UBi,LBj:UBj,Nslice))
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
           Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
         END IF
         scale=1.0_dp
@@ -793,7 +793,7 @@
 !
       IF (Qout(idUzsE,ng).and.(Nslice.gt.0)) THEN
         IF (.not.allocated(Wr3d)) THEN
-          allocate (Wr3d(LBi:UBi,LBj:UBj,Nslice))
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
           Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
         END IF
         scale=1.0_dp
@@ -803,7 +803,7 @@
      &                      OCEAN(ng) % ua,                             &
      &                      GRID(ng) % z_r,                             &
 # ifdef MASKING
-     &                      GRID(ng) % rmask,                           &
+     &                      GRID(ng) % rmask_full,                      &
 # endif
      &                      Zslice, Wr3d)
 !
@@ -830,7 +830,7 @@
 !
       IF (Qout(idVzsN,ng).and.(Nslice.gt.0)) THEN
         IF (.not.allocated(Wr3d)) THEN
-          allocate (Wr3d(LBi:UBi,LBj:UBj,Nslice))
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
           Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
         END IF
         scale=1.0_dp
@@ -840,7 +840,7 @@
      &                      OCEAN(ng) % va,                             &
      &                      GRID(ng) % z_r,                             &
 # ifdef MASKING
-     &                      GRID(ng) % rmask,                           &
+     &                      GRID(ng) % rmask_full,                      &
 # endif
      &                      Zslice, Wr3d)
 !
@@ -867,7 +867,7 @@
 !
       IF (Qout(idRVsu,ng)) THEN
         IF (.not.allocated(Wr3d)) THEN
-          allocate (Wr3d(LBi:UBi,LBj:UBj,N(ng)))
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,N(ng)) )
           Wr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
         END IF
         scale=1.0_dp
@@ -904,7 +904,7 @@
 !
       IF (Qout(idOvel,ng)) THEN
         IF (.not.allocated(Wr3d)) THEN
-          allocate (Wr3d(LBi:UBi,LBj:UBj,0:N(ng)))
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,0:N(ng)) )
           Wr3d(LBi:UBi,LBj:UBj,0:N(ng))=0.0_r8
         END IF
         scale=1.0_dp
@@ -1013,7 +1013,7 @@
       DO itrc=1,NT(ng)
         IF (Qout(idzslT(itrc),ng).and.(Nslice.gt.0)) THEN
           IF (.not.allocated(Wr3d)) THEN
-            allocate (Wr3d(LBi:UBi,LBj:UBj,Nslice))
+            allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
             Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
           END IF
           scale=1.0_dp
@@ -1357,7 +1357,7 @@
      &                    GRID(ng) % CosAngler,                         &
      &                    GRID(ng) % SinAngler,                         &
 #  ifdef MASKING
-     &                    GRID(ng) % rmask_full,                        &
+     &                    GRID(ng) % rmask,                             &
 #  endif
      &                    FORCES(ng) % Uwind,                           &
      &                    FORCES(ng) % Vwind,                           &
@@ -2375,6 +2375,110 @@
         END IF
       END IF
 !
+!  Write out 3D U-momentum component (m/s) at specified constant depth
+!  slices.
+!
+      IF (Qout(idUzsl,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+!
+        DO k=1,N(ng)
+          DO j=Jstr-1,Jend+1
+            DO i=IstrU-1,Iend+1
+              GRID(ng)%z_v(i,j,k)=0.5_r8*(GRID(ng)%z_r(i-1,j,k)+        &
+     &                                    GRID(ng)%z_r(i  ,j,k))
+            END DO
+          END DO
+        END DO
+        CALL extract_slice (ng, model, tile, u3dvar,                    &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % u(:,:,:,NOUT),                  &
+     &                      GRID(ng) % z_v,                             &
+# ifdef MASKING
+     &                      GRID(ng) % umask_full,                      &
+# endif
+     &                      Zslice, Wr3d)
+!
+        scale=1.0_dp
+        IF (QCK(ng)%pioVar(idUzsl)%dkind.eq.PIO_double) THEN
+          ioDesc => ioDesZ_dp_u3dvar(ng)
+        ELSE
+          ioDesc => ioDesZ_sp_u3dvar(ng)
+        END IF
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idUvel,          &
+     &                     QCK(ng)%pioVar(idUzsl),                      &
+     &                     QCK(ng)%Rindex,                              &
+     &                     ioDesc,                                      &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+#  ifdef MASKING
+     &                     GRID(ng) % umask_full,                       &
+#  endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idUzsl)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
+!
+!  Write out 3D V-momentum component (m/s) at specified constant depth
+!  slices.
+!
+      IF (Qout(idVzsl,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+!
+        DO k=1,N(ng)
+          DO j=JstrV-1,Jend+1
+            DO i=Istr-1,Iend+1
+              GRID(ng)%z_v(i,j,k)=0.5_r8*(GRID(ng)%z_r(i,j-1,k)+        &
+     &                                    GRID(ng)%z_r(i,j  ,k))
+            END DO
+          END DO
+        END DO
+        CALL extract_slice (ng, model, tile, v3dvar,                    &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % v(:,:,:,NOUT),                  &
+     &                      GRID(ng) % z_v,                             &
+# ifdef MASKING
+     &                      GRID(ng) % vmask_full,                      &
+# endif
+     &                      Zslice, Wr3d)
+!
+        scale=1.0_dp
+        IF (QCK(ng)%pioVar(idVzsl)%dkind.eq.PIO_double) THEN
+          ioDesc => ioDesZ_dp_v3dvar(ng)
+        ELSE
+          ioDesc => ioDesZ_sp_v3dvar(ng)
+        END IF
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idVzsl,          &
+     &                     QCK(ng)%pioVar(idVzsl),                      &
+     &                     QCK(ng)%Rindex,                              &
+     &                     ioDesc,                                      &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+#  ifdef MASKING
+     &                     GRID(ng) % vmask_full,                       &
+#  endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idVzsl)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
+!
 !  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid.
 !
       IF (Qout(idu3dE,ng)) THEN
@@ -2487,11 +2591,97 @@
         END IF
       END IF
 !
+!  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid, at
+!  specified constant depth slices.
+!
+      IF (Qout(idUzsE,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+        CALL extract_slice (ng, model, tile, r3dvar,                    &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % ua,                             &
+     &                      GRID(ng) % z_r,                             &
+# ifdef MASKING
+     &                      GRID(ng) % rmask_full,                      &
+# endif
+     &                      Zslice, Wr3d)
+!
+        scale=1.0_dp
+        IF (QCK(ng)%pioVar(idUzsE)%dkind.eq.PIO_double) THEN
+          ioDesc => ioDesZ_dp_r3dvar(ng)
+        ELSE
+          ioDesc => ioDesZ_sp_r3dvar(ng)
+        END IF
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idUzsE,          &
+     &                     QCK(ng)%pioVar(idUzsE),                      &
+     &                     QCK(ng)%Rindex,                              &
+     &                     ioDesc,                                      &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+#  ifdef MASKING
+     &                     GRID(ng) % rmask_full,                       &
+#  endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idUzsE)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
+!
+!  Write out 3D Northward momentum (m/s) at RHO-points, A-grid, at
+!  specified constant depth slices.
+!
+      IF (Qout(idVzsN,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+        CALL extract_slice (ng, model, tile, r3dvar,                    &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % va,                             &
+     &                      GRID(ng) % z_r,                             &
+# ifdef MASKING
+     &                      GRID(ng) % rmask_full,                      &
+# endif
+     &                      Zslice, Wr3d)
+!
+        scale=1.0_dp
+        IF (QCK(ng)%pioVar(idv3dN)%dkind.eq.PIO_double) THEN
+          ioDesc => ioDesZ_dp_r3dvar(ng)
+        ELSE
+          ioDesc => ioDesZ_sp_r3dvar(ng)
+        END IF
+        status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idVzsN,          &
+     &                     QCK(ng)%pioVar(idVzsN),                      &
+     &                     QCK(ng)%Rindex,                              &
+     &                     ioDesc,                                      &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+#  ifdef MASKING
+     &                     GRID(ng) % rmask_full,                       &
+#  endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idVzsN)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
+!
 !  Write out surface relative vorticity (1/s) at PSI-points.
 !
       IF (Qout(idRVsu,ng)) THEN
         IF (.not.allocated(Wr3d)) THEN
-          allocate (Wr3d(LBi:UBi,LBj:UBj,N(ng)))
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,N(ng)) )
           Wr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
         END IF
         scale=1.0_dp
@@ -2534,7 +2724,7 @@
 !
       IF (Qout(idOvel,ng)) THEN
         IF (.not.allocated(Wr3d)) THEN
-          allocate (Wr3d(LBi:UBi,LBj:UBj,0:N(ng)))
+          allocate ( Wr3d(LBi:UBi,LBj:UBj,0:N(ng)) )
           Wr3d(LBi:UBi,LBj:UBj,0:N(ng))=0.0_r8
         END IF
         scale=1.0_dp
@@ -2656,6 +2846,51 @@
             ioerror=status
             RETURN
           END IF
+        END IF
+      END DO
+!
+!  Write out tracer type variables at specified constant depth slices.
+!
+      DO itrc=1,NT(ng)
+        IF (Qout(idzslT(itrc),ng).and.(Nslice.gt.0)) THEN
+          IF (.not.allocated(Wr3d)) THEN
+            allocate ( Wr3d(LBi:UBi,LBj:UBj,Nslice) )
+            Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+          END IF
+          CALL extract_slice (ng, model, tile, r3dvar,                  &
+     &                        LBi, UBi, LBj, UBj, 1, N(ng),             &
+     &                        OCEAN(ng) % t(:,:,:,NOUT,itrc),           &
+     &                        GRID(ng) % z_r,                           &
+# ifdef MASKING
+     &                        GRID(ng) % rmask,                         &
+# endif
+     &                        Zslice, Wr3d)
+!
+          scale=1.0_dp
+          IF (QCK(ng)%pioVar(idzslT(itrc))%dkind.eq.PIO_double) THEN
+            ioDesc => ioDesZ_dp_r3dvar(ng)
+          ELSE
+            ioDesc => ioDesZ_sp_r3dvar(ng)
+          END IF
+          status=nf_fwrite3d(ng, model, QCK(ng)%pioFile, idzslT(itrc),  &
+     &                       QCK(ng)%pioVar(idzslT(itrc)),              &
+     &                       QCK(ng)%Rindex,                            &
+     &                       ioDesc,                                    &
+     &                       LBi, UBi, LBj, UBj, 1, Nslice, scale,      &
+#  ifdef MASKING
+     &                       GRID(ng) % rmask,                          &
+#  endif
+     &                       Wr3d)
+          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+            IF (Master) THEN
+              WRITE (stdout,20) TRIM(Vname(1,idzslT(itrc))),            &
+     &                          QCK(ng)%Rindex
+            END IF
+            exit_flag=3
+            ioerror=status
+            RETURN
+          END IF
+          IF (itrc.eq.NT(ng)) deallocate (Wr3d)
         END IF
       END DO
 !
@@ -3030,7 +3265,7 @@
      &                    GRID(ng) % CosAngler,                         &
      &                    GRID(ng) % SinAngler,                         &
 #   ifdef MASKING
-     &                    GRID(ng) % rmask_full,                        &
+     &                    GRID(ng) % rmask,                             &
 #   endif
      &                    FORCES(ng) % Uwind,                           &
      &                    FORCES(ng) % Vwind,                           &

--- a/ROMS/Utility/wrt_quick.F
+++ b/ROMS/Utility/wrt_quick.F
@@ -44,6 +44,7 @@
       USE bbl_output_mod,      ONLY : bbl_wrt_pio
 # endif
 #endif
+      USE extract_slice_mod,   ONLY : extract_slice
 #if defined ICE_MODEL && defined SOLVE3D
       USE ice_output_mod,      ONLY : ice_wrt_nf90
 # if defined PIO_LIB && defined DISTRIBUTE
@@ -66,6 +67,7 @@
 #ifdef SOLVE3D
       USE uv_rotate_mod,       ONLY : uv_rotate3d
 #endif
+      USE vorticity_mod,       ONLY : rvorticity3d
 #if defined WEC_VF && defined SOLVE3D
       USE wec_output_mod,      ONLY : wec_wrt_nf90
 # if defined PIO_LIB && defined DISTRIBUTE
@@ -112,11 +114,11 @@
           CALL wrt_quick_nf90 (ng, iNLM, tile,                          &
      &                         LBi, UBi, LBj, UBj)
 
-# if defined PIO_LIB && defined DISTRIBUTE
+#if defined PIO_LIB && defined DISTRIBUTE
         CASE (io_pio)
           CALL wrt_quick_pio (ng, iNLM, tile,                           &
      &                        LBi, UBi, LBj, UBj)
-# endif
+#endif
         CASE DEFAULT
           IF (Master) THEN
             WRITE (stdout,10) QCK(ng)%IOtype
@@ -161,7 +163,7 @@
       character (len=*), parameter :: MyFile =                          &
      &  __FILE__//", wrt_quick_nf90"
 
-# include "set_bounds.h"
+#include "set_bounds.h"
 !
       SourceFile=MyFile
 !
@@ -554,52 +556,6 @@
 
 #ifdef SOLVE3D
 !
-!  Write out 3D U-momentum component (m/s).
-!
-      IF (Qout(idUvel,ng)) THEN
-        scale=1.0_dp
-        gtype=gfactor*u3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idUvel,             &
-     &                     QCK(ng)%Vid(idUvel),                         &
-     &                     QCK(ng)%Rindex, gtype,                       &
-     &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-# ifdef MASKING
-     &                     GRID(ng) % umask_full,                       &
-# endif
-     &                     OCEAN(ng) % u(:,:,:,NOUT))
-        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-          IF (Master) THEN
-            WRITE (stdout,20) TRIM(Vname(1,idUvel)), QCK(ng)%Rindex
-          END IF
-          exit_flag=3
-          ioerror=status
-          RETURN
-        END IF
-      END IF
-!
-!  Write out 3D V-momentum component (m/s).
-!
-      IF (Qout(idVvel,ng)) THEN
-        scale=1.0_dp
-        gtype=gfactor*v3dvar
-        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idVvel,             &
-     &                     QCK(ng)%Vid(idVvel),                         &
-     &                     QCK(ng)%Rindex, gtype,                       &
-     &                     LBi, UBi, LBj, UBj, 1, N(ng), scale,         &
-# ifdef MASKING
-     &                     GRID(ng) % vmask_full,                       &
-# endif
-     &                     OCEAN(ng) % v(:,:,:,NOUT))
-        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
-          IF (Master) THEN
-            WRITE (stdout,20) TRIM(Vname(1,idVvel)), QCK(ng)%Rindex
-          END IF
-          exit_flag=3
-          ioerror=status
-          RETURN
-        END IF
-      END IF
-!
 !  Write out surface U-momentum component (m/s).
 !
       IF (Qout(idUsur,ng)) THEN
@@ -646,6 +602,100 @@
         END IF
       END IF
 !
+!  Write out 3D U-momentum component (m/s) at specified constant depth
+!  slices.
+!
+      IF (Qout(idUzsl,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate (Wr3d(LBi:UBi,LBj:UBj,Nslice))
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+        scale=1.0_dp
+        gtype=gfactor*u3dvar
+!
+        DO k=1,N(ng)
+          DO j=Jstr-1,Jend+1
+            DO i=IstrU-1,Iend+1
+              GRID(ng)%z_v(i,j,k)=0.5_r8*(GRID(ng)%z_r(i-1,j,k)+        &
+     &                                    GRID(ng)%z_r(i  ,j,k))
+            END DO
+          END DO
+        END DO
+        CALL extract_slice (ng, model, tile, gtype,                     &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % u(:,:,:,NOUT),                  &
+     &                      GRID(ng) % z_v,                             &
+# ifdef MASKING
+     &                      GRID(ng) % umask_full,                      &
+# endif
+     &                      Zslice, Wr3d)
+!
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idUzsl,             &
+     &                     QCK(ng)%Vid(idUzsl),                         &
+     &                     QCK(ng)%Rindex, gtype,                       &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+# ifdef MASKING
+     &                     GRID(ng) % umask_full,                       &
+# endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idUzsl)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
+!
+!  Write out 3D V-momentum component (m/s) at specified constant depth
+!  slices.
+!
+      IF (Qout(idVzsl,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate (Wr3d(LBi:UBi,LBj:UBj,Nslice))
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+        scale=1.0_dp
+        gtype=gfactor*v3dvar
+!
+        DO k=1,N(ng)
+          DO j=JstrV-1,Jend+1
+            DO i=Istr-1,Iend+1
+              GRID(ng)%z_v(i,j,k)=0.5_r8*(GRID(ng)%z_r(i,j-1,k)+        &
+     &                                    GRID(ng)%z_r(i,j  ,k))
+            END DO
+          END DO
+        END DO
+        CALL extract_slice (ng, model, tile, gtype,                     &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % v(:,:,:,NOUT),                  &
+     &                      GRID(ng) % z_v,                             &
+# ifdef MASKING
+     &                      GRID(ng) % vmask_full,                      &
+# endif
+     &                      Zslice, Wr3d)
+!
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idVzsl,             &
+     &                     QCK(ng)%Vid(idVzsl),                         &
+     &                     QCK(ng)%Rindex, gtype,                       &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+# ifdef MASKING
+     &                     GRID(ng) % vmask_full,                       &
+# endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idVvel)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
+!
 !  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid.
 !
       IF (Qout(idu3dE,ng)) THEN
@@ -672,6 +722,8 @@
 !  Write out 3D Northward momentum (m/s) at RHO-points, A-grid.
 !
       IF (Qout(idv3dN,ng)) THEN
+        scale=1.0_dp
+        gtype=gfactor*r3dvar
         status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idv3dN,             &
      &                     QCK(ng)%Vid(idv3dN),                         &
      &                     QCK(ng)%Rindex, gtype,                       &
@@ -716,6 +768,8 @@
 !  Write out surface Northward momentum (m/s) at RHO-points, A-grid.
 !
       IF (Qout(idVsuN,ng)) THEN
+        scale=1.0_dp
+        gtype=gfactor*r2dvar
         status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idVsuN,           &
      &                     QCK(ng)%Vid(idVsuN),                       &
      &                     QCK(ng)%Rindex, gtype,                     &
@@ -732,6 +786,118 @@
           ioerror=status
           RETURN
         END IF
+      END IF
+!
+!  Write out 3D Eastward momentum (m/s) at RHO-points, A-grid, at
+!  specified constant depth slices.
+!
+      IF (Qout(idUzsE,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate (Wr3d(LBi:UBi,LBj:UBj,Nslice))
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+        scale=1.0_dp
+        gtype=gfactor*r3dvar
+        CALL extract_slice (ng, model, tile, gtype,                     &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % ua,                             &
+     &                      GRID(ng) % z_r,                             &
+# ifdef MASKING
+     &                      GRID(ng) % rmask,                           &
+# endif
+     &                      Zslice, Wr3d)
+!
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idUzsE,             &
+     &                     QCK(ng)%Vid(idUzsE),                         &
+     &                     QCK(ng)%Rindex, gtype,                       &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+# ifdef MASKING
+     &                     GRID(ng) % rmask_full,                       &
+# endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idu3dE)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+      END IF
+!
+!  Write out 3D Northward momentum (m/s) at RHO-points, A-grid, at
+!  specified constant depth slices.
+!
+      IF (Qout(idVzsN,ng).and.(Nslice.gt.0)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate (Wr3d(LBi:UBi,LBj:UBj,Nslice))
+          Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+        END IF
+        scale=1.0_dp
+        gtype=gfactor*r3dvar
+        CALL extract_slice (ng, model, tile, gtype,                     &
+     &                      LBi, UBi, LBj, UBj, 1, N(ng),               &
+     &                      OCEAN(ng) % va,                             &
+     &                      GRID(ng) % z_r,                             &
+# ifdef MASKING
+     &                      GRID(ng) % rmask,                           &
+# endif
+     &                      Zslice, Wr3d)
+!
+        status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idVzsN,             &
+     &                     QCK(ng)%Vid(idVzsN),                         &
+     &                     QCK(ng)%Rindex, gtype,                       &
+     &                     LBi, UBi, LBj, UBj, 1, Nslice, scale,        &
+# ifdef MASKING
+     &                     GRID(ng) % rmask_full,                       &
+# endif
+     &                     Wr3d)
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idv3dN)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
+      END IF
+!
+!  Write out surface relative vorticity (1/s) at PSI-points.
+!
+      IF (Qout(idRVsu,ng)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate (Wr3d(LBi:UBi,LBj:UBj,N(ng)))
+          Wr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+        END IF
+        scale=1.0_dp
+        gtype=gfactor*p2dvar
+        CALL rvorticity3d (ng, model, tile,                             &
+                           LBi, UBi, LBj, UBj, NOUT,                    &
+# ifdef MASKING
+     &                     GRID(ng) % pmask,                            &
+# endif
+                           GRID(ng) % om_u, GRID(ng) % on_v,            &
+                           GRID(ng) % pm,   GRID(ng) % pn,              &
+                           OCEAN(ng) % u,   OCEAN(ng) % v,              &
+                           Wr3d)
+        status=nf_fwrite2d(ng, model, QCK(ng)%ncid, idRVsu,             &
+     &                     QCK(ng)%Vid(idRVsu),                         &
+     &                     QCK(ng)%Rindex, gtype,                       &
+     &                     LBi, UBi, LBj, UBj, scale,                   &
+# ifdef MASKING
+     &                     GRID(ng) % pmask,                            &
+# endif
+     &                     Wr3d(:,:,N(ng)))
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idRVsu)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
       END IF
 !
 !  Write out S-coordinate omega vertical velocity (m/s).
@@ -839,6 +1005,46 @@
             ioerror=status
             RETURN
           END IF
+        END IF
+      END DO
+!
+!  Write out tracer type variables at specified constant depth slices.
+!
+      DO itrc=1,NT(ng)
+        IF (Qout(idzslT(itrc),ng).and.(Nslice.gt.0)) THEN
+          IF (.not.allocated(Wr3d)) THEN
+            allocate (Wr3d(LBi:UBi,LBj:UBj,Nslice))
+            Wr3d(LBi:UBi,LBj:UBj,1:Nslice)=0.0_r8
+          END IF
+          scale=1.0_dp
+          gtype=gfactor*r3dvar
+          CALL extract_slice (ng, model, tile, gtype,                   &
+     &                        LBi, UBi, LBj, UBj, 1, N(ng),             &
+     &                        OCEAN(ng) % t(:,:,:,NOUT,itrc),           &
+     &                        GRID(ng) % z_r,                           &
+# ifdef MASKING
+     &                        GRID(ng) % rmask,                         &
+# endif
+     &                        Zslice, Wr3d)
+!
+          status=nf_fwrite3d(ng, model, QCK(ng)%ncid, idzslT(itrc),     &
+     &                       QCK(ng)%Vid(idzslT(itrc)),                 &
+     &                       QCK(ng)%Rindex, gtype,                     &
+     &                       LBi, UBi, LBj, UBj, 1, Nslice, scale,      &
+# ifdef MASKING
+     &                       GRID(ng) % rmask,                          &
+# endif
+     &                       Wr3d)
+          IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+            IF (Master) THEN
+              WRITE (stdout,20) TRIM(Vname(1,idzslT(itrc))),            &
+     &                          QCK(ng)%Rindex
+            END IF
+            exit_flag=3
+            ioerror=status
+            RETURN
+          END IF
+          IF (itrc.eq.NT(ng)) deallocate (Wr3d)
         END IF
       END DO
 !
@@ -2279,6 +2485,49 @@
           ioerror=status
           RETURN
         END IF
+      END IF
+!
+!  Write out surface relative vorticity (1/s) at PSI-points.
+!
+      IF (Qout(idRVsu,ng)) THEN
+        IF (.not.allocated(Wr3d)) THEN
+          allocate (Wr3d(LBi:UBi,LBj:UBj,N(ng)))
+          Wr3d(LBi:UBi,LBj:UBj,1:N(ng))=0.0_r8
+        END IF
+        scale=1.0_dp
+        CALL rvorticity3d (ng, model, tile,                             &
+     &                     LBi, UBi, LBj, UBj, NOUT,                    &
+#  ifdef MASKING
+     &                     GRID(ng) % pmask,                            &
+#  endif
+                           GRID(ng) % om_u, GRID(ng) % on_v,            &
+                           GRID(ng) % pm,   GRID(ng) % pn,              &
+                           OCEAN(ng) % u,   OCEAN(ng) % v,              &
+                           Wr3d)
+!
+        IF (QCK(ng)%pioVar(idRVsu)%dkind.eq.PIO_double) THEN
+          ioDesc => ioDesc_dp_p2dvar(ng)
+        ELSE
+          ioDesc => ioDesc_sp_p2dvar(ng)
+        END IF
+        status=nf_fwrite2d(ng, model, QCK(ng)%pioFile, idRVsu,          &
+     &                     QCK(ng)%pioVar(idRVsu),                      &
+     &                     QCK(ng)%Rindex,                              &
+     &                     ioDesc,                                      &
+     &                     LBi, UBi, LBj, UBj, scale,                   &
+#  ifdef MASKING
+     &                     GRID(ng) % pmask,                            &
+#  endif
+     &                     Wr3d(:,:,N(ng)))
+        IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+          IF (Master) THEN
+            WRITE (stdout,20) TRIM(Vname(1,idRVsu)), QCK(ng)%Rindex
+          END IF
+          exit_flag=3
+          ioerror=status
+          RETURN
+        END IF
+        deallocate (Wr3d)
       END IF
 !
 !  Write out S-coordinate omega vertical velocity (m/s).

--- a/User/External/roms.in
+++ b/User/External/roms.in
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2665,6 +2698,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2773,7 +2818,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3057,6 +3112,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms.in
+++ b/User/External/roms.in
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2684,15 +2684,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2767,11 +2767,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2800,25 +2800,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2886,11 +2886,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2920,14 +2920,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2985,11 +2985,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_adria02.in
+++ b/User/External/roms_adria02.in
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2688,15 +2688,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2771,11 +2771,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2804,25 +2804,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2890,11 +2890,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2924,14 +2924,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2989,11 +2989,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_adria02.in
+++ b/User/External/roms_adria02.in
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2669,6 +2702,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2777,7 +2822,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3061,6 +3116,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_cblast.in
+++ b/User/External/roms_cblast.in
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2687,15 +2687,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2770,11 +2770,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2803,25 +2803,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2889,11 +2889,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2923,14 +2923,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2988,11 +2988,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_cblast.in
+++ b/User/External/roms_cblast.in
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2668,6 +2701,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2776,7 +2821,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3060,6 +3115,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_doppio.in
+++ b/User/External/roms_doppio.in
@@ -644,11 +644,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               near surface air temperature
-Hout(idUair) == F       ! Uwind              near surface U-wind
-Hout(idVair) == F       ! Vwind              near surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
+Hout(idTair) == F       ! Tair               near near surface air temperature
+Hout(idUair) == F       ! Uwind              near near surface U-wind
+Hout(idVair) == F       ! Vwind              near near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -695,12 +695,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -769,11 +769,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               near surface air temperature
-Qout(idUair) == F       ! Uair               near surface U-wind
-Qout(idVair) == F       ! Vair               near surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
+Qout(idTair) == F       ! Tair               near near surface air temperature
+Qout(idUair) == F       ! Uair               near near surface U-wind
+Qout(idVair) == F       ! Vair               near near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -872,11 +872,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               near surface air temperature
-Aout(idUair) == F       ! Uwind              near surface U-wind
-Aout(idVair) == F       ! Vwind              near surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
+Aout(idTair) == F       ! Tair               near near surface air temperature
+Aout(idUair) == F       ! Uwind              near near surface U-wind
+Aout(idVair) == F       ! Vwind              near near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2822,12 +2822,12 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface level U-velocity component.
-! Qout(idVsur)   Write out surface level V-velocity component.
-! Qout(idUsuE)   Write out surface level Eastward  velocity at RHO-points.
-! Qout(idVsuN)   Write out surface level Northward velocity at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface level temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).

--- a/User/External/roms_doppio.in
+++ b/User/External/roms_doppio.in
@@ -565,6 +565,7 @@ Hout(idu3dE) == F       ! u_eastward         3D U-eastward  at RHO-points
 Hout(idv3dN) == F       ! v_northward        3D V-northward at RHO-points
 Hout(idWvel) == F       ! w                  3D W-velocity
 Hout(idOvel) == T       ! omega              omega vertical velocity
+Hout(idOvil) == F       ! omega_implicit     omega implicit vertical velocity
 Hout(idUbar) == T       ! ubar               2D U-velocity
 Hout(idVbar) == T       ! vbar               2D V-velocity
 Hout(idu2dE) == F       ! ubar_eastward      2D U-eastward  at RHO-points
@@ -643,11 +644,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -768,11 +769,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -871,11 +872,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -1192,7 +1193,7 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! continuation (\) or a vertical bar (|) symbol after each entry, except
 ! the last one.
 
-     NFFILES == 8                           ! number of unique forcing files
+     NFFILES == 8                          ! number of unique forcing files
 
      FRCNAME == ../../om/lwrad_down_narr_NENA_2007.nc  \
                 ../../om/Pair_filled_narr_NENA_2007.nc \
@@ -2692,15 +2693,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2775,11 +2776,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2808,25 +2809,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level U-velocity component.
+! Qout(idVsur)   Write out surface level V-velocity component.
+! Qout(idUsuE)   Write out surface level Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2894,11 +2895,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2928,14 +2929,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2993,11 +2994,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_doppio.in
+++ b/User/External/roms_doppio.in
@@ -574,6 +574,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -688,6 +700,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -976,6 +998,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2673,6 +2706,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2781,7 +2826,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3065,6 +3120,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_eac_4.in
+++ b/User/External/roms_eac_4.in
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2665,6 +2698,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2773,7 +2818,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3057,6 +3112,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_eac_4.in
+++ b/User/External/roms_eac_4.in
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2684,15 +2684,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2767,11 +2767,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2800,25 +2800,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2886,11 +2886,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2920,14 +2920,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2985,11 +2985,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_eac_8.in
+++ b/User/External/roms_eac_8.in
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2665,6 +2698,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2773,7 +2818,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3057,6 +3112,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_eac_8.in
+++ b/User/External/roms_eac_8.in
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2684,15 +2684,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2767,11 +2767,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2800,25 +2800,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2886,11 +2886,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2920,14 +2920,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2985,11 +2985,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_ias.in
+++ b/User/External/roms_ias.in
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2665,6 +2698,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2773,7 +2818,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3057,6 +3112,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_ias.in
+++ b/User/External/roms_ias.in
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2684,15 +2684,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2767,11 +2767,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2800,25 +2800,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2886,11 +2886,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2920,14 +2920,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2985,11 +2985,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_ias_40.in
+++ b/User/External/roms_ias_40.in
@@ -641,11 +641,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -692,12 +692,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -766,11 +766,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -869,11 +869,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2683,15 +2683,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2766,11 +2766,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2799,25 +2799,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2885,11 +2885,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2919,14 +2919,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2984,11 +2984,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_ias_40.in
+++ b/User/External/roms_ias_40.in
@@ -572,6 +572,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -686,6 +698,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -974,6 +996,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2664,6 +2697,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2772,7 +2817,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3056,6 +3111,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_natl.in
+++ b/User/External/roms_natl.in
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2665,6 +2698,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2773,7 +2818,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3057,6 +3112,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_natl.in
+++ b/User/External/roms_natl.in
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2684,15 +2684,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2767,11 +2767,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2800,25 +2800,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2886,11 +2886,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2920,14 +2920,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2985,11 +2985,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_nena.in
+++ b/User/External/roms_nena.in
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2666,6 +2699,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2774,7 +2819,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3058,6 +3113,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_nena.in
+++ b/User/External/roms_nena.in
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2685,15 +2685,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2768,11 +2768,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2801,25 +2801,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2887,11 +2887,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2921,14 +2921,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2986,11 +2986,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_nj_bight.in
+++ b/User/External/roms_nj_bight.in
@@ -648,11 +648,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -699,12 +699,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -773,11 +773,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -876,11 +876,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2697,15 +2697,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2780,11 +2780,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2813,25 +2813,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2899,11 +2899,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2933,14 +2933,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2998,11 +2998,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_nj_bight.in
+++ b/User/External/roms_nj_bight.in
@@ -579,6 +579,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -693,6 +705,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -981,6 +1003,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2678,6 +2711,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2786,7 +2831,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3070,6 +3125,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_scb.in
+++ b/User/External/roms_scb.in
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2665,6 +2698,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2773,7 +2818,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3057,6 +3112,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_scb.in
+++ b/User/External/roms_scb.in
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2684,15 +2684,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2767,11 +2767,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2800,25 +2800,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2886,11 +2886,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2920,14 +2920,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2985,11 +2985,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_sw06_coarse.in
+++ b/User/External/roms_sw06_coarse.in
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2665,6 +2698,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2773,7 +2818,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3057,6 +3112,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_sw06_coarse.in
+++ b/User/External/roms_sw06_coarse.in
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2684,15 +2684,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2767,11 +2767,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2800,25 +2800,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2886,11 +2886,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2920,14 +2920,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2985,11 +2985,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_sw06_fine.in
+++ b/User/External/roms_sw06_fine.in
@@ -573,6 +573,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -687,6 +699,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -975,6 +997,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2665,6 +2698,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2773,7 +2818,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3057,6 +3112,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_sw06_fine.in
+++ b/User/External/roms_sw06_fine.in
@@ -642,11 +642,11 @@ Hout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
-Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idTair) == F       ! Tair               near surface air temperature
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -693,12 +693,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -767,11 +767,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -870,11 +870,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2684,15 +2684,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2767,11 +2767,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2800,25 +2800,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2886,11 +2886,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2920,14 +2920,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2985,11 +2985,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.

--- a/User/External/roms_wcofs.in
+++ b/User/External/roms_wcofs.in
@@ -571,6 +571,18 @@ Hout(idBath) == F       ! bath               time-dependent bathymetry
 
 Hout(idTvar) == T T     ! temp, salt         temperature and salinity
 
+Hout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Hout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Hout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Hout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Hout(id3dPV) == F       ! pvorticity         potential vorticity at PSI-points
+Hout(id3dRV) == F       ! rvorticity         relative  vorticity at PSI-points
+Hout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Hout(idRVzs) == F       ! rvorticity_slice   relative  vorticity depth slices
+
+Hout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
+
 Hout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Hout(idpthU) == F       ! z_u                time-varying depths of U-points
 Hout(idpthV) == F       ! z_v                time-varying depths of V-points
@@ -685,6 +697,16 @@ Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
 Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
 
 Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+
+Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
+Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
+Qout(idUzsE) == F       ! u_eastward_slice   U-eastward  velocity depth slices
+Qout(idVzsN) == F       ! v_northward_slice  V-northward velocity depth slices
+
+Qout(idPVzs) == F       ! pvorticity_slice   potential vorticity depth slices
+Qout(idRVzs) == F       ! rvorticity_slice   relative vorticity depth slices
+
+Qout(idzslT) == F F     ! temp_slice, ...    temperature and salinity depth slices
 
 Qout(idpthR) == F       ! z_rho              time-varying depths of RHO-points
 Qout(idpthU) == F       ! z_u                time-varying depths of U-points
@@ -973,6 +995,17 @@ Dout(iTxdif) == T T     ! temp_xdiff, ...    horizontal XI-diffusion
 Dout(iTydif) == T T     ! temp_ydiff, ...    horizontal ETA-diffusion
 Dout(iTsdif) == T T     ! temp_sdiff, ...    horizontal S-diffusion
 Dout(iTvdif) == T T     ! temp_vdiff, ...    vertical diffusion
+
+! Number of output field horizontal slices and their depths (negative, m).
+! It is possible to extract selected state fields like temperature, salinity,
+! and velocity components at a constant depth in the QUICKSAVE and HISTORY
+! NetCDF files. Use wise depth values based on dynamics and model bathymetry
+! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
+! file size manageable. Order "Z_SLICE" in descending values (surface to
+! bottom).
+
+      NSLICE =  0
+     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
 
 ! Generic User parameters, [1:NUSER].
 
@@ -2663,6 +2696,18 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
+! Hout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
+!
+! Hout(id3dPV)   Write out potential vorticity at PSI-points.
+! Hout(id3dRV)   Write out relative  vorticity at PSI-points.
+! Hout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Hout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
 ! Hout(idpthR)   Write out time-varying depths of RHO-points.
 ! Hout(idpthU)   Write out time-varying depths of U-points.
 ! Hout(idpthV)   Write out time-varying depths of V-points.
@@ -2771,7 +2816,17 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
 ! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity
+! Qout(idsurT)   Write out surface temperature and salinity.
+!
+! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idUzsE)   Write out U-eastward  velocity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idVzsN)   Write out V-northward velocity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idPVzs)   Write out potential vorticity depth slices, Z_SLICE(1:NSLICE).
+! Qout(idRVzs)   Write out relative  vorticity depth slices, Z_SLICE(1:NSLICE).
+!
+! Qout(idzslT)   Write out temperature/salinity depth slices, Z_SLICE(1:NSLICE).
 !
 ! Qout(idpthR)   Write out time-varying depths of RHO-points.
 ! Qout(idpthU)   Write out time-varying depths of U-points.
@@ -3055,6 +3110,22 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Dout(iTsdif)   Write out horizontal   S-diffusion, if TS_DIF2 or TS_DIF4 and
 !                  rotated tensor (MIX_GEO_TS or MIX_ISO_TS).
 ! Dout(iTvdif)   Write out vertical diffusion.
+!
+!------------------------------------------------------------------------------
+! Generic User parameters.
+!------------------------------------------------------------------------------
+!
+! Selected state variables, such as temperature, salinity, U-velocity,
+! V-velocity, U-eastward, and V-northward, can be extracted and saved at
+! specified constant depths (Z_SLICE) in the output QUICKSAVE and HISTORY
+! NetCDF files. It is advisable to limit the number of slices (NSLICE) to
+! a small value, ideally between 1 and 4, to keep the QUICKSAVE file size
+! manageable. Choose depths wisely based on the dynamics and model bathymetry.
+!
+! NSLICE       Number of horizontal contant depth slices.
+! Z_SLICE      Depths (negative, m) of desired horizontal slices ordered
+!                in decreasing values from surface to bottom.
+!                If Z_SLICE has a ZERO value, the surface field is loaded.
 !
 !------------------------------------------------------------------------------
 ! Generic User parameters.

--- a/User/External/roms_wcofs.in
+++ b/User/External/roms_wcofs.in
@@ -641,10 +641,10 @@ Hout(idWrol) == F       ! roller_action      wave roller action density
 
 Hout(idPair) == F       ! Pair               surface air pressure
 Hout(idTair) == F       ! Tair               surface air temperature
-Hout(idUair) == F       ! Uwind              surface U-wind
-Hout(idVair) == F       ! Vwind              surface V-wind
-Hout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Hout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Hout(idUair) == F       ! Uwind              near surface U-wind
+Hout(idVair) == F       ! Vwind              near surface V-wind
+Hout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Hout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Hout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Hout(idLhea) == F       ! latent             latent heat flux
@@ -691,12 +691,12 @@ Qout(idBath) == T       ! bath               time-dependent bathymetry
 
 Qout(idTvar) == F F     ! temp, salt         temperature and salinity
 
-Qout(idUsur) == T       ! u_sur              surface U-velocity
-Qout(idVsur) == T       ! v_sur              surface V-velocity
-Qout(idUsuE) == T       ! u_sur_eastward     surface U-eastward  velocity
-Qout(idVsuN) == T       ! v_sur_northward    surface V-northward velocity
+Qout(idUsur) == T       ! u_sur              surface level U-velocity
+Qout(idVsur) == T       ! v_sur              surface level V-velocity
+Qout(idUsuE) == T       ! u_sur_eastward     surface level U-eastward  velocity
+Qout(idVsuN) == T       ! v_sur_northward    surface level V-northward velocity
 
-Qout(idsurT) == T T     ! temp_sur, salt_sur surface temperature and salinity
+Qout(idsurT) == T T     ! temp_sur, salt_sur surface level temperature and salinity
 
 Qout(idUzsl) == F       ! u_slice            U-velocity depth slices
 Qout(idVzsl) == F       ! v_slice            V-velocity depth slices
@@ -765,11 +765,11 @@ Qout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Qout(idWrol) == F       ! roller_action      wave roller action density
 
 Qout(idPair) == F       ! Pair               surface air pressure
-Qout(idTair) == F       ! Tair               surface air temperature
-Qout(idUair) == F       ! Uair               surface U-wind
-Qout(idVair) == F       ! Vair               surface V-wind
-Qout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Qout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Qout(idTair) == F       ! Tair               near surface air temperature
+Qout(idUair) == F       ! Uair               near surface U-wind
+Qout(idVair) == F       ! Vair               near surface V-wind
+Qout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Qout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Qout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Qout(idLhea) == F       ! latent             latent heat flux
@@ -868,11 +868,11 @@ Aout(idWdis) == F       ! Dissip_roller      wave roller dissipation
 Aout(idWrol) == F       ! roller_action      wave roller action density
 
 Aout(idPair) == F       ! Pair               surface air pressure
-Aout(idTair) == F       ! Tair               surface air temperature
-Aout(idUair) == F       ! Uwind              surface U-wind
-Aout(idVair) == F       ! Vwind              surface V-wind
-Aout(idUaiE) == F       ! Uwind_eastward     surface Eastward  U-wind
-Aout(idVaiN) == F       ! Vwind_northward    surface Northward V-wind
+Aout(idTair) == F       ! Tair               near surface air temperature
+Aout(idUair) == F       ! Uwind              near surface U-wind
+Aout(idVair) == F       ! Vwind              near surface V-wind
+Aout(idUaiE) == F       ! Uwind_eastward     near surface Eastward  U-wind
+Aout(idVaiN) == F       ! Vwind_northward    near surface Northward V-wind
 
 Aout(idTsur) == F F     ! shflux, ssflux     surface net heat and salt flux
 Aout(idLhea) == F       ! latent             latent heat flux
@@ -2682,15 +2682,15 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Hout(idUvel)   Write out 3D U-velocity component.
 ! Hout(idVvel)   Write out 3D V-velocity component.
-! Hout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Hout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Hout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Hout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Hout(idWvel)   Write out 3D W-velocity component.
 ! Hout(idOvel)   Write out 3D omega vertical velocity.
 ! Hout(idOvil)   Write out 3D omega implicit vertical velocity.
 ! Hout(idUbar)   Write out 2D U-velocity component.
 ! Hout(idVbar)   Write out 2D V-velocity component.
-! Hout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Hout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Hout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Hout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Hout(idFsur)   Write out free-surface.
 ! Hout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2765,11 +2765,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Hout(idWrol)   Write out wave roller action density.
 !
 ! Hout(idPair)   Write out surface air pressure.
-! Hout(idTair)   Write out surface air temperature.
-! Hout(idUair)   Write out surface U-wind component.
-! Hout(idVair)   Write out surface V-wind component.
-! Hout(idUaiE)   Write out surface Eastward  U-wind component.
-! Hout(idVaiN)   Write out surface Northward V-wind component.
+! Hout(idTair)   Write out near surface air temperature.
+! Hout(idUair)   Write out near surface U-wind component.
+! Hout(idVair)   Write out near surface V-wind component.
+! Hout(idUaiE)   Write out near surface Eastward  U-wind.
+! Hout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Hout(idTsur)   Write out surface net heat and salt flux
 ! Hout(idLhea)   Write out latent heat flux.
@@ -2798,25 +2798,25 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Qout(idUvel)   Write out 3D U-velocity component.
 ! Qout(idVvel)   Write out 3D V-velocity component.
-! Qout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Qout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Qout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Qout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Qout(idWvel)   Write out 3D W-velocity component.
 ! Qout(idOvel)   Write out 3D omega vertical velocity.
 ! Qout(idUbar)   Write out 2D U-velocity component.
 ! Qout(idVbar)   Write out 2D V-velocity component.
-! Qout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Qout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Qout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Qout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Qout(idFsur)   Write out free-surface.
 ! Qout(idBath)   Write out time-dependent bathymetry.
 !
 ! Qout(idTvar)   Write out active (NAT) tracers: temperature and salinity.
 !
-! Qout(idUsur)   Write out surface U-velocity component.
-! Qout(idVsur)   Write out surface V-velocity component.
-! Qout(idUsuE)   Write out surface Eastward  velocity component at RHO-points.
-! Qout(idVsuN)   Write out surface Northward velocity component at RHO-points.
+! Qout(idUsur)   Write out surface level (k=N) U-velocity component.
+! Qout(idVsur)   Write out surface level (k=N) V-velocity component.
+! Qout(idUsuE)   Write out surface level (k=N) Eastward  velocity at RHO-points.
+! Qout(idVsuN)   Write out surface level (k=N) Northward velocity at RHO-points.
 !
-! Qout(idsurT)   Write out surface temperature and salinity.
+! Qout(idsurT)   Write out surface level (k=N) temperature and salinity.
 !
 ! Qout(idUzsl)   Write out U-velocity depth slices, Z_SLICE(1:NSLICE).
 ! Qout(idVzsl)   Write out V-velocity depth slices, Z_SLICE(1:NSLICE).
@@ -2884,11 +2884,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Qout(idWrol)   Write out wave roller action density.
 !
 ! Qout(idPair)   Write out surface air pressure.
-! Qout(idTair)   Write out surface air temperature.
-! Qout(idUair)   Write out surface U-wind component.
-! Qout(idVair)   Write out surface V-wind component.
-! Qout(idUaiE)   Write out surface Eastward  U-wind component.
-! Qout(idVaiN)   Write out surface Northward V-wind component.
+! Qout(idTair)   Write out near surface air temperature.
+! Qout(idUair)   Write out near surface U-wind component.
+! Qout(idVair)   Write out near surface V-wind component.
+! Qout(idUaiE)   Write out near surface Eastward  U-wind.
+! Qout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Qout(idTsur)   Write out surface net heat and salt flux
 ! Qout(idLhea)   Write out latent heat flux.
@@ -2918,14 +2918,14 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 !
 ! Aout(idUvel)   Write out 3D U-velocity component.
 ! Aout(idVvel)   Write out 3D V-velocity component.
-! Aout(idu3dE)   Write out 3D Eastward  velocity component at RHO-points.
-! Aout(idv3dN)   Write out 3D Northward velocity component at RHO-points.
+! Aout(idu3dE)   Write out 3D Eastward  velocity at RHO-points.
+! Aout(idv3dN)   Write out 3D Northward velocity at RHO-points.
 ! Aout(idWvel)   Write out 3D W-velocity component.
 ! Aout(idOvel)   Write out 3D omega vertical velocity.
 ! Aout(idUbar)   Write out 2D U-velocity component.
 ! Aout(idVbar)   Write out 2D V-velocity component.
-! Aout(idu2dE)   Write out 2D Eastward  velocity component at RHO-points.
-! Aout(idv2dN)   Write out 2D Northward velocity component at RHO-points.
+! Aout(idu2dE)   Write out 2D Eastward  velocity at RHO-points.
+! Aout(idv2dN)   Write out 2D Northward velocity at RHO-points.
 ! Aout(idFsur)   Write out free-surface.
 ! Aout(idBath)   Write out time-dependent bathymetry.
 !
@@ -2983,11 +2983,11 @@ PIO_I2C_Preq = 65                 ! Maximum pending I2C requests
 ! Aout(idWrol)   Write out wave roller action density.
 !
 ! Aout(idPair)   Write out surface air pressure.
-! Aout(idTair)   Write out surface air temperature.
-! Aout(idUair)   Write out surface U-wind component.
-! Aout(idVair)   Write out surface V-wind component.
-! Aout(idUaiE)   Write out surface Eastward  U-wind component.
-! Aout(idVaiN)   Write out surface Northward V-wind component.
+! Aout(idTair)   Write out near surface air temperature.
+! Aout(idUair)   Write out near surface U-wind component.
+! Aout(idVair)   Write out near surface V-wind component.
+! Aout(idUaiE)   Write out near surface Eastward  U-wind.
+! Aout(idVaiN)   Write out near surface Northward V-wind.
 !
 ! Aout(idTsur)   Write out surface net heat and salt flux
 ! Aout(idLhea)   Write out latent heat flux.


### PR DESCRIPTION
# Description

The ROMS output **`HISTORY`** and **`QUICKSAVE`** NetCDF files now include instantaneous potential and relative vorticity and the capability to write a few state variables at specified constant depth slices.

**WARNING:** All ROMS standard input files **`roms_*.in`** and metadata file **`varinfo.yaml`** were modified!

- All standard input files include new switches to activate the writing of new fields:
``` d
Hout(idUzsl) == T       ! u_slice            U-velocity depth slices
Hout(idVzsl) == T       ! v_slice            V-velocity depth slices
Hout(idUzsE) == T       ! u_eastward_slice   U-eastward  velocity depth slices
Hout(idVzsN) == T       ! v_northward_slice  V-northward velocity depth slices

Hout(id3dPV) == T       ! pvorticity         potential vorticity at PSI-points
Hout(id3dRV) == T       ! rvorticity         relative  vorticity at PSI-points
Hout(idPVzs) == T       ! pvorticity_slice   potential vorticity depth slices
Hout(idRVzs) == T       ! rvorticity_slice   relative  vorticity depth slices

Hout(idzslT) == T T     ! temp_slice, ...    temperature and salinity depth slices

...

Qout(idUzsl) == T       ! u_slice            U-velocity depth slices
Qout(idVzsl) == T       ! v_slice            V-velocity depth slices
Qout(idUzsE) == T       ! u_eastward_slice   U-eastward  velocity depth slices
Qout(idVzsN) == T       ! v_northward_slice  V-northward velocity depth slices

Qout(idPVzs) == T       ! pvorticity_slice   potential vorticity depth slices
Qout(idRVzs) == T       ! rvorticity_slice   relative vorticity depth slices

Qout(idzslT) == T T     ! temp_slice, ...    temperature and salinity depth slices
```
- The following block in the standard input file can be used to specify the constant depth slices:
``` d
! Number of output field horizontal slices and their depths (negative, m).
! It is possible to extract selected state fields like temperature, salinity,
! and velocity components at a constant depth in the QUICKSAVE and HISTORY
! NetCDF files. Use wise depth values based on dynamics and model bathymetry
! and make sure that "NSLICE" is small (between 1 and 4) to keep the QUICKSAVE
! file size manageable. Order "Z_SLICE" in descending values (surface to
! bottom).

      NSLICE =  0
     Z_SLICE =  0.0d0 -50.0d0 -100.0d0
```
Notice that a value of **`z_slice=0.0d0`** will load, for now, the surface level values in the new module **`extract_slice.F`**.  **`We will consider extrapolating to the free-surface location in the future`**. The depth slices are computed via linear interpolation. Limiting the number of slices **NSLICE** to a small value, ideally between 1 and 4, is advisable to keep the **HISTORY** and **QUICKSAVE** files size manageable.


- NetCDF new variables:
``` nc
dimensions:
        ...
	s_rho = 40 ;
	s_w = 41 ;
	z_slice = 6 ;
        ...
variables:
	double z_slice(z_slice) ;
		z_slice:long_name = "constant depth of output fields horizontal slices" ;
		z_slice:_FillValue = 1.e+37 ;
	double u_slice(ocean_time, z_slice, eta_u, xi_u) ;
		u_slice:standard_name = "sea_water_surface_x_velocity" ;
		u_slice:long_name = "u-momentum component" ;
		u_slice:units = "meter second-1" ;
		u_slice:time = "ocean_time" ;
		u_slice:cell_methods = "ocean_time: point" ;
		u_slice:grid = "grid" ;
		u_slice:location = "edge1" ;
		u_slice:coordinates = "lon_u lat_u z_slice ocean_time" ;
		u_slice:field = "u-velocity constant depth slice" ;
		u_slice:_FillValue = 1.e+37 ;
	double v_slice(ocean_time, z_slice, eta_v, xi_v) ;
		v_slice:standard_name = "sea_water_surface_y_velocity" ;
		v_slice:long_name = "v-momentum component" ;
		v_slice:units = "meter second-1" ;
		v_slice:time = "ocean_time" ;
		v_slice:cell_methods = "ocean_time: point" ;
		v_slice:grid = "grid" ;
		v_slice:location = "edge2" ;
		v_slice:coordinates = "lon_v lat_v z_slice ocean_time" ;
		v_slice:field = "v-velocity constant depth slice" ;
		v_slice:_FillValue = 1.e+37 ;
	double u_eastward(ocean_time, s_rho, eta_rho, xi_rho) ;
		u_eastward:standard_name = "eastward_sea_water_velocity" ;
		u_eastward:long_name = "eastward momentum component at RHO-points" ;
		u_eastward:units = "meter second-1" ;
		u_eastward:time = "ocean_time" ;
		u_eastward:cell_methods = "ocean_time: point" ;
		u_eastward:grid = "grid" ;
		u_eastward:location = "face" ;
		u_eastward:coordinates = "lon_rho lat_rho s_rho ocean_time" ;
		u_eastward:field = "u-eastward" ;
		u_eastward:_FillValue = 1.e+37 ;
	double u_eastward_slice(ocean_time, z_slice, eta_rho, xi_rho) ;
		u_eastward_slice:standard_name = "eastward_sea_water_velocity" ;
		u_eastward_slice:long_name = "eastward momentum component at RHO-points" ;
		u_eastward_slice:units = "meter second-1" ;
		u_eastward_slice:time = "ocean_time" ;
		u_eastward_slice:cell_methods = "ocean_time: point" ;
		u_eastward_slice:grid = "grid" ;
		u_eastward_slice:location = "face" ;
		u_eastward_slice:coordinates = "lon_rho lat_rho z_slice ocean_time" ;
		u_eastward_slice:field = "u-eastward constant depth slice" ;
		u_eastward_slice:_FillValue = 1.e+37 ;
	double v_northward(ocean_time, s_rho, eta_rho, xi_rho) ;
		v_northward:standard_name = "northward_sea_water_velocity" ;
		v_northward:long_name = "northward momentum component at RHO-points" ;
		v_northward:units = "meter second-1" ;
		v_northward:time = "ocean_time" ;
		v_northward:cell_methods = "ocean_time: point" ;
		v_northward:grid = "grid" ;
		v_northward:location = "face" ;
		v_northward:coordinates = "lon_rho lat_rho s_rho ocean_time" ;
		v_northward:field = "v-northward" ;
		v_northward:_FillValue = 1.e+37 ;
	double v_northward_slice(ocean_time, z_slice, eta_rho, xi_rho) ;
		v_northward_slice:standard_name = "northward_sea_water_velocity" ;
		v_northward_slice:long_name = "northward momentum component at RHO-points" ;
		v_northward_slice:units = "meter second-1" ;
		v_northward_slice:time = "ocean_time" ;
		v_northward_slice:cell_methods = "ocean_time: point" ;
		v_northward_slice:grid = "grid" ;
		v_northward_slice:location = "face" ;
		v_northward_slice:coordinates = "lon_rho lat_rho z_slice ocean_time" ;
		v_northward_slice:field = "v-northward constant depth slice" ;
		v_northward_slice:_FillValue = 1.e+37 ;
	double pvorticity(ocean_time, s_rho, eta_psi, xi_psi) ;
		pvorticity:standard_name = "sea_water_potential_vorticity" ;
		pvorticity:long_name = "potential vorticity" ;
		pvorticity:units = "meter-1 second-1" ;
		pvorticity:time = "ocean_time" ;
		pvorticity:cell_methods = "ocean_time: point" ;
		pvorticity:grid = "grid" ;
		pvorticity:location = "node" ;
		pvorticity:coordinates = "lon_psi lat_psi s_rho ocean_time" ;
		pvorticity:field = "potential vorticity" ;
		pvorticity:_FillValue = 1.e+37 ;
	double rvorticity(ocean_time, s_rho, eta_psi, xi_psi) ;
		rvorticity:standard_name = "sea_water_relative_vorticity" ;
		rvorticity:long_name = "relative vorticity, vertical component" ;
		rvorticity:units = "second-1" ;
		rvorticity:time = "ocean_time" ;
		rvorticity:cell_methods = "ocean_time: point" ;
		rvorticity:grid = "grid" ;
		rvorticity:location = "node" ;
		rvorticity:coordinates = "lon_psi lat_psi s_rho ocean_time" ;
		rvorticity:field = "relative vorticity" ;
		rvorticity:_FillValue = 1.e+37 ;
	double pvorticity_slice(ocean_time, z_slice, eta_psi, xi_psi) ;
		pvorticity_slice:standard_name = "sea_water_potential_vorticity" ;
		pvorticity_slice:long_name = "potential vorticity" ;
		pvorticity_slice:units = "meter-1 second-1" ;
		pvorticity_slice:time = "ocean_time" ;
		pvorticity_slice:cell_methods = "ocean_time: point" ;
		pvorticity_slice:grid = "grid" ;
		pvorticity_slice:location = "node" ;
		pvorticity_slice:coordinates = "lon_psi lat_psi z_slice ocean_time" ;
		pvorticity_slice:field = "potential vorticity constant depth slice" ;
		pvorticity_slice:_FillValue = 1.e+37 ;
	double rvorticity_slice(ocean_time, z_slice, eta_psi, xi_psi) ;
		rvorticity_slice:standard_name = "sea_water_relative_vorticity" ;
		rvorticity_slice:long_name = "surface relative vorticity" ;
		rvorticity_slice:units = "second-1" ;
		rvorticity_slice:time = "ocean_time" ;
		rvorticity_slice:cell_methods = "ocean_time: point" ;
		rvorticity_slice:grid = "grid" ;
		rvorticity_slice:location = "node" ;
		rvorticity_slice:coordinates = "lon_psi lat_psi z_slice ocean_time" ;
		rvorticity_slice:field = "relative vorticity constant depth slice" ;
		rvorticity_slice:_FillValue = 1.e+37 ;
	double temp_slice(ocean_time, z_slice, eta_rho, xi_rho) ;
		temp_slice:standard_name = "sea_water_potential_temperature" ;
		temp_slice:long_name = "potential temperature" ;
		temp_slice:units = "Celsius" ;
		temp_slice:time = "ocean_time" ;
		temp_slice:cell_methods = "ocean_time: point" ;
		temp_slice:grid = "grid" ;
		temp_slice:location = "face" ;
		temp_slice:coordinates = "lon_rho lat_rho z_slice ocean_time" ;
		temp_slice:field = "temperature constant depth slices" ;
		temp_slice:_FillValue = 1.e+37 ;
	double salt_slice(ocean_time, z_slice, eta_rho, xi_rho) ;
		salt_slice:standard_name = "sea_water_practical_salinity" ;
		salt_slice:long_name = "salinity" ;
		salt_slice:time = "ocean_time" ;
		salt_slice:cell_methods = "ocean_time: point" ;
		salt_slice:grid = "grid" ;
		salt_slice:location = "face" ;
		salt_slice:coordinates = "lon_rho lat_rho z_slice ocean_time" ;
		salt_slice:field = "salinity constant depth slices" ;
		salt_slice:_FillValue = 1.e+37 ;
data:

 z_slice = -0, -20, -50, -100, -150, -200 ;
}
```
---
- Potential temperature and salinity constant depth slice at **0**m, **20**m, **50**m, **100**m, **150**m, and **200**m.

| Potential Temperature             | Salinity                              |
:------------------------------:|:--------------------------:
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/d764f2c6-81d7-46b1-82ad-6c88337ddb69"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/607a3ae7-d0e0-49c0-b8b5-2832a57b7598"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/2c1b3800-e8ae-4ee6-b8fc-d6ec2517a5ef"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/b5e3efbd-18c6-4a58-b05c-ec36bca104d1"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/6af91396-6832-45f3-9981-8693d01d1c30"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/571d6f04-29f5-4a80-b4fb-d5b01de21c70"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/b65e7235-d38d-4ac2-99a1-e805a62e89fd"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/8dbcde62-cbbd-445e-900f-9697340cacc6"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/c785ae07-ead2-47ff-83df-6ce24fc8d311"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/4d86dc62-f5d9-488f-8e61-e9c070888f50"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/102306b6-9f59-4148-b2df-6a1fa80310e8"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/280986eb-ada3-4401-9e97-5580c4ba4d25"> |

---

- Eastward and Northward velocity components constant depth slices at **0**m, **20**m, **50**m, **100**m, **150**m, and **200**m.

| Eastward Velocity (m s-1)          | Northward Velocity (m s-1)  |
:--------------------------------:|:----------------------------:
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/cd0f55ee-e980-4ce4-8206-5ca56d3a2e9a"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/4f742151-8d9f-41de-9e34-9887512e62b1"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/aea3928d-9154-4d26-950e-aa25c1797d04"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/5b60d89c-2768-4cb4-8981-31d1de0942df"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/369f95f2-8b7a-438d-abda-4653d5261952"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/f6fd835a-6fb8-4bce-a86e-ae2363bfaa4c"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/632e1791-bac5-4cf4-af13-2cb66cde661d"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/927982fd-e42f-4ce8-83bd-a65d84cb1343"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/e09097a1-4b7f-4f75-b666-cfccfa3f39a2"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/c52e8454-5d5a-4e52-a6a0-d4d4f672df7d"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/80ad8ced-aebc-4cca-868d-71595a8561cf"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/13938510-5581-47b8-b420-8893e94030f5"> |

---

- Potential and Relative vorticity at constant depth slices of **20**m, **50**m, **100**m, **150**m, and **200**m.  The potential vorticity makes it difficult to scale a single dynamic range of values.

| Potential Vorticity (m-1 s-1)    | Relative Vorticity (s-1)       |
:------------------------------:|:--------------------------:
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/2b1874d6-aac6-4590-8a89-42094cb5d615"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/19771b3b-44c3-4e67-a2ae-629a44165ad7"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/eef49dd3-8696-4f71-baed-8cb0d593d4b0"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/28b5f631-ab2c-4d0a-b8ae-fbd86e0e8256"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/3485352a-6c60-4cd6-a3bc-1816c569cd3f"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/2dfbb65b-ccdc-4bc8-b741-fdbfbc37bbef"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/aaebaa93-65d8-4449-9532-f846e6377129"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/c95ac493-5886-4375-8afd-fee78e9d856a"> |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/542bf68c-249d-4365-904c-e7089a9d0d5f"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/53c8125a-3f89-4bf2-a90c-333d895f745f"> |

---

## Issue(s) addressed
None.

## Impacts
It expands the output capabilities of ROMS's **`HISTORY`** and **`QUICKSAVE`** NetCDF files. This option is essential to keep files manageable in large applications since saving the whole water column frequently will be expensive.

## Dependencies
None.

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR
- [x] I have run and tested the changes before creating the PR
