### PR TITLE
Corrected typo when deallocating slice index idzslT

### DIFF
--- a/ROMS/Modules/mod_ncparam.F
+++ b/ROMS/Modules/mod_ncparam.F
@@ -1,4 +1,4 @@
-dz#include "cppdefs.h"
+#include "cppdefs.h"
       MODULE mod_ncparam
 !
 !git $Id$
@@ -1085,7 +1085,7 @@ dz#include "cppdefs.h"
 !
       IF (allocated(idRtrc))      deallocate ( idRtrc )
       IF (allocated(idsurT))      deallocate ( idsurT )
-      IF (allocated(idzslT))      deallocate ( idzslT )
+      IF (allocated(idsurT))      deallocate ( idzslT )
       IF (allocated(idTads))      deallocate ( idTads )
       IF (allocated(idTbot))      deallocate ( idTbot )
       IF (allocated(idTbry))      deallocate ( idTbry )

--- a/ROMS/Modules/mod_ncparam.F
+++ b/ROMS/Modules/mod_ncparam.F
@@ -1085,7 +1085,7 @@
 !
       IF (allocated(idRtrc))      deallocate ( idRtrc )
       IF (allocated(idsurT))      deallocate ( idsurT )
-      IF (allocated(idsurT))      deallocate ( idzslT )
+      IF (allocated(idzslT))      deallocate ( idzslT )
       IF (allocated(idTads))      deallocate ( idTads )
       IF (allocated(idTbot))      deallocate ( idTbot )
       IF (allocated(idTbry))      deallocate ( idTbry )


### PR DESCRIPTION
# Description

Corrected typo in subroutine **`deallocate_ncparam`** of module **`mod_ncparam.F`** when deallocating metadata index **`idzslT`**.

## Issue(s) addressed
See the following [link](https://www.myroms.org/forum/viewtopic.php?p=25845&hilit=idzslT#p25845) in the ROMS forum for details.  We need to have
``` f90
      IF (allocated(idzslT))      deallocate ( idzslT )

instead of

      IF (allocated(idsurT))      deallocate ( idzslT )
```
## Impacts
The error is triggered **`ROMS_finalize`** at the end of execution when deallocating all the variables.

## Dependencies
None.

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR