### PR TITLE
Updated the Incremental Analysis Update (IAU) implmentation

### DIFF
--- a/ROMS/Drivers/rbl4dvar.F
+++ b/ROMS/Drivers/rbl4dvar.F
@@ -2428,11 +2428,16 @@
 !  If activated IAU, compute the NLM model forcing contribution
 !  (f_state arrays) for the incremental analysis update. The tangent
 !  linear state is needed during the "timeIAU" interval if weak
-!  constraint is also activated (FrequentImpulse=TRUE).
+!  constraint is also activated (FrequentImpulse=TRUE). The IAU
+!  contribution is need in the work d_state array. Thus, a pointer
+!  association with TLM arrays is needed.
 !
       DO ng=1,Ngrids
         IF (timeIAU(ng).gt.0.0_dp) THEN
           IAUswitch(ng)=.TRUE.
+          CALL get_state (ng, 19, 19, ITL(ng), Rec3, LTLM1)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+!
           DO tile=first_tile(ng),last_tile(ng),+1
             CALL frc_iau_ini (ng, tile, iTLM, LTLM1)
           END DO
@@ -2477,26 +2482,27 @@
 
 #  ifdef RPCG
 !
-!  Compute the incremental analysis update forcing for the NLM.
-!  Read the accumulated increment from Rec3 of the ITL file.
+!  Read in cummulative increment (ITL, Rec3) for current outer loop and
+!  load it to the work d_state arrays. It is needed to compute the
+!  Incremental Analysis Update (IAU) forcing contribution.
 !
-        DO ng=1,Ngrids
-          IF (timeIAU(ng).gt.0.0_dp) THEN
-            IAUswitch(ng)=.TRUE.
-            CALL get_state (ng, iADM, 4, ITL(ng), Rec3, LTLM1)
-          END IF
-        END DO
+      DO ng=1,Ngrids
+        IF (timeIAU(ng).gt.0.0_dp) THEN
+          IAUswitch(ng)=.TRUE.
+          CALL get_state (ng, 19, 19, ITL(ng), Rec3, LTLM1)
+          IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+        END IF
+      END DO
 !
-!    Set up the NL model forcing contribution for the incremental
-!    analysis update.
+!  Initialize NL model Incremental Analysis Update forcing terms.
 !
-        DO ng=1,Ngrids
-          IF (timeIAU(ng).gt.0.0_dp) THEN
-            DO tile=first_tile(ng),last_tile(ng),+1
-              CALL frc_iau_ini (ng, tile, iTLM, LTLM1)
-            END DO
-          END IF
-        END DO
+      DO ng=1,Ngrids
+        IF (timeIAU(ng).gt.0.0_dp) THEN
+          DO tile=first_tile(ng),last_tile(ng),+1
+            CALL frc_iau_ini (ng, tile, iTLM, LTLM1)
+          END DO
+        END IF
+      END DO
 #  endif
 # endif
 !

--- a/ROMS/Modules/mod_strings.F
+++ b/ROMS/Modules/mod_strings.F
@@ -139,7 +139,7 @@
         integer, parameter :: Mregion = 60      ! start of mpi-region
         integer, parameter :: Nregion = 88
 !
