### PR TITLE
Missing local variable declaration in step2d

### DIFF
--- a/ROMS/Nonlinear/step2d_LF_AM3.h
+++ b/ROMS/Nonlinear/step2d_LF_AM3.h
@@ -592,7 +592,7 @@
       integer :: idiag
 #endif
 !
-      real(r8) :: cff, cff1, cff2, cff3, cff4, cff5, cff6, cff7
+      real(r8) :: cff, cff1, cff2, cff3, cff4, cff5, cff6, cff7, cff8
       real(r8) :: fac, fac1, fac2, fac3
 !
       real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: Dgrad


### PR DESCRIPTION
# Description

This PR adds the missing declaration of the local variable **cff8** in **step2d_LF_AM3.h**, which is required when the option **`WEC_VF`** is activated.

Many thanks to Brian Powell for reporting this issue.

## Dependencies

None.

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR
- [x] I have run and tested the changes before creating the PR