-        character (len=48), dimension(18) :: StateMsg =                 &
+        character (len=48), dimension(19) :: StateMsg =                 &
      &    (/'state initial conditions,                       ',         & !01
      &      'previous state initial conditions,              ',         & !02
      &      'previous adjoint state solution,                ',         & !03
@@ -157,7 +157,8 @@
      &      'model error normalization factors,              ',         & !15
      &      'OBC normalization factors,                      ',         & !16
      &      'surface forcing normalization factors,          ',         & !17
-     &      'saddle-point Arnoldi state vector,              '/)          !18
+     &      'saddle-point Arnoldi state vector,              ',         & !18
+     &      'cummulative increments for IAU,                 '/)          !19
 !
         character (len=50), dimension(Nregion) :: Pregion =             &
      &    (/'Allocation and array initialization ..............',       & !01

--- a/ROMS/Utility/checkvars.F
+++ b/ROMS/Utility/checkvars.F
@@ -142,7 +142,8 @@
 !  process open boundary condition or surface forcing variable in the
 !  4D-Var control vector.
 !
-      IF ((model.le.11).or.(model.eq.14).or.(model.eq.15)) THEN
+      IF ((model.le.11).or.                                             &
+     &    (model.eq.14).or.(model.eq.15).or.(model.eq.19)) THEN
 #ifdef ANA_INITIAL
         IF (nrrec(ng).ne.0) THEN
           get_var(idFsur)=.TRUE.

--- a/ROMS/Utility/frc_iau.F
+++ b/ROMS/Utility/frc_iau.F
@@ -83,14 +83,14 @@
      &                       GRID(ng) % vmask,                          &
 # endif
 # ifdef SOLVE3D
-     &                       OCEAN(ng) % tl_u,                          &
-     &                       OCEAN(ng) % tl_v,                          &
-     &                       OCEAN(ng) % tl_t,                          &
+     &                       OCEAN(ng) % d_u,                           &
+     &                       OCEAN(ng) % d_v,                           &
+     &                       OCEAN(ng) % d_t,                           &
 # else
-     &                       OCEAN(ng) % tl_ubar,                       &
-     &                       OCEAN(ng) % tl_vbar,                       &
+     &                       OCEAN(ng) % d_ubar,                        &
+     &                       OCEAN(ng) % d_vbar,                        &
 # endif
-     &                       OCEAN(ng) % tl_zeta,                       &
+     &                       OCEAN(ng) % d_zeta,                        &
 # ifdef SOLVE3D
      &                       OCEAN(ng) % f_u,                           &
      &                       OCEAN(ng) % f_v,                           &
@@ -114,11 +114,11 @@
      &                             rmask, umask, vmask,                 &
 # endif
 # ifdef SOLVE3D
-     &                             tl_u, tl_v, tl_t,                    &
+     &                             d_u, d_v, d_t,                       &
 # else
-     &                             tl_ubar, tl_vbar,                    &
+     &                             d_ubar, d_vbar,                      &
 # endif
-     &                             tl_zeta,                             &
+     &                             d_zeta,                              &
 # ifdef SOLVE3D
      &                             f_u, f_v, f_t,                       &
 # else
@@ -139,14 +139,14 @@
       real(r8), intent(in   ) :: vmask(LBi:,LBj:)
 #  endif
 #  ifdef SOLVE3D
-      real(r8), intent(inout) :: tl_u(LBi:,LBj:,:,:)
-      real(r8), intent(inout) :: tl_v(LBi:,LBj:,:,:)
-      real(r8), intent(inout) :: tl_t(LBi:,LBj:,:,:,:)
+      real(r8), intent(inout) :: d_u(LBi:,LBj:,:)
+      real(r8), intent(inout) :: d_v(LBi:,LBj:,:)
+      real(r8), intent(inout) :: d_t(LBi:,LBj:,:,:)
 #  else
-      real(r8), intent(inout) :: tl_ubar(LBi:,LBj:,:)
-      real(r8), intent(inout) :: tl_vbar(LBi:,LBj:,:)
+      real(r8), intent(inout) :: d_ubar(LBi:,LBj:)
+      real(r8), intent(inout) :: d_vbar(LBi:,LBj:)
 #  endif
-      real(r8), intent(inout) :: tl_zeta(LBi:,LBj:,:)
+      real(r8), intent(inout) :: d_zeta(LBi:,LBj:)
 #  ifdef SOLVE3D
       real(r8), intent(inout) :: f_u(LBi:,LBj:,:)
       real(r8), intent(inout) :: f_v(LBi:,LBj:,:)
@@ -165,14 +165,14 @@
       real(r8), intent(in   ) :: vmask(LBi:UBi,LBj:UBj)
 #  endif
 #  ifdef SOLVE3D
-      real(r8), intent(inout) :: tl_u(LBi:UBi,LBj:UBj,N(ng),2)
-      real(r8), intent(inout) :: tl_v(LBi:UBi,LBj:UBj,N(ng),2)
-      real(r8), intent(inout) :: tl_t(LBi:UBi,LBj:UBj,N(ng),2,NT(ng))
+      real(r8), intent(inout) :: d_u(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(inout) :: d_v(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(inout) :: d_t(LBi:UBi,LBj:UBj,N(ng),NT(ng))
 #  else
-      real(r8), intent(inout) :: tl_ubar(LBi:UBi,LBj:UBj,3)
-      real(r8), intent(inout) :: tl_vbar(LBi:UBi,LBj:UBj,3)
+      real(r8), intent(inout) :: d_ubar(LBi:UBi,LBj:UBj)
+      real(r8), intent(inout) :: d_vbar(LBi:UBi,LBj:UBj)
 #  endif
-      real(r8), intent(inout) :: tl_zeta(LBi:UBi,LBj:UBj,3)
+      real(r8), intent(inout) :: d_zeta(LBi:UBi,LBj:UBj)
 #  ifdef SOLVE3D
       real(r8), intent(inout) :: f_u(LBi:UBi,LBj:UBj,N(ng))
       real(r8), intent(inout) :: f_v(LBi:UBi,LBj:UBj,N(ng))
@@ -184,8 +184,7 @@
       real(r8), intent(inout) :: f_zeta(LBi:UBi,LBj:UBj)
 # endif
 !
-!  Local variable declarations.
-!
+!  Local variable declarations
       integer :: i, it1, it2, j, k
 # ifdef SOLVE3D
       integer :: itrc
@@ -195,10 +194,13 @@
 # include "set_bounds.h"
 !
 !-----------------------------------------------------------------------
-!  Compute IAU forcing terms used in the nonlinear model.
-!  Use tl_var arrays as temporary storage for incremental analysis
-!  update forcing - needed when weak constraing is also activated
-!  and used in in the routine frc_iau.
+!  Initialize Incremental Analysis Update (IAU) forcing terms used in
+!  the nonlinear model. The cummulative increment from 4D-Var outer
+!  loop is stored in the work "d_*" arrays, and it is gradually added
+!  over the specified time interval. 
+!
+!  The "d_*" arrays are overwritten by the fractional increment to be
+!  added during time-stepping until the end filtering period.
 !-----------------------------------------------------------------------
 !
 !  Set uniform weights in time.
@@ -206,77 +208,79 @@
       fac1=REAL(timeIAU(ng)/dt(ng),r8)
       fac1=1.0_r8/fac1
 !
+!  Compute free-surface IAU forcing term.
+!
       DO j=JstrT,JendT
         DO i=IstrT,IendT
-          f_zeta(i,j)=fac1*tl_zeta(i,j,Linp)
+          f_zeta(i,j)=fac1*d_zeta(i,j)
 # ifdef MASKING
           f_zeta(i,j)=f_zeta(i,j)*rmask(i,j)
 # endif
-          tl_zeta(i,j,Linp)=f_zeta(i,j)
+          d_zeta(i,j)=f_zeta(i,j)
         END DO
       END DO
 
 # ifndef SOLVE3D
 !
-!  Compute 2D-momentum iau forcing terms.
+!  Compute 2D-momentum IAU forcing terms.
 !
       DO j=JstrT,JendT
         DO i=IstrP,IendT
-          f_ubar(i,j)=fac1*tl_ubar(i,j,Linp)
+          f_ubar(i,j)=fac1*d_ubar(i,j)
 #  ifdef MASKING
           f_ubar(i,j)=f_ubar(i,j)*umask(i,j)
 #  endif
-          tl_ubar(i,j,Linp)=f_ubar(i,j)
+          d_ubar(i,j)=f_ubar(i,j)
         END DO
       END DO
       DO j=JstrP,JendT
         DO i=IstrT,IendT
-          f_vbar(i,j)=fac1*tl_vbar(i,j,Linp)
+          f_vbar(i,j)=fac1*d_vbar(i,j)
 #  ifdef MASKING
           f_vbar(i,j)=f_vbar(i,j)*vmask(i,j)
 #  endif
-          tl_vbar(i,j,Linp)=f_vbar(i,j)
+          d_vbar(i,j)=f_vbar(i,j)
         END DO
       END DO
 # endif
 # ifdef SOLVE3D
 !
-!  Compute 3D-momentum iau forcing terms.
+!  Compute 3D-momentum IAU forcing terms.
 !
       DO k=1,N(ng)
         DO j=JstrT,JendT
           DO i=IstrP,IendT
-            f_u(i,j,k)=fac1*tl_u(i,j,k,Linp)
+            f_u(i,j,k)=fac1*d_u(i,j,k)
 #  ifdef MASKING
             f_u(i,j,k)=f_u(i,j,k)*umask(i,j)
 #  endif
-            tl_u(i,j,k,Linp)=f_u(i,j,k)
+            d_u(i,j,k)=f_u(i,j,k)
           END DO
         END DO
       END DO
       DO k=1,N(ng)
         DO j=JstrP,JendT
           DO i=IstrT,IendT
-            f_v(i,j,k)=fac1*tl_v(i,j,k,Linp)
+            f_v(i,j,k)=fac1*d_v(i,j,k)
 #  ifdef MASKING
             f_v(i,j,k)=f_v(i,j,k)*vmask(i,j)
 #  endif
-            tl_v(i,j,k,Linp)=f_v(i,j,k)
+            d_v(i,j,k)=f_v(i,j,k)
           END DO
         END DO
       END DO
 !
-!  Compute tracer iau forcing terms.
+!  Compute tracer IAU forcing terms.
 !
       DO itrc=1,NT(ng)
         DO k=1,N(ng)
           DO j=JstrT,JendT
             DO i=IstrT,IendT
-              f_t(i,j,k,itrc)=fac1*tl_t(i,j,k,Linp,itrc)
+              f_t(i,j,k,itrc)=fac1*d_t(i,j,k,itrc)
 #  ifdef MASKING
               f_t(i,j,k,itrc)=f_t(i,j,k,itrc)*rmask(i,j)
 #  endif
-              tl_t(i,j,k,Linp,itrc)=f_t(i,j,k,itrc)
+              d_t(i,j,k,itrc)=f_t(i,j,k,itrc)
             END DO
           END DO
         END DO
@@ -328,14 +332,14 @@
      &                   GRID(ng) % vmask,                              &
 # endif
 # ifdef SOLVE3D
-     &                   OCEAN(ng) % tl_u,                              &
-     &                   OCEAN(ng) % tl_v,                              &
-     &                   OCEAN(ng) % tl_t,                              &
+     &                   OCEAN(ng) % d_u,                               &
+     &                   OCEAN(ng) % d_v,                               &
+     &                   OCEAN(ng) % d_t,                               &
 # else
-     &                   OCEAN(ng) % tl_ubar,                           &
-     &                   OCEAN(ng) % tl_vbar,                           &
+     &                   OCEAN(ng) % d_ubar,                            &
+     &                   OCEAN(ng) % d_vbar,                            &
 # endif
-     &                   OCEAN(ng) % tl_zeta,                           &
+     &                   OCEAN(ng) % d_zeta,                            &
 # ifdef SOLVE3D
      &                   OCEAN(ng) % f_u,                               &
      &                   OCEAN(ng) % f_v,                               &
@@ -359,11 +363,11 @@
      &                         rmask, umask, vmask,                     &
 # endif
 # ifdef SOLVE3D
-     &                         tl_u, tl_v, tl_t,                        &
+     &                         d_u, d_v, d_t,                           &
 # else
-     &                         tl_ubar, tl_vbar,                        &
+     &                         d_ubar, d_vbar,                          &
 # endif
-     &                         tl_zeta,                                 &
+     &                         d_zeta,                                  &
 # ifdef SOLVE3D
      &                         f_u, f_v, f_t,                           &
 # else
@@ -384,14 +388,14 @@
       real(r8), intent(in   ) :: vmask(LBi:,LBj:)
 #  endif
 #  ifdef SOLVE3D
-      real(r8), intent(in   ) :: tl_u(LBi:,LBj:,:,:)
-      real(r8), intent(in   ) :: tl_v(LBi:,LBj:,:,:)
-      real(r8), intent(in   ) :: tl_t(LBi:,LBj:,:,:,:)
+      real(r8), intent(in   ) :: d_u(LBi:,LBj:,:)
+      real(r8), intent(in   ) :: d_v(LBi:,LBj:,:)
+      real(r8), intent(in   ) :: d_t(LBi:,LBj:,:,:)
 #  else
-      real(r8), intent(in   ) :: tl_ubar(LBi:,LBj:,:)
-      real(r8), intent(in   ) :: tl_vbar(LBi:,LBj:,:)
+      real(r8), intent(in   ) :: d_ubar(LBi:,LBj:)
+      real(r8), intent(in   ) :: d_vbar(LBi:,LBj:)
 #  endif
-      real(r8), intent(in   ) :: tl_zeta(LBi:,LBj:,:)
+      real(r8), intent(in   ) :: d_zeta(LBi:,LBj:)
 #  ifdef SOLVE3D
       real(r8), intent(inout) :: f_u(LBi:,LBj:,:)
       real(r8), intent(inout) :: f_v(LBi:,LBj:,:)
@@ -410,14 +414,14 @@
       real(r8), intent(in   ) :: vmask(LBi:UBi,LBj:UBj)
 #  endif
 #  ifdef SOLVE3D
-      real(r8), intent(in   ) :: tl_u(LBi:UBi,LBj:UBj,N(ng),2)
-      real(r8), intent(in   ) :: tl_v(LBi:UBi,LBj:UBj,N(ng),2)
-      real(r8), intent(in   ) :: tl_t(LBi:UBi,LBj:UBj,N(ng),2,NT(ng))
+      real(r8), intent(in   ) :: d_u(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(in   ) :: d_v(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(in   ) :: d_t(LBi:UBi,LBj:UBj,N(ng),NT(ng))
 #  else
-      real(r8), intent(in   ) :: tl_ubar(LBi:UBi,LBj:UBj,3)
-      real(r8), intent(in   ) :: tl_vbar(LBi:UBi,LBj:UBj,3)
+      real(r8), intent(in   ) :: d_ubar(LBi:UBi,LBj:UBj)
+      real(r8), intent(in   ) :: d_vbar(LBi:UBi,LBj:UBj)
 #  endif
-      real(r8), intent(in   ) :: tl_zeta(LBi:UBi,LBj:UBj,3)
+      real(r8), intent(in   ) :: d_zeta(LBi:UBi,LBj:UBj)
 #  ifdef SOLVE3D
       real(r8), intent(inout) :: f_u(LBi:UBi,LBj:UBj,N(ng))
       real(r8), intent(inout) :: f_v(LBi:UBi,LBj:UBj,N(ng))
@@ -439,13 +443,13 @@
 # include "set_bounds.h"
 !
 !-----------------------------------------------------------------------
-!  Update the weak constraint forcing arrays with the IAU forcing
-!  which is stored in the tl_var(Linp) arrays.
+!  Update the weak constraint forcing arrays with the IAU frational
+!  forcing contribution, which is stored in the work "d_*" arrays.
 !-----------------------------------------------------------------------
 !
       DO j=JstrT,JendT
         DO i=IstrT,IendT
-          f_zeta(i,j)=f_zeta(i,j)+tl_zeta(i,j,Linp)
+          f_zeta(i,j)=f_zeta(i,j)+d_zeta(i,j)
 # ifdef MASKING
           f_zeta(i,j)=f_zeta(i,j)*rmask(i,j)
 # endif
@@ -458,7 +462,7 @@
 !
       DO j=JstrT,JendT
         DO i=IstrP,IendT
-          f_ubar(i,j)=f_ubar(i,j)+tl_ubar(i,j,Linp)
+          f_ubar(i,j)=f_ubar(i,j)+d_ubar(i,j)
 #  ifdef MASKING
           f_ubar(i,j)=f_ubar(i,j)*umask(i,j)
 #  endif
@@ -466,7 +470,7 @@
       END DO
       DO j=JstrP,JendT
         DO i=IstrT,IendT
-          f_vbar(i,j)=f_vbar(i,j)+tl_vbar(i,j,Linp)
+          f_vbar(i,j)=f_vbar(i,j)+d_vbar(i,j)
 #  ifdef MASKING
           f_vbar(i,j)=f_vbar(i,j)*vmask(i,j)
 #  endif
@@ -480,7 +484,7 @@
       DO k=1,N(ng)
         DO j=JstrT,JendT
           DO i=IstrP,IendT
-            f_u(i,j,k)=f_u(i,j,k)+tl_u(i,j,k,Linp)
+            f_u(i,j,k)=f_u(i,j,k)+d_u(i,j,k)
 #  ifdef MASKING
             f_u(i,j,k)=f_u(i,j,k)*umask(i,j)
 #  endif
@@ -490,9 +494,9 @@
       DO k=1,N(ng)
         DO j=JstrP,JendT
           DO i=IstrT,IendT
-            f_v(i,j,k)=f_v(i,j,k)+tl_v(i,j,k,Linp)
+            f_v(i,j,k)=f_v(i,j,k)+d_v(i,j,k)
 #  ifdef MASKING
-           f_v(i,j,k)=f_v(i,j,k)*vmask(i,j)
+            f_v(i,j,k)=f_v(i,j,k)*vmask(i,j)
 #  endif
           END DO
         END DO
@@ -504,7 +508,7 @@
         DO k=1,N(ng)
           DO j=JstrT,JendT
             DO i=IstrT,IendT
-              f_t(i,j,k,itrc)=f_t(i,j,k,itrc)+tl_t(i,j,k,Linp,itrc)
+              f_t(i,j,k,itrc)=f_t(i,j,k,itrc)+d_t(i,j,k,itrc)
 #  ifdef MASKING
               f_t(i,j,k,itrc)=f_t(i,j,k,itrc)*rmask(i,j)
 #  endif

--- a/ROMS/Utility/get_state.F
+++ b/ROMS/Utility/get_state.F
@@ -273,6 +273,9 @@
       ELSE IF (model.eq.17) THEN
         string='NRM: '                     ! normalization factor
         IDmod=iNLM                         ! surface forcing
+      ELSE IF (model.eq.19) THEN
+        string='ITL: '                     ! cummulative increments for
+        IDmod=iTLM                         ! Incremental Analysis Update
       END IF
 
 #ifdef PROFILE
@@ -6336,6 +6339,336 @@
         END DO
 # endif
       END IF STD_STATE
+#endif
+
+#if defined FOUR_DVAR
+!
+!-----------------------------------------------------------------------
+!  Read in generic state variables into work "d_" arrays.
+!-----------------------------------------------------------------------
+!
+      GENERIC_STATE: IF (model.eq.19) THEN
+!
+!  Read in generic free-surface.
+!
+        IF (get_var(idFsur)) THEN
+          foundit=find_string(var_name, n_var, TRIM(Vname(1,idFsur)),   &
+     &                        varid)
+          IF (foundit) THEN
+            gtype=var_flag(varid)*r2dvar
+            status=nf_fread2d(ng, IDmod, ncname, ncINPid,               &
+     &                        Vname(1,idFsur), varid,                   &
+     &                        InpRec, gtype, Vsize,                     &
+     &                        LBi, UBi, LBj, UBj,                       &
+     &                        Fscl, Fmin, Fmax,                         &
+# ifdef MASKING
+     &                        GRID(ng) % rmask,                         &
+# endif
+# ifdef CHECKSUM
+     &                        OCEAN(ng) % f_zeta,                       &
+     &                        checksum = Fhash)
+# else
+     &                        OCEAN(ng) % d_zeta)
+# endif
+            IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+              IF (Master) THEN
+                WRITE (stdout,60) string, TRIM(Vname(1,idFsur)),        &
+     &                            InpRec, TRIM(ncname)
+              END IF
+              exit_flag=2
+              ioerror=status
+              RETURN
+            ELSE
+              IF (Master) THEN
+# ifdef CHECKSUM
+                WRITE (stdout,70) TRIM(Vname(2,idFsur)), Fmin, Fmax,    &
+     &                            Fhash
+# else
+                WRITE (stdout,70) TRIM(Vname(2,idFsur)), Fmin, Fmax
+# endif
+              END IF
+            END IF
+          ELSE
+            IF (Master) THEN
+              WRITE (stdout,80) string, TRIM(Vname(1,idFsur)),          &
+     &                          TRIM(ncname)
+            END IF
+            exit_flag=4
+            IF (FoundError(exit_flag, nf90_noerr,                       &
+     &                     __LINE__, MyFile)) THEN
+              RETURN
+            END IF
+          END IF
+        END IF
+
+# ifndef SOLVE3D
+!
+!  Read in genric 2D U-momentum.
+!
+        IF (get_var(idUbar)) THEN
+          foundit=find_string(var_name, n_var, TRIM(Vname(1,idUbar)),   &
+     &                        varid)
+          IF (foundit) THEN
+            gtype=var_flag(varid)*u2dvar
+            status=nf_fread2d(ng, IDmod, ncname, ncINPid,               &
+     &                        Vname(1,idUbar), varid,                   &
+     &                        InpRec, gtype, Vsize,                     &
+     &                        LBi, UBi, LBj, UBj,                       &
+     &                        Fscl, Fmin, Fmax,                         &
+#  ifdef MASKING
+     &                        GRID(ng) % umask,                         &
+#  endif
+#  ifdef CHECKSUM
+     &                        OCEAN(ng) % d_ubar,                       &
+     &                        checksum = Fhash)
+#  else
+     &                        OCEAN(ng) % d_ubar)
+#  endif
+            IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+              IF (Master) THEN
+                WRITE (stdout,60) string, TRIM(Vname(1,idUbar)),        &
+     &                            InpRec, TRIM(ncname)
+              END IF
+              exit_flag=2
+              ioerror=status
+              RETURN
+            ELSE
+              IF (Master) THEN
+#  ifdef CHECKSUM
+                WRITE (stdout,70) TRIM(Vname(2,idUbar)), Fmin, Fmax,    &
+     &                            Fhash
+#  else
+                WRITE (stdout,70) TRIM(Vname(2,idUbar)), Fmin, Fmax
+#  endif
+              END IF
+            END IF
+          ELSE
+            IF (Master) THEN
+              WRITE (stdout,80) string, TRIM(Vname(1,idUbar)),          &
+     &                          TRIM(ncname)
+            END IF
+            exit_flag=4
+            IF (FoundError(exit_flag, nf90_noerr,                       &
+     &                     __LINE__, MyFile)) THEN
+              RETURN
+            END IF
+          END IF
+        END IF
+!
+!  Read in generic 2D V-momentum.
+!
+        IF (get_var(idVbar)) THEN
+          foundit=find_string(var_name, n_var, TRIM(Vname(1,idVbar)),   &
+     &                        varid)
+          IF (foundit) THEN
+            gtype=var_flag(varid)*v2dvar
+            status=nf_fread2d(ng, IDmod, ncname, ncINPid,               &
+     &                        Vname(1,idVbar), varid,                   &
+     &                        InpRec, gtype, Vsize,                     &
+     &                        LBi, UBi, LBj, UBj,                       &
+     &                        Fscl, Fmin, Fmax,                         &
+#  ifdef MASKING
+     &                        GRID(ng) % vmask,                         &
+#  endif
+#  ifdef CHECKSUM
+     &                        OCEAN(ng) % d_vbar,                       &
+     &                        checksum = Fhash)
+#  else
+     &                        OCEAN(ng) % d_vbar)
+#  endif
+            IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+              IF (Master) THEN
+                WRITE (stdout,60) string, TRIM(Vname(1,idVbar)),        &
+     &                            InpRec, TRIM(ncname)
+              END IF
+              exit_flag=2
+              ioerror=status
+              RETURN
+            ELSE
+              IF (Master) THEN
+#  ifdef CHECKSUM
+                WRITE (stdout,70) TRIM(Vname(2,idVbar)), Fmin, Fmax,    &
+     &                            Fhash
+#  else
+                WRITE (stdout,70) TRIM(Vname(2,idVbar)), Fmin, Fmax
+#  endif
+              END IF
+            END IF
+          ELSE
+            IF (Master) THEN
+              WRITE (stdout,80) string, TRIM(Vname(1,idVbar)),          &
+     &                          TRIM(ncname)
+            END IF
+            exit_flag=4
+            IF (FoundError(exit_flag, nf90_noerr,                       &
+     &                     __LINE__, MyFile)) THEN
+              RETURN
+            END IF
+          END IF
+        END IF
+# endif
+# ifdef SOLVE3D
+!
+!  Read in generic 3D U-momentum.
+!
+        IF (get_var(idUvel)) THEN
+          foundit=find_string(var_name, n_var, TRIM(Vname(1,idUvel)),   &
+     &                        varid)
+          IF (foundit) THEN
+            gtype=var_flag(varid)*u3dvar
+            status=nf_fread3d(ng, IDmod, ncname, ncINPid,               &
+     &                        Vname(1,idUvel), varid,                   &
+     &                        InpRec, gtype, Vsize,                     &
+     &                        LBi, UBi, LBj, UBj, 1, N(ng),             &
+     &                        Fscl, Fmin, Fmax,                         &
+#  ifdef MASKING
+     &                        GRID(ng) % umask,                         &
+#  endif
+#  ifdef CHECKSUM
+     &                        OCEAN(ng) % d_u,                          &
+     &                        checksum = Fhash)
+#  else
+     &                        OCEAN(ng) % d_u)
+#  endif
+            IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+              IF (Master) THEN
+                WRITE (stdout,60) string, TRIM(Vname(1,idUvel)),        &
+     &                            InpRec, TRIM(ncname)
+              END IF
+              exit_flag=2
+              ioerror=status
+              RETURN
+            ELSE
+              IF (Master) THEN
+#  ifdef CHECKSUM
+                WRITE (stdout,70) TRIM(Vname(2,idUvel)), Fmin, Fmax,    &
+     &                            Fhash
+#  else
+                WRITE (stdout,70) TRIM(Vname(2,idUvel)), Fmin, Fmax
+#  endif
+              END IF
+            END IF
+          ELSE
+            IF (Master) THEN
+              WRITE (stdout,80) string, TRIM(Vname(1,idUvel)),          &
+     &                          TRIM(ncname)
+            END IF
+            exit_flag=4
+            IF (FoundError(exit_flag, nf90_noerr,                       &
+     &                     __LINE__, MyFile)) THEN
+              RETURN
+            END IF
+          END IF
+        END IF
+!
+!  Read in generic 3D V-momentum.
+!
+        IF (get_var(idVvel)) THEN
+          foundit=find_string(var_name, n_var, TRIM(Vname(1,idVvel)),   &
+     &                        varid)
+          IF (foundit) THEN
+            gtype=var_flag(varid)*v3dvar
+            status=nf_fread3d(ng, IDmod, ncname, ncINPid,               &
+     &                        Vname(1,idVvel), varid,                   &
+     &                        InpRec, gtype, Vsize,                     &
+     &                        LBi, UBi, LBj, UBj, 1, N(ng),             &
+     &                        Fscl, Fmin, Fmax,                         &
+#  ifdef MASKING
+     &                        GRID(ng) % vmask,                         &
+#  endif
+#  ifdef CHECKSUM
+     &                        OCEAN(ng) % d_v,                          &
+     &                        checksum = Fhash)
+#  else
+     &                        OCEAN(ng) % d_v)
+#  endif
+            IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+              IF (Master) THEN
+                WRITE (stdout,60) string, TRIM(Vname(1,idVvel)),        &
+     &                            InpRec, TRIM(ncname)
+              END IF
+              exit_flag=2
+              ioerror=status
+              RETURN
+            ELSE
+              IF (Master) THEN
+#  ifdef CHECKSUM
+                WRITE (stdout,70) TRIM(Vname(2,idVvel)), Fmin, Fmax,    &
+     &                            Fhash
+#  else
+                WRITE (stdout,70) TRIM(Vname(2,idVvel)), Fmin, Fmax
+#  endif
+              END IF
+            END IF
+          ELSE
+            IF (Master) THEN
+              WRITE (stdout,80) string, TRIM(Vname(1,idVvel)),          &
+     &                          TRIM(ncname)
+            END IF
+            exit_flag=4
+            IF (FoundError(exit_flag, nf90_noerr,                       &
+     &                     __LINE__, MyFile)) THEN
+              RETURN
+            END IF
+          END IF
+        END IF
+!
+!  Read in generic tracer variables.
+!
+        DO itrc=1,NT(ng)
+          IF (get_var(idTvar(itrc))) THEN
+            foundit=find_string(var_name, n_var,                        &
+     &                          TRIM(Vname(1,idTvar(itrc))), varid)
+            IF (foundit) THEN
+              gtype=var_flag(varid)*r3dvar
+              status=nf_fread3d(ng, IDmod, ncname, ncINPid,             &
+     &                          Vname(1,idTvar(itrc)), varid,           &
+     &                          InpRec, gtype, Vsize,                   &
+     &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
+     &                          Fscl, Fmin, Fmax,                       &
+#  ifdef MASKING
+     &                          GRID(ng) % rmask,                       &
+#  endif
+#  ifdef CHECKSUM
+     &                          OCEAN(ng) % d_t(:,:,:,itrc),            &
+     &                          checksum = Fhash)
+#  else
+     &                          OCEAN(ng) % d_t(:,:,:,itrc))
+#  endif
+              IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
+                IF (Master) THEN
+                  WRITE (stdout,60) string, TRIM(Vname(1,idTvar(itrc))),&
+     &                              InpRec, TRIM(ncname)
+                END IF
+                exit_flag=2
+                ioerror=status
+                RETURN
+              ELSE
+                IF (Master) THEN
+#  ifdef CHECKSUM
+                  WRITE (stdout,70) TRIM(Vname(2,idTvar(itrc))),        &
+     &                              Fmin, Fmax, Fhash
+#  else
+                  WRITE (stdout,70) TRIM(Vname(2,idTvar(itrc))),        &
+     &                              Fmin, Fmax
+#  endif
+                END IF
+              END IF
+            ELSE
+              IF (Master) THEN
+                WRITE (stdout,80) string, TRIM(Vname(1,idTvar(itrc))),  &
+     &                            TRIM(ncname)
+              END IF
+              exit_flag=4
+              IF (FoundError(exit_flag, nf90_noerr,                     &
+     &                       __LINE__, MyFile)) THEN
+                RETURN
+              END IF
+            END IF
+          END IF
+        END DO
+# endif
+      END IF GENERIC_STATE
 #endif
 
 #if defined IMPULSE
@@ -14692,6 +15025,390 @@
         END DO
 #  endif
       END IF STD_STATE
+# endif
+
+# if defined FOUR_DVAR
+!
+!-----------------------------------------------------------------------
+!  Read in generic state variables into work "d_" arrays.
+!-----------------------------------------------------------------------
+!
+      GENERIC_STATE: IF (model.eq.19) THEN
+!
+!  Read in generic free-surface.
+!
+        IF (get_var(idFsur)) THEN
+          foundit=find_string(var_name, n_var, TRIM(Vname(1,idFsur)),   &
+     &                        vindex)
+          IF (foundit) THEN
+            my_pioVar%vd=var_desc(vindex)
+            my_pioVar%gtype=r2dvar
+            IF (KIND(OCEAN(ng)%f_zeta).eq.8) THEN
+              my_pioVar%dkind=PIO_double
+              ioDesc => ioDesc_dp_r2dvar(ng)
+            ELSE
+              my_pioVar%dkind=PIO_real
+              ioDesc => ioDesc_sp_r2dvar(ng)
+            END IF
+!
+            status=nf_fread2d(ng, IDmod, ncname, pioFile,               &
+     &                        Vname(1,idFsur), my_pioVar,               &
+     &                        InpRec, ioDesc, Vsize,                    &
+     &                        LBi, UBi, LBj, UBj,                       &
+     &                        Fscl, Fmin, Fmax,                         &
+#  ifdef MASKING
+     &                        GRID(ng) % rmask,                         &
+#  endif
+#  ifdef CHECKSUM
+     &                        OCEAN(ng) % d_zeta,                       &
+     &                        checksum = Fhash)
+#  else
+     &                        OCEAN(ng) % d_zeta)
+#  endif
+            IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+              IF (Master) THEN
+                WRITE (stdout,60) string, TRIM(Vname(1,idFsur)),        &
+     &                            InpRec, TRIM(ncname)
+              END IF
+              exit_flag=2
+              ioerror=status
+              RETURN
+            ELSE
+              IF (Master) THEN
+#  ifdef CHECKSUM
+                WRITE (stdout,70) TRIM(Vname(2,idFsur)), Fmin, Fmax,    &
+     &                            Fhash
+#  else
+                WRITE (stdout,70) TRIM(Vname(2,idFsur)), Fmin, Fmax
+#  endif
+              END IF
+            END IF
+          ELSE
+            IF (Master) THEN
+              WRITE (stdout,80) string, TRIM(Vname(1,idFsur)),          &
+     &                          TRIM(ncname)
+            END IF
+            exit_flag=4
+            IF (FoundError(exit_flag, PIO_noerr,                        &
+     &                     __LINE__, MyFile)) THEN
+              RETURN
+            END IF
+          END IF
+        END IF
+
+#  ifndef SOLVE3D
+!
+!  Read in generic 2D U-momentum.
+!
+        IF (get_var(idUbar)) THEN
+          foundit=find_string(var_name, n_var, TRIM(Vname(1,idUbar)),   &
+     &                        vindex)
+          IF (foundit) THEN
+            my_pioVar%vd=var_desc(vindex)
+            my_pioVar%gtype=u2dvar
+            IF (KIND(OCEAN(ng)%f_ubar).eq.8) THEN
+              my_pioVar%dkind=PIO_double
+              ioDesc => ioDesc_dp_u2dvar(ng)
+            ELSE
+              my_pioVar%dkind=PIO_real
+              ioDesc => ioDesc_sp_u2dvar(ng)
+            END IF
+!
+            status=nf_fread2d(ng, IDmod, ncname, pioFile,               &
+     &                        Vname(1,idUbar), my_pioVar,               &
+     &                        InpRec, ioDesc, Vsize,                    &
+     &                        LBi, UBi, LBj, UBj,                       &
+     &                        Fscl, Fmin, Fmax,                         &
+#   ifdef MASKING
+     &                        GRID(ng) % umask,                         &
+#   endif
+#   ifdef CHECKSUM
+     &                        OCEAN(ng) % d_ubar,                       &
+     &                        checksum = Fhash)
+#   else
+     &                        OCEAN(ng) % d_ubar)
+#   endif
+            IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+              IF (Master) THEN
+                WRITE (stdout,60) string, TRIM(Vname(1,idUbar)),        &
+     &                            InpRec, TRIM(ncname)
+              END IF
+              exit_flag=2
+              ioerror=status
+              RETURN
+            ELSE
+              IF (Master) THEN
+#   ifdef CHECKSUM
+                WRITE (stdout,70) TRIM(Vname(2,idUbar)), Fmin, Fmax,    &
+     &                            Fhash
+#   else
+                WRITE (stdout,70) TRIM(Vname(2,idUbar)), Fmin, Fmax
+#   endif
+              END IF
+            END IF
+          ELSE
+            IF (Master) THEN
+              WRITE (stdout,80) string, TRIM(Vname(1,idUbar)),          &
+     &                          TRIM(ncname)
+            END IF
+            exit_flag=4
+            IF (FoundError(exit_flag, PIO_noerr,                        &
+     &                     __LINE__, MyFile)) THEN
+              RETURN
+            END IF
+          END IF
+        END IF
+!
+!  Read in generic 2D generic V-momentum.
+!
+        IF (get_var(idVbar)) THEN
+          foundit=find_string(var_name, n_var, TRIM(Vname(1,idVbar)),   &
+     &                        vindex)
+          IF (foundit) THEN
+            my_pioVar%vd=var_desc(vindex)
+            my_pioVar%gtype=v2dvar
+            IF (KIND(OCEAN(ng)%f_vbar).eq.8) THEN
+              my_pioVar%dkind=PIO_double
+              ioDesc => ioDesc_dp_v2dvar(ng)
+            ELSE
+              my_pioVar%dkind=PIO_real
+              ioDesc => ioDesc_sp_v2dvar(ng)
+            END IF
+!
+            status=nf_fread2d(ng, IDmod, ncname, pioFile,               &
+     &                        Vname(1,idVbar), my_pioVar,               &
+     &                        InpRec, ioDesc, Vsize,                    &
+     &                        LBi, UBi, LBj, UBj,                       &
+     &                        Fscl, Fmin, Fmax,                         &
+#   ifdef MASKING
+     &                        GRID(ng) % vmask,                         &
+#   endif
+#   ifdef CHECKSUM
+     &                        OCEAN(ng) % d_vbar,                       &
+     &                        checksum = Fhash)
+#   else
+     &                        OCEAN(ng) % d_vbar)
+#   endif
+            IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+              IF (Master) THEN
+                WRITE (stdout,60) string, TRIM(Vname(1,idVbar)),        &
+     &                            InpRec, TRIM(ncname)
+              END IF
+              exit_flag=2
+              ioerror=status
+              RETURN
+            ELSE
+              IF (Master) THEN
+#   ifdef CHECKSUM
+                WRITE (stdout,70) TRIM(Vname(2,idVbar)), Fmin, Fmax,    &
+     &                            Fhash
+#   else
+                WRITE (stdout,70) TRIM(Vname(2,idVbar)), Fmin, Fmax
+#   endif
+              END IF
+            END IF
+          ELSE
+            IF (Master) THEN
+              WRITE (stdout,80) string, TRIM(Vname(1,idVbar)),          &
+     &                          TRIM(ncname)
+            END IF
+            exit_flag=4
+            IF (FoundError(exit_flag, PIO_noerr,                        &
+     &                     __LINE__, MyFile)) THEN
+              RETURN
+            END IF
+          END IF
+        END IF
+#  endif
+#  ifdef SOLVE3D
+!
+!  Read in generic 3D U-momentum.
+!
+        IF (get_var(idUvel)) THEN
+          foundit=find_string(var_name, n_var, TRIM(Vname(1,idUvel)),   &
+     &                        vindex)
+          IF (foundit) THEN
+            my_pioVar%vd=var_desc(vindex)
+            my_pioVar%gtype=u3dvar
+            IF (KIND(OCEAN(ng)%f_u).eq.8) THEN
+              my_pioVar%dkind=PIO_double
+              ioDesc => ioDesc_dp_u3dvar(ng)
+            ELSE
+              my_pioVar%dkind=PIO_real
+              ioDesc => ioDesc_sp_u3dvar(ng)
+            END IF
+!
+            status=nf_fread3d(ng, IDmod, ncname, pioFile,               &
+     &                        Vname(1,idUvel), my_pioVar,               &
+     &                        InpRec, ioDesc, Vsize,                    &
+     &                        LBi, UBi, LBj, UBj, 1, N(ng),             &
+     &                        Fscl, Fmin, Fmax,                         &
+#   ifdef MASKING
+     &                        GRID(ng) % umask,                         &
+#   endif
+#   ifdef CHECKSUM
+     &                        OCEAN(ng) % d_u,                          &
+     &                        checksum = Fhash)
+#   else
+     &                        OCEAN(ng) % d_u)
+#   endif
+            IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+              IF (Master) THEN
+                WRITE (stdout,60) string, TRIM(Vname(1,idUvel)),        &
+     &                            InpRec, TRIM(ncname)
+              END IF
+              exit_flag=2
+              ioerror=status
+              RETURN
+            ELSE
+              IF (Master) THEN
+#   ifdef CHECKSUM
+                WRITE (stdout,70) TRIM(Vname(2,idUvel)), Fmin, Fmax,    &
+     &                            Fhash
+#   else
+                WRITE (stdout,70) TRIM(Vname(2,idUvel)), Fmin, Fmax
+#   endif
+              END IF
+            END IF
+          ELSE
+            IF (Master) THEN
+              WRITE (stdout,80) string, TRIM(Vname(1,idUvel)),          &
+     &                          TRIM(ncname)
+            END IF
+            exit_flag=4
+            IF (FoundError(exit_flag, PIO_noerr,                        &
+     &                     __LINE__, MyFile)) THEN
+              RETURN
+            END IF
+          END IF
+        END IF
+!
+!  Read in generic 3D V-momentum.
+!
+        IF (get_var(idVvel)) THEN
+          foundit=find_string(var_name, n_var, TRIM(Vname(1,idVvel)),   &
+     &                        vindex)
+          IF (foundit) THEN
+            my_pioVar%vd=var_desc(vindex)
+            my_pioVar%gtype=v3dvar
+            IF (KIND(OCEAN(ng)%f_v).eq.8) THEN
+              my_pioVar%dkind=PIO_double
+              ioDesc => ioDesc_dp_v3dvar(ng)
+            ELSE
+              my_pioVar%dkind=PIO_real
+              ioDesc => ioDesc_sp_v3dvar(ng)
+            END IF
+!
+            status=nf_fread3d(ng, IDmod, ncname, pioFile,               &
+     &                        Vname(1,idVvel), my_pioVar,               &
+     &                        InpRec, ioDesc, Vsize,                    &
+     &                        LBi, UBi, LBj, UBj, 1, N(ng),             &
+     &                        Fscl, Fmin, Fmax,                         &
+#   ifdef MASKING
+     &                        GRID(ng) % vmask,                         &
+#   endif
+#   ifdef CHECKSUM
+     &                        OCEAN(ng) % d_v,                          &
+     &                        checksum = Fhash)
+#   else
+     &                        OCEAN(ng) % d_v)
+#   endif
+            IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+              IF (Master) THEN
+                WRITE (stdout,60) string, TRIM(Vname(1,idVvel)),        &
+     &                            InpRec, TRIM(ncname)
+              END IF
+              exit_flag=2
+              ioerror=status
+              RETURN
+            ELSE
+              IF (Master) THEN
+#   ifdef CHECKSUM
+                WRITE (stdout,70) TRIM(Vname(2,idVvel)), Fmin, Fmax,    &
+     &                            Fhash
+#   else
+                WRITE (stdout,70) TRIM(Vname(2,idVvel)), Fmin, Fmax
+#   endif
+              END IF
+            END IF
+          ELSE
+            IF (Master) THEN
+              WRITE (stdout,80) string, TRIM(Vname(1,idVvel)),          &
+     &                          TRIM(ncname)
+            END IF
+            exit_flag=4
+            IF (FoundError(exit_flag, PIO_noerr,                        &
+     &                     __LINE__, MyFile)) THEN
+              RETURN
+            END IF
+          END IF
+        END IF
+!
+!  Read in generic tracers variables.
+!
+        DO itrc=1,NT(ng)
+          IF (get_var(idTvar(itrc))) THEN
+            foundit=find_string(var_name, n_var,                        &
+     &                          TRIM(Vname(1,idTvar(itrc))), vindex)
+            IF (foundit) THEN
+              my_pioVar%vd=var_desc(vindex)
+              my_pioVar%gtype=r3dvar
+              IF (KIND(OCEAN(ng)%f_t).eq.8) THEN
+                my_pioVar%dkind=PIO_double
+                ioDesc => ioDesc_dp_r3dvar(ng)
+              ELSE
+                my_pioVar%dkind=PIO_real
+                ioDesc => ioDesc_sp_r3dvar(ng)
+              END IF
+!
+              status=nf_fread3d(ng, IDmod, ncname, pioFile,             &
+     &                          Vname(1,idTvar(itrc)), my_pioVar,       &
+     &                          InpRec, ioDesc, Vsize,                  &
+     &                          LBi, UBi, LBj, UBj, 1, N(ng),           &
+     &                          Fscl, Fmin, Fmax,                       &
+#   ifdef MASKING
+     &                          GRID(ng) % rmask,                       &
+#   endif
+#   ifdef CHECKSUM
+     &                          OCEAN(ng) % d_t(:,:,:,itrc),            &
+     &                          checksum = Fhash)
+#   else
+     &                          OCEAN(ng) % d_t(:,:,:,itrc))
+#   endif
+              IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+                IF (Master) THEN
+                  WRITE (stdout,60) string, TRIM(Vname(1,idTvar(itrc))),&
+     &                              InpRec, TRIM(ncname)
+                END IF
+                exit_flag=2
+                ioerror=status
+                RETURN
+              ELSE
+                IF (Master) THEN
+#   ifdef CHECKSUM
+                  WRITE (stdout,70) TRIM(Vname(2,idTvar(itrc))),        &
+     &                              Fmin, Fmax, Fhash
+#   else
+                  WRITE (stdout,70) TRIM(Vname(2,idTvar(itrc))),        &
+     &                              Fmin, Fmax
+#   endif
+                END IF
+              END IF
+            ELSE
+              IF (Master) THEN
+                WRITE (stdout,80) string, TRIM(Vname(1,idTvar(itrc))),  &
+     &                            TRIM(ncname)
+              END IF
+              exit_flag=4
+              IF (FoundError(exit_flag, PIO_noerr,                      &
+     &                       __LINE__, MyFile)) THEN
+                RETURN
+              END IF
+            END IF
+          END IF
+        END DO
+#  endif
+      END IF GENERIC_STATE
 # endif
 
 # if defined IMPULSE

--- a/ROMS/Utility/obs_write.F
+++ b/ROMS/Utility/obs_write.F
@@ -1118,7 +1118,8 @@
         END DO
       END IF
 
-# if defined BGQC && !defined I4DVAR_ANA_SENSITIVITY
+# if defined BGQC && !(defined I4DVAR_ANA_SENSITIVITY || \
+                       defined VERIFICATION)
 !
 !-----------------------------------------------------------------------
 !  Perform the background quality control: check and reject observations


### PR DESCRIPTION
# Description

Corrected an issue in the non-split **RBL4D-Var** implementation of the Incremental Analysis Update (**IAU**) with multiple outer loops. The code was designed to use the adjoint state arrays as a workspace to store the fractional increment contributions for **zeta**, **u**, **v**, **T**, and **S** in the **4D-Va**r analysis phase. It was changed to use the tangent linear arrays to reduce the memory requirements in mixed-resolution **4D-Var**, where the outer loops run at higher resolution. However, using the tangent linear array affected the convergence of the non-split algorithm with multiple outer loops.

This PR remedies the **IAU** convergence issue using the **`d_`** prefix state arrays instead as temporary storage.

The figures below show the convergence of the cost function for the **WC13** application with **Nouter=2** and **Ninner=26** for the cases where **IAU** is applied for **12** or **96** hours compared to the solution without the **IAU** adjustment (**`timeIAU=0`**). Notice the **cyan** curve for the solution without **IAU** adjustment.

|  timeIAU=12 hours            |   timeIAU=96 hours          |
:--------------------------:|:-------------------------:
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/5b024f90-0dd8-4ed9-a366-4d4645d2ffcb"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/f7bf731b-970f-4313-8cc4-f89b2dec2a12"> |

Many thanks to Andy Moore for reporting this problem.

## Issue(s) addressed

Fixed convergence of non-split **4D-Var** when the **IAU** is activated to eliminate shocks in the **4D-Var** analysis.

## Dependencies

None.

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR
- [x] I have run and tested the changes before creating the PR
