### PR TITLE
Removing ioDesc from 4D-Var adjust boundary

### DIFF
--- a/ROMS/Adjoint/ad_def_his.F
+++ b/ROMS/Adjoint/ad_def_his.F
@@ -581,6 +581,7 @@
 #  if defined WRITE_WATER && defined MASKING
         Vinfo(20)='mask_u'
 #  endif
+        Vinfo(21)=Vname(6,idUsms)
         Vinfo(22)='coordinates'
         Aval(5)=REAL(Iinfo(1,idUsms,ng),r8)
         status=def_var(ng, model, ADM(ng)%ncid, ADM(ng)%Vid(idUsms),    &
@@ -598,6 +599,7 @@
 #  if defined WRITE_WATER && defined MASKING
         Vinfo(20)='mask_v'
 #  endif
+        Vinfo(21)=Vname(6,idVsms)
         Vinfo(22)='coordinates'
         Aval(5)=REAL(Iinfo(1,idVsms,ng),r8)
         status=def_var(ng, model, ADM(ng)%ncid, ADM(ng)%Vid(idVsms),    &
@@ -627,6 +629,7 @@
 #  if defined WRITE_WATER && defined MASKING
             Vinfo(20)='mask_rho'
 #  endif
+            Vinfo(21)=Vname(6,idTsur(itrc))
             Vinfo(22)='coordinates'
             Aval(5)=REAL(Iinfo(1,idTsur(itrc),ng),r8)
             status=def_var(ng, model, ADM(ng)%ncid,                     &
@@ -732,7 +735,7 @@
           Vinfo( 3)='meter-1'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, ADM(ng)%ncid, ADM(ng)%Vid(ifield),  &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -771,7 +774,7 @@
           Vinfo( 3)='second meter-1'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, ADM(ng)%ncid, ADM(ng)%Vid(ifield),  &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -810,7 +813,7 @@
           Vinfo( 3)='second meter-1'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, ADM(ng)%ncid, ADM(ng)%Vid(ifield),  &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -850,7 +853,7 @@
           Vinfo( 3)='second meter-1'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, ADM(ng)%ncid, ADM(ng)%Vid(ifield),  &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -889,7 +892,7 @@
           Vinfo( 3)='second meter-1'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, ADM(ng)%ncid, ADM(ng)%Vid(ifield),  &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -1001,7 +1004,7 @@
               END IF
             END DO
 #   endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             status=def_var(ng, model, ADM(ng)%ncid, ADM(ng)%Vid(ifield),&
      &                     NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,     &
@@ -2052,6 +2055,7 @@
 #   if defined WRITE_WATER && defined MASKING
         Vinfo(20)='mask_u'
 #   endif
+        Vinfo(21)=Vname(6,idUsms)
         Vinfo(22)='coordinates'
         Aval(5)=REAL(Iinfo(1,idUsms,ng),r8)
         ADM(ng)%pioVar(idUsms)%dkind=PIO_FOUT
@@ -2073,6 +2077,7 @@
 #   if defined WRITE_WATER && defined MASKING
         Vinfo(20)='mask_v'
 #   endif
+        Vinfo(21)=Vname(6,idVsms)
         Vinfo(22)='coordinates'
         Aval(5)=REAL(Iinfo(1,idVsms,ng),r8)
         ADM(ng)%pioVar(idVsms)%dkind=PIO_FOUT
@@ -2106,6 +2111,7 @@
 #   if defined WRITE_WATER && defined MASKING
             Vinfo(20)='mask_rho'
 #   endif
+            Vinfo(21)=Vname(6,idTsur(itrc))
             Vinfo(22)='coordinates'
             Aval(5)=REAL(Iinfo(1,idTsur(itrc),ng),r8)
             ADM(ng)%pioVar(idTsur(itrc))%dkind=PIO_FOUT
@@ -2230,7 +2236,7 @@
           Vinfo( 3)='meter-1'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ADM(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ADM(ng)%pioVar(ifield)%gtype=r2dobc
@@ -2277,7 +2283,7 @@
           Vinfo( 3)='second meter-1'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ADM(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ADM(ng)%pioVar(ifield)%gtype=u2dobc
@@ -2324,7 +2330,7 @@
           Vinfo( 3)='second meter-1'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ADM(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ADM(ng)%pioVar(ifield)%gtype=v2dobc
@@ -2372,7 +2378,7 @@
           Vinfo( 3)='second meter-1'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ADM(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ADM(ng)%pioVar(ifield)%gtype=u3dobc
@@ -2419,7 +2425,7 @@
           Vinfo( 3)='second meter-1'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ADM(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ADM(ng)%pioVar(ifield)%gtype=v3dvar
@@ -2496,7 +2502,7 @@
 !
           status=def_var(ng, model, ADM(ng)%pioFile,                    &
      &                   ADM(ng)%pioVar(idOvel)%vd,                     &
-     &                   PIO_FOUT, nvd4, v3dgrd, Aval, Vinfo, ncname)
+     &                   PIO_FOUT, nvd4, w3dgrd, Aval, Vinfo, ncname)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
 !
@@ -2551,7 +2557,7 @@
               END IF
             END DO
 #    endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             ADM(ng)%pioVar(ifield)%dkind=PIO_FOUT
             ADM(ng)%pioVar(ifield)%gtype=r2dvar

--- a/ROMS/Adjoint/ad_wrt_his.F
+++ b/ROMS/Adjoint/ad_wrt_his.F
@@ -1677,17 +1677,12 @@
 !
       IF (ANY(Lobc(:,isFsur,ng))) THEN
         scale=1.0_dp
-        IF (ADM(ng)%pioVar(idSbry(isFsur))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_r2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_r2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, model, ADM(ng)%name,                 &
      &                         ADM(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isFsur)),                 &
      &                         ADM(ng)%pioVar(idSbry(isFsur)),          &
-     &                         ADM(ng)%Rindex, ioDesc,                  &
+     &                         ADM(ng)%Rindex,                          &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % ad_zeta_obc(LBij:,:,:,    &
      &                                                    Lbout(ng)))
@@ -1771,17 +1766,12 @@
 !
       IF (ANY(Lobc(:,isUbar,ng))) THEN
         scale=1.0_dp
-        IF (ADM(ng)%pioVar(idSbry(isUbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, model, ADM(ng)%name,                 &
      &                         ADM(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isUbar)),                 &
      &                         ADM(ng)%pioVar(idSbry(isUbar)),          &
-     &                         ADM(ng)%Rindex, ioDesc,                  &
+     &                         ADM(ng)%Rindex,                          &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % ad_ubar_obc(LBij:,:,:,    &
      &                                                    Lbout(ng)))
@@ -1866,17 +1856,12 @@
 !
       IF (ANY(Lobc(:,isVbar,ng))) THEN
         scale=1.0_dp
-        IF (ADM(ng)%pioVar(idSbry(isVbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, model, ADM(ng)%name,                 &
      &                         ADM(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isVbar)),                 &
      &                         ADM(ng)%pioVar(idSbry(isVbar)),          &
-     &                         ADM(ng)%Rindex, ioDesc,                  &
+     &                         ADM(ng)%Rindex,                          &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % ad_vbar_obc(LBij:,:,:,    &
      &                                                    Lbout(ng)))
@@ -1966,17 +1951,12 @@
 !
       IF (ANY(Lobc(:,isUvel,ng))) THEN
         scale=1.0_dp
-        IF (ADM(ng)%pioVar(idSbry(isUvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry(ng, model, ADM(ng)%name,                 &
      &                         ADM(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isUvel)),                 &
      &                         ADM(ng)%pioVar(idSbry(isUvel)),          &
-     &                         ADM(ng)%Rindex, ioDesc,                  &
+     &                         ADM(ng)%Rindex,                          &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng), scale,  &
      &                         BOUNDARY(ng) % ad_u_obc(LBij:,:,:,:,     &
      &                                                 Lbout(ng)))
@@ -2064,17 +2044,12 @@
 !
       IF (ANY(Lobc(:,isVvel,ng))) THEN
         scale=1.0_dp
-        IF (ADM(ng)%pioVar(idSbry(isVvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry(ng, model, ADM(ng)%name,                 &
      &                         ADM(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isVvel)),                 &
      &                         ADM(ng)%pioVar(idSbry(isVvel)),          &
-     &                         ADM(ng)%Rindex, ioDesc,                  &
+     &                         ADM(ng)%Rindex,                          &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng), scale,  &
      &                         BOUNDARY(ng) % ad_v_obc(LBij:,:,:,:,     &
      &                                                 Lbout(ng)))
@@ -2264,17 +2239,12 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           ifield=idSbry(isTvar(itrc))
-          IF (ADM(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-            ioDesc => ioDesc_dp_r3dobc(ng)
-          ELSE
-            ioDesc => ioDesc_sp_r3dobc(ng)
-          END IF
 !
           status=nf_fwrite3d_bry(ng, model, ADM(ng)%name,               &
      &                           ADM(ng)%pioFile,                       &
      &                           Vname(1,ifield),                       &
      &                           ADM(ng)%pioVar(ifield),                &
-     &                           ADM(ng)%Rindex, ioDesc,                &
+     &                           ADM(ng)%Rindex,                        &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng),       &
      &                           scale,                                 &
      &                           BOUNDARY(ng) % ad_t_obc(LBij:,:,:,:,   &

--- a/ROMS/Bin/cbuild_roms.csh
+++ b/ROMS/Bin/cbuild_roms.csh
@@ -437,7 +437,7 @@ if ( $?FORT ) then
   if ( "${FORT}" == "ifort" ) then
     set compiler="-DCMAKE_Fortran_COMPILER=ifort"
   elif ( "${FORT}" == "ifx" ) then
-    set compiler="-DCMAKE_Fortran_COMPILER=ifort"
+    set compiler="-DCMAKE_Fortran_COMPILER=ifx"
   else if ( "${FORT}" == "gfortran" ) then
     set compiler="-DCMAKE_Fortran_COMPILER=gfortran"
   else

--- a/ROMS/Modules/mod_pio_netcdf.F
+++ b/ROMS/Modules/mod_pio_netcdf.F
@@ -216,16 +216,6 @@
       TYPE (IO_desc_t), pointer :: ioDesZ_sp_u3dvar(:) ! (i,j,Nslice)
       TYPE (IO_desc_t), pointer :: ioDesZ_sp_v3dvar(:) ! (i,j,Nslice)
 # endif
-# ifdef ADJUST_BOUNDARY
-      TYPE (IO_desc_t), pointer :: ioDesc_sp_r2dobc(:) ! (ij,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesc_sp_u2dobc(:) ! (ij,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesc_sp_v2dobc(:) ! (ij,4,Nbrec)
-#  ifdef SOLVE3D
-      TYPE (IO_desc_t), pointer :: ioDesc_sp_r3dobc(:) ! (ij,N,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesc_sp_u3dobc(:) ! (ij,N,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesc_sp_v3dobc(:) ! (ij,N,4,Nbrec)
-#  endif
-# endif
 # ifdef ADJUST_STFLUX
       TYPE (IO_desc_t), pointer :: ioDesc_sp_r2dfrc(:) ! (i,j,Nfrec)
 # endif
@@ -263,16 +253,6 @@
       TYPE (IO_desc_t), pointer :: ioDesZ_dp_u3dvar(:) ! (i,j,Nslice)
       TYPE (IO_desc_t), pointer :: ioDesZ_dp_v3dvar(:) ! (i,j,Nslice)
 # endif
-# ifdef ADJUST_BOUNDARY
-      TYPE (IO_desc_t), pointer :: ioDesc_dp_r2dobc(:) ! (ij,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesc_dp_u2dobc(:) ! (ij,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesc_dp_v2dobc(:) ! (ij,4,Nbrec)
-#  ifdef SOLVE3D
-      TYPE (IO_desc_t), pointer :: ioDesc_dp_r3dobc(:) ! (ij,N,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesc_dp_u3dobc(:) ! (ij,N,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesc_dp_v3dobc(:) ! (ij,N,4,Nbrec)
-#  endif
-# endif
 # ifdef ADJUST_STFLUX
       TYPE (IO_desc_t), pointer :: ioDesc_dp_r2dfrc(:) ! (i,j,Nfrec)
 # endif
@@ -309,16 +289,6 @@
       TYPE (IO_desc_t), pointer :: ioDesX_sp_v3dvar(:) ! (i,j,N)
       TYPE (IO_desc_t), pointer :: ioDesX_sp_w3dvar(:) ! (i,j,0:N)
 #  endif
-#  ifdef ADJUST_BOUNDARY
-      TYPE (IO_desc_t), pointer :: ioDesX_sp_r2dobc(:) ! (ij,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesX_sp_u2dobc(:) ! (ij,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesX_sp_v2dobc(:) ! (ij,4,Nbrec)
-#   ifdef SOLVE3D
-      TYPE (IO_desc_t), pointer :: ioDesX_sp_r3dobc(:) ! (ij,N,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesX_sp_u3dobc(:) ! (ij,N,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesX_sp_v3dobc(:) ! (ij,N,4,Nbrec)
-#   endif
-#  endif
 #  ifdef ADJUST_STFLUX
       TYPE (IO_desc_t), pointer :: ioDesX_sp_r2dfrc(:) ! (i,j,Nfrec)
 #  endif
@@ -347,16 +317,6 @@
       TYPE (IO_desc_t), pointer :: ioDesX_dp_u3dvar(:) ! (i,j,N)
       TYPE (IO_desc_t), pointer :: ioDesX_dp_v3dvar(:) ! (i,j,N)
       TYPE (IO_desc_t), pointer :: ioDesX_dp_w3dvar(:) ! (i,j,0:N)
-#  endif
-#  ifdef ADJUST_BOUNDARY
-      TYPE (IO_desc_t), pointer :: ioDesX_dp_r2dobc(:) ! (ij,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesX_dp_u2dobc(:) ! (ij,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesX_dp_v2dobc(:) ! (ij,4,Nbrec)
-#   ifdef SOLVE3D
-      TYPE (IO_desc_t), pointer :: ioDesX_dp_r3dobc(:) ! (ij,N,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesX_dp_u3dobc(:) ! (ij,N,4,Nbrec)
-      TYPE (IO_desc_t), pointer :: ioDesX_dp_v3dobc(:) ! (ij,N,4,Nbrec)
-#   endif
 #  endif
 #  ifdef ADJUST_STFLUX
       TYPE (IO_desc_t), pointer :: ioDesX_dp_r2dfrc(:) ! (i,j,Nfrec)

--- a/ROMS/Representer/rp_def_ini.F
+++ b/ROMS/Representer/rp_def_ini.F
@@ -403,7 +403,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iRPM, IRP(ng)%ncid, IRP(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &

--- a/ROMS/Representer/rp_wrt_ini.F
+++ b/ROMS/Representer/rp_wrt_ini.F
@@ -686,17 +686,12 @@
 !
       IF (ANY(Lobc(:,isFsur,ng))) THEN
         scale=1.0_dp
-        IF (IRP(ng)%pioVar(idSBry(isFsur))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_r2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_r2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, iRPM, IRP(ng)%name,                  &
      &                         IRP(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isFsur)),                 &
      &                         IRP(ng)%pioVar(idSbry(isFsur)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % tl_zeta_obc(LBij:,:,:,    &
      &                                                    Tindex))
@@ -743,17 +738,12 @@
 !
       IF (ANY(Lobc(:,isUbar,ng))) THEN
         scale=1.0_dp
-        IF (IRP(ng)%pioVar(idSbry(isUbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, iRPM, IRP(ng)%name,                  &
      &                         IRP(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isUbar)),                 &
      &                         IRP(ng)%pioVar(idSbry(isUbar)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % tl_ubar_obc(LBij:,:,:,    &
      &                                                    Tindex))
@@ -800,17 +790,12 @@
 !
       IF (ANY(Lobc(:,isVbar,ng))) THEN
         scale=1.0_dp
-        IF (IRP(ng)%pioVar(idSbry(isVbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, iRPM, IRP(ng)%name,                  &
      &                         IRP(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isVbar)),                 &
      &                         IRP(ng)%pioVar(idSbry(isVbar)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % tl_vbar_obc(LBij:,:,:,    &
      &                                                    Tindex))
@@ -918,17 +903,12 @@
 !
       IF (ANY(Lobc(:,isUvel,ng))) THEN
         scale=1.0_dp
-        IF (IRP(ng)%pioVar(idSbry(isUvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry(ng, iRPM, IRP(ng)%name,                  &
      &                         IRP(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isUvel)),                 &
      &                         IRP(ng)%pioVar(idSbry(isUvel)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng), scale,  &
      &                         BOUNDARY(ng) % tl_u_obc(LBij:,:,:,:,     &
      &                                                 Tindex))
@@ -975,17 +955,12 @@
 !
       IF (ANY(Lobc(:,isVvel,ng))) THEN
         scale=1.0_dp
-        IF (IRP(ng)%pioVar(idSbry(isVvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry(ng, iRPM, IRP(ng)%name,                  &
      &                         IRP(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isVvel)),                 &
      &                         IRP(ng)%pioVar(idSbry(isVvel)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng), scale,  &
      &                         BOUNDARY(ng) % tl_v_obc(LBij:,:,:,:,     &
      &                                                 Tindex))
@@ -1036,17 +1011,12 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           ifield=idSbry(isTvar(itrc))
-          IF (IRP(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-            ioDesc => ioDesc_dp_r3dobc(ng)
-          ELSE
-            ioDesc => ioDesc_sp_r3dobc(ng)
-          END IF
 !
           status=nf_fwrite3d_bry(ng, iRPM, IRP(ng)%name,                &
      &                           IRP(ng)%pioFile,                       &
      &                           Vname(1,ifield),                       &
      &                           IRP(ng)%pioVar(ifield),                &
-     &                           OutRec, ioDesc,                        &
+     &                           OutRec,                                &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng),       &
      &                           scale,                                 &
      &                           BOUNDARY(ng) % tl_t_obc(LBij:,:,:,:,   &

--- a/ROMS/Tangent/tl_def_his.F
+++ b/ROMS/Tangent/tl_def_his.F
@@ -530,6 +530,7 @@
 #  if defined WRITE_WATER && defined MASKING
         Vinfo(20)='mask_u'
 #  endif
+        Vinfo(21)=Vname(6,idUsms)
         Vinfo(22)='coordinates'
         Aval(5)=REAL(Iinfo(1,idUsms,ng),r8)
         status=def_var(ng, model, TLM(ng)%ncid, TLM(ng)%Vid(idUsms),    &
@@ -545,6 +546,7 @@
 #  if defined WRITE_WATER && defined MASKING
         Vinfo(20)='mask_v'
 #  endif
+        Vinfo(21)=Vname(6,idVsms)
         Vinfo(22)='coordinates'
         Aval(5)=REAL(Iinfo(1,idVsms,ng),r8)
         status=def_var(ng, model, TLM(ng)%ncid, TLM(ng)%Vid(idVsms),     &
@@ -644,6 +646,7 @@
 #  if defined WRITE_WATER && defined MASKING
             Vinfo(20)='mask_rho'
 #  endif
+            Vinfo(21)=Vname(6,idTsur(itrc))
             Vinfo(22)='coordinates'
             Aval(5)=REAL(Iinfo(1,idTsur(itrc),ng),r8)
             status=def_var(ng, model, TLM(ng)%ncid,                     &
@@ -747,7 +750,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, TLM(ng)%ncid, TLM(ng)%Vid(ifield),  &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -853,7 +856,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, TLM(ng)%ncid, TLM(ng)%Vid(ifield),  &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -958,7 +961,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, TLM(ng)%ncid, TLM(ng)%Vid(ifield),  &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -1014,7 +1017,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, TLM(ng)%ncid, TLM(ng)%Vid(ifield),  &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -1069,7 +1072,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, TLM(ng)%ncid, TLM(ng)%Vid(ifield),  &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -1164,7 +1167,7 @@
               END IF
             END DO
 #   endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             status=def_var(ng, model, TLM(ng)%ncid, TLM(ng)%Vid(ifield),&
      &                     NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,     &
@@ -2326,6 +2329,7 @@
 #   if defined WRITE_WATER && defined MASKING
         Vinfo(20)='mask_u'
 #   endif
+        Vinfo(21)=Vname(6,idUsms)
         Vinfo(22)='coordinates'
         Aval(5)=REAL(Iinfo(1,idUsms,ng),r8)
         TLM(ng)%pioVar(idUsms)%dkind=PIO_FOUT
@@ -2345,6 +2349,7 @@
 #   if defined WRITE_WATER && defined MASKING
         Vinfo(20)='mask_v'
 #   endif
+        Vinfo(21)=Vname(6,idVsms)
         Vinfo(22)='coordinates'
         Aval(5)=REAL(Iinfo(1,idVsms,ng),r8)
         TLM(ng)%pioVar(idVsms)%dkind=PIO_FOUT
@@ -2459,6 +2464,7 @@
 #   if defined WRITE_WATER && defined MASKING
             Vinfo(20)='mask_rho'
 #   endif
+            Vinfo(21)=Vname(6,idTsur(itrc))
             Vinfo(22)='coordinates'
             Aval(5)=REAL(Iinfo(1,idTsur(itrc),ng),r8)
             TLM(ng)%pioVar(idTsur(itrc))%dkind=PIO_FOUT
@@ -2583,7 +2589,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           TLM(ng)%pioVar(ifield)%dkind=PIO_FOUT
           TLM(ng)%pioVar(ifield)%gtype=r2dobc
@@ -2715,7 +2721,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           TLM(ng)%pioVar(ifield)%dkind=PIO_FOUT
           TLM(ng)%pioVar(ifield)%gtype=u2dobc
@@ -2847,7 +2853,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           TLM(ng)%pioVar(ifield)%dkind=PIO_FOUT
           TLM(ng)%pioVar(ifield)%gtype=v2dobc
@@ -2917,7 +2923,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           TLM(ng)%pioVar(ifield)%dkind=PIO_FOUT
           TLM(ng)%pioVar(ifield)%gtype=u3dobc
@@ -2986,7 +2992,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           TLM(ng)%pioVar(ifield)%dkind=PIO_FOUT
           TLM(ng)%pioVar(ifield)%gtype=v3dobc
@@ -3098,7 +3104,7 @@
               END IF
             END DO
 #    endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             TLM(ng)%pioVar(ifield)%dkind=PIO_FOUT
             TLM(ng)%pioVar(ifield)%gtype=r3dobc

--- a/ROMS/Tangent/tl_def_ini.F
+++ b/ROMS/Tangent/tl_def_ini.F
@@ -486,7 +486,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -523,7 +523,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -560,7 +560,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -635,7 +635,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(ifield),   &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -672,7 +672,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(ifield),   &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -726,7 +726,7 @@
               END IF
             END DO
 #   endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             status=def_var(ng, iTLM, ITL(ng)%ncid, ITL(ng)%Vid(ifield), &
      &                     NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,     &
@@ -1463,7 +1463,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ITL(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ITL(ng)%pioVar(ifield)%gtype=r2dobc
@@ -1508,7 +1508,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ITL(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ITL(ng)%pioVar(ifield)%gtype=u2dobc
@@ -1553,7 +1553,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ITL(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ITL(ng)%pioVar(ifield)%gtype=v2dobc
@@ -1644,7 +1644,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ITL(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ITL(ng)%pioVar(ifield)%gtype=u3dobc
@@ -1689,7 +1689,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ITL(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ITL(ng)%pioVar(ifield)%gtype=v3dobc
@@ -1751,7 +1751,7 @@
               END IF
             END DO
 #   endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             ITL(ng)%pioVar(ifield)%dkind=PIO_FOUT
             ITL(ng)%pioVar(ifield)%gtype=r3dobc

--- a/ROMS/Tangent/tl_wrt_his.F
+++ b/ROMS/Tangent/tl_wrt_his.F
@@ -1654,17 +1654,12 @@
       IF (ANY(Lobc(:,isFsur,ng))) THEN
         scale=1.0_dp
         ifield=idSbry(isFsur)
-        IF (TLM(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_r2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_r2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, model, TLM(ng)%name,                 &
      &                         TLM(ng)%pioFile,                         &
      &                         Vname(1,ifield),                         &
      &                         TLM(ng)%pioVar(ifield),                  &
-     &                         TLM(ng)%Rindex, ioDesc,                  &
+     &                         TLM(ng)%Rindex,                          &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % tl_zeta_obc(LBij:,:,:,    &
      &                                                    Lbout(ng)))
@@ -1819,17 +1814,12 @@
       IF (ANY(Lobc(:,isUbar,ng))) THEN
         scale=1.0_dp
         ifield=idSbry(isUbar)
-        IF (TLM(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u2dobc(ng)
-        END IF
-
+!
         status=nf_fwrite2d_bry(ng, model, TLM(ng)%name,                 &
      &                         TLM(ng)%pioFile,                         &
      &                         Vname(1,ifield),                         &
      &                         TLM(ng)%pioVar(ifield),                  &
-     &                         TLM(ng)%Rindex, ioDesc,                  &
+     &                         TLM(ng)%Rindex,                          &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % tl_ubar_obc(LBij:,:,:,    &
      &                                                    Lbout(ng)))
@@ -1984,17 +1974,12 @@
       IF (ANY(Lobc(:,isVbar,ng))) THEN
         scale=1.0_dp
         ifield=idSbry(isVbar)
-        IF (TLM(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, model, TLM(ng)%name,                 &
      &                         TLM(ng)%pioFile,                         &
      &                         Vname(1,ifield),                         &
      &                         TLM(ng)%pioVar(ifield),                  &
-     &                         TLM(ng)%Rindex, ioDesc,                  &
+     &                         TLM(ng)%Rindex,                          &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % tl_vbar_obc(LBij:,:,:,    &
      &                                                    Lbout(ng)))
@@ -2075,17 +2060,12 @@
       IF (ANY(Lobc(:,isUvel,ng))) THEN
         scale=1.0_dp
         ifield=idSbry(isUvel)
-        IF (TLM(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry(ng, model, TLM(ng)%name,                 &
      &                         TLM(ng)%pioFile,                         &
      &                         Vname(1,ifield),                         &
      &                         TLM(ng)%pioVar(ifield),                  &
-     &                         TLM(ng)%Rindex, ioDesc,                  &
+     &                         TLM(ng)%Rindex,                          &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng), scale,  &
      &                         BOUNDARY(ng) % tl_u_obc(LBij:,:,:,:,     &
      &                                                 Lbout(ng)))
@@ -2165,17 +2145,12 @@
       IF (ANY(Lobc(:,isVvel,ng))) THEN
         scale=1.0_dp
         ifield=idSbry(isVvel)
-        IF (TLM(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry(ng, model, TLM(ng)%name,                 &
      &                         TLM(ng)%pioFile,                         &
      &                         Vname(1,ifield),                         &
      &                         TLM(ng)%pioVar(ifield),                  &
-     &                         TLM(ng)%Rindex, ioDesc,                  &
+     &                         TLM(ng)%Rindex,                          &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng), scale,  &
      &                         BOUNDARY(ng) % tl_v_obc(LBij:,:,:,:,     &
      &                                                 Lbout(ng)))
@@ -2290,17 +2265,12 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           ifield=idSbry(isTvar(itrc))
-          IF (TLM(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-            ioDesc => ioDesc_dp_r3dobc(ng)
-          ELSE
-            ioDesc => ioDesc_sp_r3dobc(ng)
-          END IF
 !
           status=nf_fwrite3d_bry(ng, model, TLM(ng)%name,               &
      &                           TLM(ng)%pioFile,                       &
      &                           Vname(1,ifield),                       &
      &                           TLM(ng)%pioVar(ifield),                &
-     &                           TLM(ng)%Rindex, ioDesc,                &
+     &                           TLM(ng)%Rindex,                        &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng),       &
      &                           scale,                                 &
      &                           BOUNDARY(ng) % tl_t_obc(LBij:,:,:,:,   &

--- a/ROMS/Tangent/tl_wrt_ini.F
+++ b/ROMS/Tangent/tl_wrt_ini.F
@@ -810,17 +810,12 @@
 !
       IF (ANY(Lobc(:,isFsur,ng))) THEN
         scale=1.0_dp
-        IF (ITL(ng)%pioVar(idSBry(isFsur))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_r2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_r2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, iTLM, ITL(ng)%name,                  &
      &                         ITL(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isFsur)),                 &
      &                         ITL(ng)%pioVar(idSbry(isFsur)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % tl_zeta_obc(LBij:,:,:,    &
      &                                                    Tindex))
@@ -867,17 +862,12 @@
 !
       IF (ANY(Lobc(:,isUbar,ng))) THEN
         scale=1.0_dp
-        IF (ITL(ng)%pioVar(idSbry(isUbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, iTLM, ITL(ng)%name,                  &
      &                         ITL(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isUbar)),                 &
      &                         ITL(ng)%pioVar(idSbry(isUbar)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % tl_ubar_obc(LBij:,:,:,    &
      &                                                    Tindex))
@@ -924,17 +914,12 @@
 !
       IF (ANY(Lobc(:,isVbar,ng))) THEN
         scale=1.0_dp
-        IF (ITL(ng)%pioVar(idSbry(isVbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, iTLM, ITL(ng)%name,                  &
      &                         ITL(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isVbar)),                 &
      &                         ITL(ng)%pioVar(idSbry(isVbar)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % tl_vbar_obc(LBij:,:,:,    &
      &                                                    Tindex))
@@ -1038,17 +1023,12 @@
 !
       IF (ANY(Lobc(:,isUvel,ng))) THEN
         scale=1.0_dp
-        IF (ITL(ng)%pioVar(idSbry(isUvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry(ng, iTLM, ITL(ng)%name,                  &
      &                         ITL(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isUvel)),                 &
      &                         ITL(ng)%pioVar(idSbry(isUvel)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng), scale,  &
      &                         BOUNDARY(ng) % tl_u_obc(LBij:,:,:,:,     &
      &                                                 Tindex))
@@ -1095,17 +1075,12 @@
 !
       IF (ANY(Lobc(:,isVvel,ng))) THEN
         scale=1.0_dp
-        IF (ITL(ng)%pioVar(idSbry(isVvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry(ng, iTLM, ITL(ng)%name,                  &
      &                         ITL(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isVvel)),                 &
      &                         ITL(ng)%pioVar(idSbry(isVvel)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng), scale,  &
      &                         BOUNDARY(ng) % tl_v_obc(LBij:,:,:,:,     &
      &                                                 Tindex))
@@ -1156,17 +1131,12 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           ifield=idSbry(isTvar(itrc))
-          IF (ITL(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-            ioDesc => ioDesc_dp_r3dobc(ng)
-          ELSE
-            ioDesc => ioDesc_sp_r3dobc(ng)
-          END IF
 !
           status=nf_fwrite3d_bry(ng, iTLM, ITL(ng)%name,                &
      &                           ITL(ng)%pioFile,                       &
      &                           Vname(1,ifield),                       &
      &                           ITL(ng)%pioVar(ifield),                &
-     &                           OutRec, ioDesc,                        &
+     &                           OutRec,                                &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng),       &
      &                           scale,                                 &
      &                           BOUNDARY(ng) % tl_t_obc(LBij:,:,:,:,   &

--- a/ROMS/Utility/def_error.F
+++ b/ROMS/Utility/def_error.F
@@ -548,7 +548,7 @@
           Vinfo( 3)='meter2'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -585,7 +585,7 @@
           Vinfo( 3)='meter2 second-2'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -622,7 +622,7 @@
           Vinfo( 3)='meter2 second-2'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -660,7 +660,7 @@
           Vinfo( 3)='meter2 second-2'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(ifield),   &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -697,7 +697,7 @@
           Vinfo( 3)='meter2 second-2'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(ifield),   &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -763,7 +763,7 @@
               END IF
             END DO
 #   endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             status=def_var(ng, iTLM, ERR(ng)%ncid, ERR(ng)%Vid(ifield), &
      &                     NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,     &
@@ -1589,7 +1589,7 @@
           Vinfo( 3)='meter2'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ERR(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ERR(ng)%pioVar(ifield)%gtype=r2dobc
@@ -1634,7 +1634,7 @@
           Vinfo( 3)='meter2 second-2'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ERR(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ERR(ng)%pioVar(ifield)%gtype=u2dobc
@@ -1679,7 +1679,7 @@
           Vinfo( 3)='meter2 second-2'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ERR(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ERR(ng)%pioVar(ifield)%gtype=v2dobc
@@ -1725,7 +1725,7 @@
           Vinfo( 3)='meter2 second-2'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ERR(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ERR(ng)%pioVar(ifield)%gtype=u3dobc
@@ -1770,7 +1770,7 @@
           Vinfo( 3)='meter2 second-2'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           ERR(ng)%pioVar(ifield)%dkind=PIO_FOUT
           ERR(ng)%pioVar(ifield)%gtype=v3dobc
@@ -1844,7 +1844,7 @@
               END IF
             END DO
 #    endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             ERR(ng)%pioVar(ifield)%dkind=PIO_FOUT
             ERR(ng)%pioVar(ifield)%gtype=r3dobc

--- a/ROMS/Utility/def_extract.F
+++ b/ROMS/Utility/def_extract.F
@@ -743,7 +743,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, XTR(ng)%ncid, XTR(ng)%Vid(ifield),  &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -851,7 +851,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, XTR(ng)%ncid, XTR(ng)%Vid(ifield),  &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -959,7 +959,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, XTR(ng)%ncid, XTR(ng)%Vid(ifield),  &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -1056,7 +1056,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, XTR(ng)%ncid, XTR(ng)%Vid(ifield),  &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -1113,7 +1113,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, XTR(ng)%ncid, XTR(ng)%Vid(ifield),  &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -1267,7 +1267,7 @@
               END IF
             END DO
 #   endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             status=def_var(ng, model, XTR(ng)%ncid, XTR(ng)%Vid(ifield),&
      &                     NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,     &
@@ -3440,7 +3440,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           XTR(ng)%pioVar(ifield)%dkind=PIO_FOUT
           XTR(ng)%pioVar(ifield)%gtype=r2dobc
@@ -3572,7 +3572,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           XTR(ng)%pioVar(ifield)%dkind=PIO_FOUT
           XTR(ng)%pioVar(ifield)%gtype=u2dobc
@@ -3704,7 +3704,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           XTR(ng)%pioVar(ifield)%dkind=PIO_FOUT
           XTR(ng)%pioVar(ifield)%gtype=v2dobc
@@ -3821,7 +3821,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           XTR(ng)%pioVar(ifield)%dkind=PIO_FOUT
           XTR(ng)%pioVar(ifield)%gtype=u3dobc
@@ -3890,7 +3890,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           XTR(ng)%pioVar(ifield)%dkind=PIO_FOUT
           XTR(ng)%pioVar(ifield)%gtype=v3dobc
@@ -4072,7 +4072,7 @@
               END IF
             END DO
 #    endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             XTR(ng)%pioVar(ifield)%dkind=PIO_FOUT
             XTR(ng)%pioVar(ifield)%gtype=r3dobc

--- a/ROMS/Utility/def_hessian.F
+++ b/ROMS/Utility/def_hessian.F
@@ -588,7 +588,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -625,7 +625,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -662,7 +662,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -700,7 +700,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(ifield),   &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -737,7 +737,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(ifield),   &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -791,7 +791,7 @@
               END IF
             END DO
 #   endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             status=def_var(ng, iADM, HSS(ng)%ncid, HSS(ng)%Vid(ifield), &
      &                     NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,     &
@@ -1647,7 +1647,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           HSS(ng)%pioVar(ifield)%dkind=PIO_FOUT
           HSS(ng)%pioVar(ifield)%gtype=r2dobc
@@ -1692,7 +1692,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           HSS(ng)%pioVar(ifield)%dkind=PIO_FOUT
           HSS(ng)%pioVar(ifield)%gtype=u2dobc
@@ -1737,7 +1737,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           HSS(ng)%pioVar(ifield)%dkind=PIO_FOUT
           HSS(ng)%pioVar(ifield)%gtype=v2dobc
@@ -1783,7 +1783,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           HSS(ng)%pioVar(ifield)%dkind=PIO_FOUT
           HSS(ng)%pioVar(ifield)%gtype=u3dobc
@@ -1828,7 +1828,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           HSS(ng)%pioVar(ifield)%dkind=PIO_FOUT
           HSS(ng)%pioVar(ifield)%gtype=v3dobc
@@ -1890,7 +1890,7 @@
               END IF
             END DO
 #   endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             HSS(ng)%pioVar(ifield)%dkind=PIO_FOUT
             HSS(ng)%pioVar(ifield)%gtype=r3dobc

--- a/ROMS/Utility/def_his.F
+++ b/ROMS/Utility/def_his.F
@@ -785,7 +785,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(ifield),  &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -893,7 +893,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(ifield),  &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -1001,7 +1001,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(ifield),  &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -1117,7 +1117,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(ifield),  &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -1193,7 +1193,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(ifield),  &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -1494,7 +1494,7 @@
               END IF
             END DO
 #  endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             status=def_var(ng, model, HIS(ng)%ncid, HIS(ng)%Vid(ifield),&
      &                     NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,     &
@@ -3834,7 +3834,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           HIS(ng)%pioVar(ifield)%dkind=PIO_FOUT
           HIS(ng)%pioVar(ifield)%gtype=r2dobc
@@ -3966,7 +3966,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           HIS(ng)%pioVar(ifield)%dkind=PIO_FOUT
           HIS(ng)%pioVar(ifield)%gtype=u2dobc
@@ -4098,7 +4098,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           HIS(ng)%pioVar(ifield)%dkind=PIO_FOUT
           HIS(ng)%pioVar(ifield)%gtype=v2dobc
@@ -4238,7 +4238,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           HIS(ng)%pioVar(ifield)%dkind=PIO_FOUT
           HIS(ng)%pioVar(ifield)%gtype=u3dobc
@@ -4330,7 +4330,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           HIS(ng)%pioVar(ifield)%dkind=PIO_FOUT
           HIS(ng)%pioVar(ifield)%gtype=v3dobc
@@ -4686,7 +4686,7 @@
               END IF
             END DO
 #   endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             HIS(ng)%pioVar(ifield)%dkind=PIO_FOUT
             HIS(ng)%pioVar(ifield)%gtype=r3dobc

--- a/ROMS/Utility/def_ini.F
+++ b/ROMS/Utility/def_ini.F
@@ -436,7 +436,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -550,6 +550,7 @@
 #   if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_u'
 #   endif
+          Vinfo(21)=Vname(6,idUsms)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(u2dvar,r8)
           status=def_var(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idUsms),   &
@@ -566,6 +567,7 @@
 #   if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_v'
 #   endif
+          Vinfo(21)=Vname(6,idVsms)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(v2dvar,r8)
           status=def_var(ng, iNLM, INI(ng)%ncid, INI(ng)%Vid(idVsms),   &
@@ -592,6 +594,7 @@
 #   if defined WRITE_WATER && defined MASKING
             Vinfo(20)='mask_rho'
 #   endif
+            Vinfo(21)=Vname(6,idTsur(itrc))
             Vinfo(22)='coordinates'
             Aval(5)=REAL(r2dvar,r8)
             status=def_var(ng, iNLM, INI(ng)%ncid,                      &
@@ -1263,7 +1266,7 @@
           Vinfo( 3)=Vname(3,ifield)
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           INI(ng)%pioVar(ifield)%dkind=PIO_FOUT
           INI(ng)%pioVar(ifield)%gtype=r2dobc
@@ -1401,6 +1404,7 @@
 #    if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_u'
 #    endif
+          Vinfo(21)=Vname(6,idUsms)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(u2dvar,r8)
           INI(ng)%pioVar(idUsms)%dkind=PIO_FOUT
@@ -1421,6 +1425,7 @@
 #    if defined WRITE_WATER && defined MASKING
           Vinfo(20)='mask_v'
 #    endif
+          Vinfo(21)=Vname(6,idVsms)
           Vinfo(22)='coordinates'
           Aval(5)=REAL(v2dvar,r8)
           INI(ng)%pioVar(idVsms)%dkind=PIO_FOUT
@@ -1452,6 +1457,7 @@
 #    if defined WRITE_WATER && defined MASKING
             Vinfo(20)='mask_rho'
 #    endif
+            Vinfo(21)=Vname(6,idTsur(itrc))
             Vinfo(22)='coordinates'
             Aval(5)=REAL(r2dvar,r8)
             INI(ng)%pioVar(idTsur(itrc))%dkind=PIO_FOUT

--- a/ROMS/Utility/def_lanczos.F
+++ b/ROMS/Utility/def_lanczos.F
@@ -559,7 +559,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iADM, LCZ(ng)%ncid, LCZ(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -596,7 +596,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iADM, LCZ(ng)%ncid, LCZ(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -633,7 +633,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iADM, LCZ(ng)%ncid, LCZ(ng)%Vid(ifield),   &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -671,7 +671,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iADM, LCZ(ng)%ncid, LCZ(ng)%Vid(ifield),   &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -708,7 +708,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, iADM, LCZ(ng)%ncid, LCZ(ng)%Vid(ifield),   &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -762,7 +762,7 @@
               END IF
             END DO
 #   endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             status=def_var(ng, iADM, LCZ(ng)%ncid, LCZ(ng)%Vid(ifield), &
      &                     NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,     &
@@ -1590,7 +1590,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           LCZ(ng)%pioVar(ifield)%dkind=PIO_FOUT
           LCZ(ng)%pioVar(ifield)%gtype=r2dobc
@@ -1635,7 +1635,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           LCZ(ng)%pioVar(ifield)%dkind=PIO_FOUT
           LCZ(ng)%pioVar(ifield)%gtype=u2dobc
@@ -1680,7 +1680,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           LCZ(ng)%pioVar(ifield)%dkind=PIO_FOUT
           LCZ(ng)%pioVar(ifield)%gtype=v2dobc
@@ -1726,7 +1726,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           LCZ(ng)%pioVar(ifield)%dkind=PIO_FOUT
           LCZ(ng)%pioVar(ifield)%gtype=u3dobc
@@ -1771,7 +1771,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           LCZ(ng)%pioVar(ifield)%dkind=PIO_FOUT
           LCZ(ng)%pioVar(ifield)%gtype=v3dobc
@@ -1833,7 +1833,7 @@
               END IF
             END DO
 #   endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             LCZ(ng)%pioVar(ifield)%dkind=PIO_FOUT
             LCZ(ng)%pioVar(ifield)%gtype=r3dobc

--- a/ROMS/Utility/def_norm.F
+++ b/ROMS/Utility/def_norm.F
@@ -567,7 +567,7 @@
             Vinfo( 3)=Vname(3,ifield)
             Vinfo(14)=Vname(4,ifield)
             Vinfo(16)=Vname(1,idtime)
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idFsur)
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             status=def_var(ng, iTLM, NRM(ifile,ng)%ncid,                &
      &                     NRM(ifile,ng)%Vid(ifield),                   &
@@ -1530,7 +1530,7 @@
             Vinfo( 3)=Vname(3,ifield)
             Vinfo(14)=Vname(4,ifield)
             Vinfo(16)=Vname(1,idtime)
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idFsur)
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             NRM(ifile,ng)%pioVar(ifield)%dkind=PIO_FOUT
             NRM(ifile,ng)%pioVar(ifield)%gtype=r2dobc

--- a/ROMS/Utility/def_state.F
+++ b/ROMS/Utility/def_state.F
@@ -532,7 +532,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, S(ng)%ncid, S(ng)%Vid(ifield),      &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -569,7 +569,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, S(ng)%ncid, S(ng)%Vid(ifield),      &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -606,7 +606,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, S(ng)%ncid, S(ng)%Vid(ifield),      &
      &                   NF_FOUT, 4, t2dobc, Aval, Vinfo, ncname,       &
@@ -644,7 +644,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, S(ng)%ncid, S(ng)%Vid(ifield),      &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -681,7 +681,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           status=def_var(ng, model, S(ng)%ncid, S(ng)%Vid(ifield),      &
      &                   NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,       &
@@ -735,7 +735,7 @@
               END IF
             END DO
 #  endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             status=def_var(ng, model, S(ng)%ncid, S(ng)%Vid(ifield),    &
      &                     NF_FOUT, 5, t3dobc, Aval, Vinfo, ncname,     &
@@ -1531,7 +1531,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idFsur)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           S(ng)%pioVar(ifield)%dkind=PIO_FOUT
           S(ng)%pioVar(ifield)%gtype=r2dobc
@@ -1576,7 +1576,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           S(ng)%pioVar(ifield)%dkind=PIO_FOUT
           S(ng)%pioVar(ifield)%gtype=u2dobc
@@ -1621,7 +1621,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVbar)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           S(ng)%pioVar(ifield)%dkind=PIO_FOUT
           S(ng)%pioVar(ifield)%gtype=v2dobc
@@ -1667,7 +1667,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idUvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           S(ng)%pioVar(ifield)%dkind=PIO_FOUT
           S(ng)%pioVar(ifield)%gtype=u3dobc
@@ -1712,7 +1712,7 @@
           Vinfo( 3)='nondimensional'
           Vinfo(14)=Vname(4,ifield)
           Vinfo(16)=Vname(1,idtime)
-          Vinfo(21)=Vname(6,ifield)
+          Vinfo(21)=Vname(6,idVvel)
           Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
           S(ng)%pioVar(ifield)%dkind=PIO_FOUT
           S(ng)%pioVar(ifield)%gtype=v3dobc
@@ -1774,7 +1774,7 @@
               END IF
             END DO
 #   endif
-            Vinfo(21)=Vname(6,ifield)
+            Vinfo(21)=Vname(6,idTvar(itrc))
             Aval(5)=REAL(Iinfo(1,ifield,ng),r8)
             S(ng)%pioVar(ifield)%dkind=PIO_FOUT
             S(ng)%pioVar(ifield)%gtype=r3dobc

--- a/ROMS/Utility/get_state.F
+++ b/ROMS/Utility/get_state.F
@@ -10700,15 +10700,13 @@
             my_pioVar%gtype=r2dobc
             IF (KIND(BOUNDARY(ng)%tl_zeta_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_r2dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_r2dobc(ng)
             END IF
 !
             status=nf_fread2d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, Nbrec(ng),                &
      &                            Fscl, Fmin, Fmax,                     &
 #   ifdef CHECKSUM
@@ -10826,15 +10824,13 @@
             my_pioVar%gtype=u2dobc
             IF (KIND(BOUNDARY(ng)%tl_ubar_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_u2dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_u2dobc(ng)
             END IF
 !
             status=nf_fread2d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, Nbrec(ng),                &
      &                            Fscl, Fmin, Fmax,                     &
 #   ifdef CHECKSUM
@@ -10952,15 +10948,13 @@
             my_pioVar%gtype=v2dobc
             IF (KIND(BOUNDARY(ng)%tl_vbar_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_v2dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_v2dobc(ng)
             END IF
 !
             status=nf_fread2d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, Nbrec(ng),                &
      &                            Fscl, Fmin, Fmax,                     &
 #   ifdef CHECKSUM
@@ -11210,15 +11204,13 @@
             my_pioVar%gtype=u3dobc
             IF (KIND(BOUNDARY(ng)%tl_u_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_u3dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_u3dobc(ng)
             END IF
 !
             status=nf_fread3d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, 1, N(ng), Nbrec(ng),      &
      &                            Fscl, Fmin, Fmax,                     &
 #   ifdef CHECKSUM
@@ -11336,15 +11328,13 @@
             my_pioVar%gtype=v3dobc
             IF (KIND(BOUNDARY(ng)%tl_v_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_v3dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_v3dobc(ng)
             END IF
 !
             status=nf_fread3d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, 1, N(ng), Nbrec(ng),      &
      &                            Fscl, Fmin, Fmax,                     &
 #    ifdef CHECKSUM
@@ -11466,15 +11456,13 @@
               my_pioVar%gtype=r3dobc
               IF (KIND(BOUNDARY(ng)%tl_t_obc).eq.8) THEN
                 my_pioVar%dkind=PIO_double
-                ioDesc => ioDesc_dp_r3dobc(ng)
               ELSE
                 my_pioVar%dkind=PIO_real
-                ioDesc => ioDesc_sp_r3dobc(ng)
               END IF
 !
               status=nf_fread3d_bry(ng, IDmod, ncname, pioFile,         &
      &                              Vname(1,ifield), my_pioVar,         &
-     &                              InpRec, ioDesc,                     &
+     &                              InpRec,                             &
      &                              LBij, UBij, 1, N(ng), Nbrec(ng),    &
      &                              Fscl, Fmin, Fmax,                   &
 #    ifdef CHECKSUM
@@ -12065,15 +12053,13 @@
             my_pioVar%gtype=r2dobc
             IF (KIND(BOUNDARY(ng)%ad_zeta_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_r2dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_r2dobc(ng)
             END IF
 !
             status=nf_fread2d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, Nbrec(ng),                &
      &                            Fscl, Fmin, Fmax,                     &
 #   ifdef CHECKSUM
@@ -12191,15 +12177,13 @@
             my_pioVar%gtype=u2dobc
             IF (KIND(BOUNDARY(ng)%ad_ubar_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_u2dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_u2dobc(ng)
             END IF
 !
             status=nf_fread2d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, Nbrec(ng),                &
      &                            Fscl, Fmin, Fmax,                     &
 #   ifdef CHECKSUM
@@ -12317,15 +12301,13 @@
             my_pioVar%gtype=v2dobc
             IF (KIND(BOUNDARY(ng)%ad_vbar_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_v2dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_v2dobc(ng)
             END IF
 !
             status=nf_fread2d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, Nbrec(ng),                &
      &                            Fscl, Fmin, Fmax,                     &
 #   ifdef CHECKSUM
@@ -12576,15 +12558,13 @@
             my_pioVar%gtype=u3dobc
             IF (KIND(BOUNDARY(ng)%ad_u_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_u3dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_u3dobc(ng)
             END IF
 !
             status=nf_fread3d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, 1, N(ng), Nbrec(ng),      &
      &                            Fscl, Fmin, Fmax,                     &
 #    ifdef CHECKSUM
@@ -12703,15 +12683,13 @@
             my_pioVar%gtype=v3dobc
             IF (KIND(BOUNDARY(ng)%ad_v_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_v3dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_v3dobc(ng)
             END IF
 !
             status=nf_fread3d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, 1, N(ng), Nbrec(ng),      &
      &                            Fscl, Fmin, Fmax,                     &
 #    ifdef CHECKSUM
@@ -12833,15 +12811,13 @@
               my_pioVar%gtype=r3dobc
               IF (KIND(BOUNDARY(ng)%ad_t_obc).eq.8) THEN
                 my_pioVar%dkind=PIO_double
-                ioDesc => ioDesc_dp_r3dobc(ng)
               ELSE
                 my_pioVar%dkind=PIO_real
-                ioDesc => ioDesc_sp_r3dobc(ng)
               END IF
 !
               status=nf_fread3d_bry(ng, IDmod, ncname, pioFile,         &
      &                              Vname(1,ifield), my_pioVar,         &
-     &                              InpRec, ioDesc,                     &
+     &                              InpRec,                             &
      &                              LBij, UBij, 1, N(ng), Nbrec(ng),    &
      &                              Fscl, Fmin, Fmax,                   &
 #    ifdef CHECKSUM
@@ -15841,15 +15817,13 @@
             my_pioVar%gtype=r2dobc
             IF (KIND(BOUNDARY(ng)%tl_zeta_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_r2dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_r2dobc(ng)
             END IF
 !
             status=nf_fread2d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, Nbrec(ng),                &
      &                            Fscl, Fmin, Fmax,                     &
 #   ifdef CHECKSUM
@@ -15903,15 +15877,13 @@
             my_pioVar%gtype=u2dobc
             IF (KIND(BOUNDARY(ng)%tl_ubar_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_u2dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_u2dobc(ng)
             END IF
 !
             status=nf_fread2d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,            &
+     &                            InpRec,                               &
      &                            LBij, UBij, Nbrec(ng),                &
      &                            Fscl, Fmin, Fmax,                     &
 #   ifdef CHECKSUM
@@ -15965,15 +15937,13 @@
             my_pioVar%gtype=v2dobc
             IF (KIND(BOUNDARY(ng)%tl_vbar_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_v2dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_v2dobc(ng)
             END IF
 !
             status=nf_fread2d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, Nbrec(ng),                &
      &                            Fscl, Fmin, Fmax,                     &
 #   ifdef CHECKSUM
@@ -16029,15 +15999,13 @@
             my_pioVar%gtype=u3dobc
             IF (KIND(BOUNDARY(ng)%tl_u_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_u3dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_u3dobc(ng)
             END IF
 !
             status=nf_fread3d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, 1, N(ng), Nbrec(ng),      &
      &                            Fscl, Fmin, Fmax,                     &
 #    ifdef CHECKSUM
@@ -16091,15 +16059,13 @@
             my_pioVar%gtype=v3dobc
             IF (KIND(BOUNDARY(ng)%tl_v_obc).eq.8) THEN
               my_pioVar%dkind=PIO_double
-              ioDesc => ioDesc_dp_v3dobc(ng)
             ELSE
               my_pioVar%dkind=PIO_real
-              ioDesc => ioDesc_sp_v3dobc(ng)
             END IF
 !
             status=nf_fread3d_bry(ng, IDmod, ncname, pioFile,           &
      &                            Vname(1,ifield), my_pioVar,           &
-     &                            InpRec, ioDesc,                       &
+     &                            InpRec,                               &
      &                            LBij, UBij, 1, N(ng), Nbrec(ng),      &
      &                            Fscl, Fmin, Fmax,                     &
 #    ifdef CHECKSUM
@@ -16155,15 +16121,13 @@
               my_pioVar%gtype=r3dobc
               IF (KIND(BOUNDARY(ng)%tl_t_obc).eq.8) THEN
                 my_pioVar%dkind=PIO_double
-                ioDesc => ioDesc_dp_r3dobc(ng)
               ELSE
                 my_pioVar%dkind=PIO_real
-                ioDesc => ioDesc_sp_r3dobc(ng)
               END IF
 !
               status=nf_fread3d_bry(ng, IDmod, ncname, pioFile,         &
      &                              Vname(1,ifield), my_pioVar,         &
-     &                              InpRec, ioDesc,                     &
+     &                              InpRec,                             &
      &                              LBij, UBij, 1, N(ng), Nbrec(ng),    &
      &                              Fscl, Fmin, Fmax,                   &
 #    ifdef CHECKSUM

--- a/ROMS/Utility/nf_fread2d_bry.F
+++ b/ROMS/Utility/nf_fread2d_bry.F
@@ -33,9 +33,6 @@
 #endif
 !     tindex       NetCDF time record index to write (integer)         !
 !     gtype        Grid type (integer)                                 !
-#if defined PIO_LIB && defined DISTRIBUTE
-!or   pioDesc      IO data decomposition descriptor, TYPE(IO_desc_t)   !
-#endif
 !     LBij         IJ-dimension Lower bound (integer)                  !
 !     UBij         IJ-dimension Upper bound (integer)                  !
 !     Nrec         Number of boundary records (integer)                !
@@ -358,7 +355,7 @@
 !***********************************************************************
       FUNCTION pio_fread2d_bry (ng, model, ncname, pioFile,             &
      &                          ncvname, pioVar,                        &
-     &                          tindex, pioDesc,                        &
+     &                          tindex,                                 &
      &                          LBij, UBij, Nrec,                       &
      &                          Ascl, Amin, Amax,                       &
      &                          Abry, checksum)  RESULT(status)
@@ -387,7 +384,6 @@
 # endif
 !
       TYPE (File_desc_t), intent(inout) :: pioFile
-      TYPE (IO_Desc_t),   intent(inout) :: pioDesc
       TYPE (My_VarDesc),  intent(inout) :: pioVar
 !
 !  Local variable declarations.

--- a/ROMS/Utility/nf_fread3d_bry.F
+++ b/ROMS/Utility/nf_fread3d_bry.F
@@ -33,9 +33,6 @@
 #endif
 !     tindex       NetCDF time record index to write (integer)         !
 !     gtype        Grid type (integer)                                 !
-#if defined PIO_LIB && defined DISTRIBUTE
-!or   pioDesc      IO data decomposition descriptor, TYPE(IO_desc_t)   !
-#endif
 !     LBij         IJ-dimension Lower bound (integer)                  !
 !     UBij         IJ-dimension Upper bound (integer)                  !
 !     LBk          K-dimension lower bound (integer)                   !
@@ -370,7 +367,7 @@
 !***********************************************************************
       FUNCTION pio_fread3d_bry (ng, model, ncname, pioFile,             &
      &                          ncvname, pioVar,                        &
-     &                          tindex, pioDesc,                        &
+     &                          tindex,                                 &
      &                          LBij, UBij, LBk, UBk, Nrec,             &
      &                          Ascl, Amin, Amax,                       &
      &                          Abry, checksum)  RESULT(status)
@@ -399,7 +396,6 @@
 # endif
 !
       TYPE (File_desc_t), intent(inout) :: pioFile
-      TYPE (IO_Desc_t),   intent(inout) :: pioDesc
       TYPE (My_VarDesc),  intent(inout) :: pioVar
 !
 !  Local variable declarations.

--- a/ROMS/Utility/nf_fwrite2d_bry.F
+++ b/ROMS/Utility/nf_fwrite2d_bry.F
@@ -215,6 +215,7 @@
      &                           tindex,                                &
      &                           LBij, UBij, Nrec,                      &
      &                           Ascl, Abry,                            &
+     &                           ExtractField,                          &
      &                           MinValue, MaxValue)  RESULT(status)
 !***********************************************************************
 !
@@ -224,6 +225,8 @@
 !
       integer, intent(in) :: ng, model, tindex
       integer, intent(in) :: LBij, UBij, Nrec
+!
+      integer, intent(in), optional :: ExtractField
 !
       real(dp), intent(in) :: Ascl
 !

--- a/ROMS/Utility/nf_fwrite2d_bry.F
+++ b/ROMS/Utility/nf_fwrite2d_bry.F
@@ -35,9 +35,6 @@
 # endif
 !     tindex       NetCDF time record index to write (integer)         !
 !     gtype        Grid type (integer)                                 !
-# if defined PIO_LIB && defined DISTRIBUTE
-!or   pioDesc      IO data decomposition descriptor, TYPE(IO_desc_t)   !
-# endif
 !     LBij         IJ-dimension Lower bound (integer)                  !
 !     UBij         IJ-dimension Upper bound (integer)                  !
 !     Nrec         Number of boundary records (integer)                !
@@ -215,7 +212,7 @@
 !***********************************************************************
       FUNCTION pio_fwrite2d_bry (ng, model, ncname, pioFile,            &
      &                           ncvname, pioVar,                       &
-     &                           tindex, pioDesc,                       &
+     &                           tindex,                                &
      &                           LBij, UBij, Nrec,                      &
      &                           Ascl, Abry,                            &
      &                           MinValue, MaxValue)  RESULT(status)
@@ -242,7 +239,6 @@
       real(r8), intent(out), optional :: MaxValue
 !
       TYPE (File_desc_t), intent(inout) :: pioFile
-      TYPE (IO_Desc_t),   intent(inout) :: pioDesc
       TYPE (My_VarDesc),  intent(inout) :: pioVar
 !
 !  Local variable declarations.

--- a/ROMS/Utility/nf_fwrite3d_bry.F
+++ b/ROMS/Utility/nf_fwrite3d_bry.F
@@ -35,9 +35,6 @@
 # endif
 !     tindex       NetCDF time record index to write (integer)         !
 !     gtype        Grid type (integer)                                 !
-# if defined PIO_LIB && defined DISTRIBUTE
-!or   pioDesc      IO data decomposition descriptor, TYPE(IO_desc_t)   !
-# endif
 !     LBij         IJ-dimension lower bound (integer)                  !
 !     UBij         IJ-dimension upper bound (integer)                  !
 !     LBk          K-dimension lower bound (integer)                   !
@@ -221,7 +218,7 @@
 !***********************************************************************
       FUNCTION pio_fwrite3d_bry (ng, model, ncname, pioFile,            &
      &                           ncvname, pioVar,                       &
-     &                           tindex, pioDesc,                       &
+     &                           tindex,                                &
      &                           LBij, UBij, LBk, UBk, Nrec,            &
      &                           Ascl, Abry,                            &
      &                           MinValue, MaxValue) RESULT(status)
@@ -248,7 +245,6 @@
       real(r8), intent(out), optional :: MaxValue
 !
       TYPE (File_desc_t), intent(inout) :: pioFile
-      TYPE (IO_Desc_t),   intent(inout) :: pioDesc
       TYPE (My_VarDesc),  intent(inout) :: pioVar
 !
 !  Local variable declarations.

--- a/ROMS/Utility/nf_fwrite3d_bry.F
+++ b/ROMS/Utility/nf_fwrite3d_bry.F
@@ -221,6 +221,7 @@
      &                           tindex,                                &
      &                           LBij, UBij, LBk, UBk, Nrec,            &
      &                           Ascl, Abry,                            &
+     &                           ExtractField,                          &
      &                           MinValue, MaxValue) RESULT(status)
 !***********************************************************************
 !
@@ -230,6 +231,8 @@
 !
       integer, intent(in) :: ng, model, tindex
       integer, intent(in) :: LBij, UBij, LBk, UBk, Nrec
+!
+      integer, intent(in), optional :: ExtractField
 !
       real(dp), intent(in) :: Ascl
 !

--- a/ROMS/Utility/set_pio.F
+++ b/ROMS/Utility/set_pio.F
@@ -311,11 +311,6 @@
         DO ng=1,Ngrids
           DO i=1,NpioComps
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_p2dvar(ng))
-# ifdef ADJUST_BOUNDARY
-            CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_r2dobc(ng))
-            CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_u2dobc(ng))
-            CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_v2dobc(ng))
-# endif
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_r2dvar(ng))
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_u2dvar(ng))
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_v2dvar(ng))
@@ -334,11 +329,6 @@
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_l4dvar(ng))
 #  endif
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_p3dvar(ng))
-# ifdef ADJUST_BOUNDARY
-            CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_r3dobc(ng))
-            CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_u3dobc(ng))
-            CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_v3dobc(ng))
-# endif
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_r3dvar(ng))
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_u3dvar(ng))
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_sp_v3dvar(ng))
@@ -359,11 +349,6 @@
         DO ng=1,Ngrids
           DO i=1,NpioComps
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_p2dvar(ng))
-# ifdef ADJUST_BOUNDARY
-            CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_r2dobc(ng))
-            CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_u2dobc(ng))
-            CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_v2dobc(ng))
-# endif
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_r2dvar(ng))
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_u2dvar(ng))
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_v2dvar(ng))
@@ -382,11 +367,6 @@
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_l4dvar(ng))
 #  endif
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_p3dvar(ng))
-# ifdef ADJUST_BOUNDARY
-            CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_r3dobc(ng))
-            CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_u3dobc(ng))
-            CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_v3dobc(ng))
-# endif
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_r3dvar(ng))
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_u3dvar(ng))
             CALL PIO_freedecomp (pioSystem(i,ng), ioDesc_dp_v3dvar(ng))
@@ -536,8 +516,6 @@
 !
 !  Local variable declarations.
 !
-      logical :: Lboundary
-!
       integer :: Cgrid, ghost
       integer :: i, ic, j, jc, k, kc, l, lc, np
       integer :: Is, Ie, Js, Je
@@ -555,30 +533,10 @@
 !  from storage order to memory order.
 !-----------------------------------------------------------------------
 !
-      Lboundary=.FALSE.
-
 !  Get GLOBAL lower and upper bounds for each variable type in input
 !  or ouput NetCDF files.
 !
       SELECT CASE (gtype)
-        CASE (r2dobc, u2dobc, v2dobc)
-          Lboundary=.TRUE.
-          Cgrid=2
-          Is=0
-          Ie=IOBOUNDS(ng) % IorJ
-          Js=1
-          Je=4
-          Ioff=1
-          Joff=0
-        CASE (r3dobc, u3dobc, v3dobc)
-          Lboundary=.TRUE.
-          Cgrid=2
-          Is=0
-          Ie=IOBOUNDS(ng) % IorJ
-          Js=1
-          Je=4
-          Ioff=1
-          Joff=0
         CASE (p2dvar, p3dvar)
           Cgrid=1
           Is=IOBOUNDS(ng) % ILB_psi
@@ -651,18 +609,11 @@
 !  Starting/ending I- and J-indices for each decomposition tile
 !  according to C-grid locatation, excluding ghost points.
 !
-      IF (Lboundary) THEN
-        Imin=Is
-        Imax=Ie
-        Jmin=Js
-        Jmax=Je
-      ELSE
-        ghost=0
-        Imin=BOUNDS(ng) % Imin(Cgrid,ghost,MyRank)
-        Imax=BOUNDS(ng) % Imax(Cgrid,ghost,MyRank)
-        Jmin=BOUNDS(ng) % Jmin(Cgrid,ghost,MyRank)
-        Jmax=BOUNDS(ng) % Jmax(Cgrid,ghost,MyRank)
-      END IF
+      ghost=0
+      Imin=BOUNDS(ng) % Imin(Cgrid,ghost,MyRank)
+      Imax=BOUNDS(ng) % Imax(Cgrid,ghost,MyRank)
+      Jmin=BOUNDS(ng) % Jmin(Cgrid,ghost,MyRank)
+      Jmax=BOUNDS(ng) % Jmax(Cgrid,ghost,MyRank)
 !
 !  Allocate 1D array for mapping of the storage order of the variable to
 !  its memory order.
@@ -771,11 +722,6 @@
       allocate ( ioDesc_sp_u2dfrc(Ngrids) )
       allocate ( ioDesc_sp_v2dfrc(Ngrids) )
 # endif
-# ifdef ADJUST_BOUNDARY
-      allocate ( ioDesc_sp_r2dobc(Ngrids) )
-      allocate ( ioDesc_sp_u2dobc(Ngrids) )
-      allocate ( ioDesc_sp_v2dobc(Ngrids) )
-# endif
       allocate ( ioDesc_sp_r2dvar(Ngrids) )
       allocate ( ioDesc_sp_u2dvar(Ngrids) )
       allocate ( ioDesc_sp_v2dvar(Ngrids) )
@@ -797,11 +743,6 @@
 #  ifdef ADJUST_STFLUX
       allocate ( ioDesc_sp_r2dfrc(Ngrids) )
 #  endif
-#  ifdef ADJUST_BOUNDARY
-      allocate ( ioDesc_sp_r3dobc(Ngrids) )
-      allocate ( ioDesc_sp_u3dobc(Ngrids) )
-      allocate ( ioDesc_sp_v3dobc(Ngrids) )
-#  endif
       allocate ( ioDesc_sp_r3dvar(Ngrids) )
       allocate ( ioDesc_sp_u3dvar(Ngrids) )
       allocate ( ioDesc_sp_v3dvar(Ngrids) )
@@ -821,11 +762,6 @@
 # ifdef ADJUST_WSTRESS
       allocate ( ioDesc_dp_u2dfrc(Ngrids) )
       allocate ( ioDesc_dp_v2dfrc(Ngrids) )
-# endif
-# ifdef ADJUST_BOUNDARY
-      allocate ( ioDesc_dp_r2dobc(Ngrids) )
-      allocate ( ioDesc_dp_u2dobc(Ngrids) )
-      allocate ( ioDesc_dp_v2dobc(Ngrids) )
 # endif
       allocate ( ioDesc_dp_r2dvar(Ngrids) )
       allocate ( ioDesc_dp_u2dvar(Ngrids) )
@@ -847,11 +783,6 @@
       allocate ( ioDesc_dp_p3dvar(Ngrids) )
 #  ifdef ADJUST_STFLUX
       allocate ( ioDesc_dp_r2dfrc(Ngrids) )
-#  endif
-#  ifdef ADJUST_BOUNDARY
-      allocate ( ioDesc_dp_r3dobc(Ngrids) )
-      allocate ( ioDesc_dp_u3dobc(Ngrids) )
-      allocate ( ioDesc_dp_v3dobc(Ngrids) )
 #  endif
       allocate ( ioDesc_dp_r3dvar(Ngrids) )
       allocate ( ioDesc_dp_u3dvar(Ngrids) )
@@ -1032,28 +963,6 @@
      &                       ioDesc_sp_v2dfrc(ng),                      &
      &                       v2dvar, 3, 1, Nfrec(ng))
 # endif
-# ifdef ADJUST_BOUNDARY
-        CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_real,      &
-     &                       ioDesc_sp_r2dobc(ng),                      &
-     &                       r2dobc, 3, 1, Nbrec(ng))
-        CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_real,      &
-     &                       ioDesc_sp_u2dobc(ng),                      &
-     &                       u2dobc, 3, 1, Nbrec(ng))
-        CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_real,      &
-     &                       ioDesc_sp_v2dobc(ng),                      &
-     &                       v2dobc, 3, 1, Nbrec(ng))
-#  ifdef SOLVE3D
-        CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_real,      &
-     &                       ioDesc_sp_r3dobc(ng),                      &
-     &                       r3dobc, 4, 1, N(ng), 1, Nbrec(ng))
-        CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_real,      &
-     &                       ioDesc_sp_u3dobc(ng),                      &
-     &                       u3dobc, 4, 1, N(ng), 1, Nbrec(ng))
-        CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_real,      &
-     &                       ioDesc_sp_v3dobc(ng),                      &
-     &                       v3dobc, 4, 1, N(ng), 1, Nbrec(ng))
-#  endif
-# endif
       END DO
 !
 !  Set IO decomposition descriptors for double precision data.
@@ -1138,28 +1047,6 @@
         CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,    &
      &                       ioDesc_dp_v2dfrc(ng),                      &
      &                       v2dvar, 3, 1, Nfrec(ng))
-# endif
-# ifdef ADJUST_BOUNDARY
-        CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,    &
-     &                       ioDesc_dp_r2dobc(ng),                      &
-     &                       r2dobc, 3, 1, Nbrec(ng))
-        CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,    &
-     &                       ioDesc_dp_u2dobc(ng),                      &
-     &                       u2dobc, 3, 1, Nbrec(ng))
-        CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,    &
-     &                       ioDesc_dp_v2dobc(ng),                      &
-     &                       v2dobc, 3, 1, Nbrec(ng))
-#  ifdef SOLVE3D
-        CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,    &
-     &                       ioDesc_dp_r3dobc(ng),                      &
-     &                       r3dobc, 4, 1, N(ng), 1, Nbrec(ng))
-        CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,    &
-     &                       ioDesc_dp_u3dobc(ng),                      &
-     &                       u3dobc, 4, 1, N(ng), 1, Nbrec(ng))
-        CALL field_iodecomp (ng, pioSystem(IpioROMS,ng), PIO_double,    &
-     &                       ioDesc_dp_v3dobc(ng),                      &
-     &                       v3dobc, 4, 1, N(ng), 1, Nbrec(ng))
-#  endif
 # endif
       END DO
 !

--- a/ROMS/Utility/state_read.F
+++ b/ROMS/Utility/state_read.F
@@ -1254,15 +1254,13 @@
         my_pioVar%gtype=r2dobc
         IF (KIND(s_zeta_obc).eq.8) THEN
           my_pioVar%dkind=PIO_double
-          my_ioDesc => ioDesc_dp_r2dobc(ng)
         ELSE
           my_pioVar%dkind=PIO_real
-          my_ioDesc => ioDesc_sp_r2dobc(ng)
         END IF
 !
         status=nf_fread2d_bry(ng, model, ncname, my_pioFile,            &
      &                        Vname(1,ifield), my_pioVar,               &
-     &                        rec, my_ioDesc,                           &
+     &                        rec,                                      &
      &                        LBij, UBij, Nbrec(ng),                    &
      &                        scale, Fmin, Fmax,                        &
      &                        s_zeta_obc(:,:,:,Lout))
@@ -1374,15 +1372,13 @@
         my_pioVar%gtype=u2dobc
         IF (KIND(s_ubar_obc).eq.8) THEN
           my_pioVar%dkind=PIO_double
-          my_ioDesc => ioDesc_dp_u2dobc(ng)
         ELSE
           my_pioVar%dkind=PIO_real
-          my_ioDesc => ioDesc_sp_u2dobc(ng)
         END IF
 !
         status=nf_fread2d_bry(ng, model, ncname, my_pioFile,            &
      &                        Vname(1,ifield), my_pioVar,               &
-     &                        rec, my_ioDesc,                           &
+     &                        rec,                                      &
      &                        LBij, UBij, Nbrec(ng),                    &
      &                        scale, Fmin, Fmax,                        &
      &                        s_ubar_obc(:,:,:,Lout))
@@ -1412,15 +1408,13 @@
         my_pioVar%gtype=v2dobc
         IF (KIND(s_vbar_obc).eq.8) THEN
           my_pioVar%dkind=PIO_double
-          my_ioDesc => ioDesc_dp_v2dobc(ng)
         ELSE
           my_pioVar%dkind=PIO_real
-          my_ioDesc => ioDesc_sp_v2dobc(ng)
         END IF
 !
         status=nf_fread2d_bry(ng, model, ncname, my_pioFile,            &
      &                        Vname(1,ifield), my_pioVar,               &
-     &                        rec, my_ioDesc,                           &
+     &                        rec,                                      &
      &                        LBij, UBij, Nbrec(ng),                    &
      &                        scale, Fmin, Fmax,                        &
      &                        s_vbar_obc(:,:,:,Lout))
@@ -1570,15 +1564,13 @@
         my_pioVar%gtype=u3dobc
         IF (KIND(s_u_obc).eq.8) THEN
           my_pioVar%dkind=PIO_double
-          my_ioDesc => ioDesc_dp_u3dobc(ng)
         ELSE
           my_pioVar%dkind=PIO_real
-          my_ioDesc => ioDesc_sp_u3dobc(ng)
         END IF
 !
         status=nf_fread3d_bry (ng, model, ncname, my_pioFile,           &
      &                         Vname(1,ifield), my_pioVar,              &
-     &                         rec, my_ioDesc,                          &
+     &                         rec,                                     &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng),         &
      &                         scale, Fmin, Fmax,                       &
      &                         s_u_obc(:,:,:,:,Lout))
@@ -1649,15 +1641,13 @@
         my_pioVar%gtype=v3dobc
         IF (KIND(s_v_obc).eq.8) THEN
           my_pioVar%dkind=PIO_double
-          my_ioDesc => ioDesc_dp_v3dobc(ng)
         ELSE
           my_pioVar%dkind=PIO_real
-          my_ioDesc => ioDesc_sp_v3dobc(ng)
         END IF
 !
         status=nf_fread3d_bry(ng, model, ncname, my_pioFile,            &
      &                        Vname(1,ifield), my_pioVar,               &
-     &                        rec, my_ioDesc,                           &
+     &                        rec,                                      &
      &                        LBij, UBij, 1, N(ng), Nbrec(ng),          &
      &                        scale, Fmin, Fmax,                        &
      &                        s_v_obc(:,:,:,:,Lout))
@@ -1734,15 +1724,13 @@
           my_pioVar%gtype=r3dobc
           IF (KIND(s_t_obc).eq.8) THEN
             my_pioVar%dkind=PIO_double
-            my_ioDesc => ioDesc_dp_r3dobc(ng)
           ELSE
             my_pioVar%dkind=PIO_real
-            my_ioDesc => ioDesc_sp_r3dobc(ng)
           END IF
 !
           status=nf_fread3d_bry (ng, model, ncname, my_pioFile,         &
      &                           Vname(1,ifield), my_pioVar,            &
-     &                           rec, my_ioDesc,                        &
+     &                           rec,                                   &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng),       &
      &                           scale, Fmin, Fmax,                     &
      &                           s_t_obc(:,:,:,:,Lout,itrc))

--- a/ROMS/Utility/state_regrid.F
+++ b/ROMS/Utility/state_regrid.F
@@ -192,7 +192,7 @@
       integer :: gtype, i, it1, it2, j
       integer :: method
 #  if defined ADJUST_STFLUX && defined SOLVE3D
-      integer :: itrc
+      integer :: ifield, itrc
 #  endif
 !
       real(r8) :: fac, fac1, fac2
@@ -319,16 +319,16 @@
       DO j=JstrR,JendR
         DO i=Istr,IendR
           nl_sustr(i,j)=nl_sustr(i,j)+                                  &
-     &                  fac1*tl_ustr(i,j,it1,Lout)+                     &
-     &                  fac2*tl_ustr(i,j,it2,Lout)
+     &                  fac1*ustr(i,j,it1,Lout)+                        &
+     &                  fac2*ustr(i,j,it2,Lout)
         END DO
       END DO
 !
       DO j=Jstr,JendR
         DO i=IstrR,IendR
-          svstr(i,j)=svstr(i,j)+                                        &
-     &               fac1*tl_vstr(i,j,it1,Lout)+                        &
-     &               fac2*tl_vstr(i,j,it2,Lout)
+          nl_svstr(i,j)=nl_svstr(i,j)+                                  &
+     &                  fac1*vstr(i,j,it1,Lout)+                        &
+     &                  fac2*vstr(i,j,it2,Lout)
         END DO
       END DO
 #  endif
@@ -342,9 +342,9 @@
         IF (Lstflux(itrc,ng)) THEN
           DO j=JstrR,JendR
             DO i=IstrR,IendR
-              nl_stflx(i,j,itrc)=stflx(i,j,itrc)+                       &
-     &                           fac1*tl_tflux(i,j,it1,Lout,itrc)+      &
-     &                           fac2*tl_tflux(i,j,it2,Lout,itrc)
+              nl_stflx(i,j,itrc)=nl_stflx(i,j,itrc)+                    &
+     &                           fac1*tflux(i,j,it1,Lout,itrc)+         &
+     &                           fac2*tflux(i,j,it2,Lout,itrc)
             END DO
           END DO
         END IF

--- a/ROMS/Utility/wrt_error.F
+++ b/ROMS/Utility/wrt_error.F
@@ -730,18 +730,12 @@
 !
       IF (ANY(Lobc(:,isFsur,ng))) THEN
         scale=1.0_dp
-        IF (ERR(ng)%pioVar(idSbry(isFsur))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_r2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_r2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry (ng, iTLM, ERR(ng)%name,                 &
      &                          ERR(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isFsur)),                &
      &                          ERR(ng)%pioVar(idSbry(isFsur)),         &
      &                          ERR(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % tl_zeta_obc(LBij:,:,:,   &
      &                                                     kout))
@@ -790,18 +784,12 @@
 !
       IF (ANY(Lobc(:,isUbar,ng))) THEN
         scale=1.0_dp
-        IF (ERR(ng)%pioVar(idSbry(isUbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry (ng, iTLM, ERR(ng)%name,                 &
      &                          ERR(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isUbar)),                &
      &                          ERR(ng)%pioVar(idSbry(isUbar)),         &
      &                          ERR(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % tl_ubar_obc(LBij:,:,:,   &
      &                                                     kout))
@@ -850,18 +838,12 @@
 !
       IF (ANY(Lobc(:,isVbar,ng))) THEN
         scale=1.0_dp
-        IF (ERR(ng)%pioVar(idSbry(isVbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry (ng, iTLM, ERR(ng)%name,                 &
      &                          ERR(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isVbar)),                &
      &                          ERR(ng)%pioVar(idSbry(isVbar)),         &
      &                          ERR(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % tl_vbar_obc(LBij:,:,:,   &
      &                                                     kout))
@@ -912,18 +894,12 @@
 !
       IF (ANY(Lobc(:,isUvel,ng))) THEN
         scale=1.0_dp
-        IF (ERR(ng)%pioVar(idSbry(isUvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry (ng, iTLM, ERR(ng)%name,                 &
      &                          ERR(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isUvel)),                &
      &                          ERR(ng)%pioVar(idSbry(isUvel)),         &
      &                          ERR(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, 1, N(ng), Nbrec(ng), scale, &
      &                          BOUNDARY(ng) % tl_u_obc(LBij:,:,:,:,    &
      &                                                  nout))
@@ -972,18 +948,12 @@
 !
       IF (ANY(Lobc(:,isVvel,ng))) THEN
         scale=1.0_dp
-        IF (ERR(ng)%pioVar(idSbry(isVvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry (ng, iTLM, ERR(ng)%name,                 &
      &                          ERR(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isVvel)),                &
      &                          ERR(ng)%pioVar(idSbry(isVvel)),         &
      &                          ERR(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, 1, N(ng), Nbrec(ng), scale, &
      &                          BOUNDARY(ng) % tl_v_obc(LBij:,:,:,:,    &
      &                                                  nout))
@@ -1037,18 +1007,12 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           ifield=idSbry(isTvar(itrc))
-          IF (ERR(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-            ioDesc => ioDesc_dp_r3dobc(ng)
-          ELSE
-            ioDesc => ioDesc_sp_r3dobc(ng)
-          END IF
 !
           status=nf_fwrite3d_bry (ng, iTLM, ERR(ng)%name,               &
      &                            ERR(ng)%pioFile,                      &
      &                            Vname(1,ifield),                      &
      &                            ERR(ng)%pioVar(ifield),               &
      &                            ERR(ng)%Rindex,                       &
-     &                            ioDesc,                               &
      &                            LBij, UBij, 1, N(ng), Nbrec(ng),      &
      &                            scale,                                &
      &                            BOUNDARY(ng) % tl_t_obc(LBij:,:,:,:,  &

--- a/ROMS/Utility/wrt_evolved.F
+++ b/ROMS/Utility/wrt_evolved.F
@@ -683,18 +683,12 @@
 !
       IF (ANY(Lobc(:,isFsur,ng))) THEN
         scale=1.0_dp
-        IF (LZE(ng)%pioVar(idSbry(isFsur))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_r2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_r2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry (ng, iADM, LZE(ng)%name,                 &
      &                          LZE(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isFsur)),                &
      &                          LZE(ng)%pioVar(idSbry(isFsur)),         &
      &                          LZE(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % tl_zeta_obc(LBij:,:,:,   &
      &                                                     kout))
@@ -743,18 +737,12 @@
 !
       IF (ANY(Lobc(:,isUbar,ng))) THEN
         scale=1.0_dp
-        IF (LZE(ng)%pioVar(idSbry(isUbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry (ng, iADM, LZE(ng)%name,                 &
      &                          LZE(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isUbar)),                &
      &                          LZE(ng)%pioVar(idSbry(isUbar)),         &
      &                          LZE(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % tl_ubar_obc(LBij:,:,:,   &
      &                                                     kout))
@@ -803,18 +791,12 @@
 !
       IF (ANY(Lobc(:,isVbar,ng))) THEN
         scale=1.0_dp
-        IF (LZE(ng)%pioVar(idSbry(isVbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry (ng, iADM, LZE(ng)%name,                 &
      &                          LZE(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isVbar)),                &
      &                          LZE(ng)%pioVar(idSbry(isVbar)),         &
      &                          LZE(ng)%Rindex, v2dvar,                 &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % tl_vbar_obc(LBij:,:,:,   &
      &                                                     kout))
@@ -865,18 +847,12 @@
 !
       IF (ANY(Lobc(:,isUvel,ng))) THEN
         scale=1.0_dp
-        IF (LZE(ng)%pioVar(idSbry(isUvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry (ng, iADM, LZE(ng)%name,                 &
      &                          LZE(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isUvel)),                &
      &                          LZE(ng)%pioVar(idSbry(isUvel)),         &
      &                          LZE(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, 1, N(ng), Nbrec(ng), scale, &
      &                          BOUNDARY(ng) % tl_u_obc(LBij:,:,:,:,    &
      &                                                  nout))
@@ -925,18 +901,12 @@
 !
       IF (ANY(Lobc(:,isVvel,ng))) THEN
         scale=1.0_dp
-        IF (LZE(ng)%pioVar(idSbry(isVvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry (ng, iADM, LZE(ng)%name,                 &
      &                          LZE(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isVvel)),                &
      &                          LZE(ng)%pioVar(idSbry(isVvel)),         &
      &                          LZE(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, 1, N(ng), Nbrec(ng), scale, &
      &                          BOUNDARY(ng) % tl_v_obc(LBij:,:,:,:,    &
      &                                                  nout))
@@ -990,18 +960,12 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           ifield=idSbry(isTvar(itrc))
-          IF (LZE(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-            ioDesc => ioDesc_dp_r3dobc(ng)
-          ELSE
-            ioDesc => ioDesc_sp_r3dobc(ng)
-          END IF
 !
           status=nf_fwrite3d_bry (ng, iADM, LZE(ng)%name,               &
      &                            LZE(ng)%pioFile,                      &
      &                            Vname(1,ifield),                      &
      &                            LZE(ng)%pioVar(ifield),               &
      &                            LZE(ng)%Rindex,                       &
-     &                            ioDesc,                               &
      &                            LBij, UBij, 1, N(ng), Nbrec(ng),      &
      &                            scale,                                &
      &                            BOUNDARY(ng) % tl_t_obc(LBij:,:,:,:,  &

--- a/ROMS/Utility/wrt_extract.F
+++ b/ROMS/Utility/wrt_extract.F
@@ -2556,17 +2556,11 @@
 !
       IF (ANY(Lobc(:,isFsur,ng))) THEN
         scale=1.0_dp
-        IF (XTR(ng)%pioVar(idSbry(isFsur))%dkind.eq.PIO_double) THEN
-          ioDesX => ioDesX_dp_r2dobc(ng)
-        ELSE
-          ioDesX => ioDesX_sp_r2dobc(ng)
-        END IF
         status=nf_fwrite2d_bry (ng, model, XTR(ng)%name,                &
      &                          XTR(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isFsur)),                &
      &                          XTR(ng)%pioVar(idSbry(isFsur)),         &
      &                          XTR(ng)%Rindex,                         &
-     &                          ioDesX,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % zeta_obc(LBij:,:,:,      &
      &                                                  Lbout(ng)),     &
@@ -2736,17 +2730,11 @@
 !
       IF (ANY(Lobc(:,isUbar,ng))) THEN
         scale=1.0_dp
-        IF (XTR(ng)%pioVar(idSbry(isUbar))%dkind.eq.PIO_double) THEN
-          ioDesX => ioDesX_dp_u2dobc(ng)
-        ELSE
-          ioDesX => ioDesX_sp_u2dobc(ng)
-        END IF
         status=nf_fwrite2d_bry (ng, model, XTR(ng)%name,                &
      &                          XTR(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isUbar)),                &
      &                          XTR(ng)%pioVar(idSbry(isUbar)),         &
      &                          XTR(ng)%Rindex,                         &
-     &                          ioDesX,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % ubar_obc(LBij:,:,:,      &
      &                                                  Lbout(ng)),     &
@@ -2917,17 +2905,11 @@
 !
       IF (ANY(Lobc(:,isVbar,ng))) THEN
         scale=1.0_dp
-        IF (XTR(ng)%pioVar(idSbry(isVbar))%dkind.eq.PIO_double) THEN
-          ioDesX => ioDesX_dp_v2dobc(ng)
-        ELSE
-          ioDesX => ioDesX_sp_v2dobc(ng)
-        END IF
         status=nf_fwrite2d_bry (ng, model, XTR(ng)%name,                &
      &                          XTR(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isVbar)),                &
      &                          XTR(ng)%pioVar(idSbry(isVbar)),         &
      &                          XTR(ng)%Rindex,                         &
-     &                          ioDesX,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % vbar_obc(LBij:,:,:,      &
      &                                                  Lbout(ng)),     &
@@ -3087,17 +3069,11 @@
 !
       IF (ANY(Lobc(:,isUvel,ng))) THEN
         scale=1.0_dp
-        IF (XTR(ng)%pioVar(idSbry(isUvel))%dkind.eq.PIO_double) THEN
-          ioDesX => ioDesX_dp_u3dobc(ng)
-        ELSE
-          ioDesX => ioDesX_sp_u3dobc(ng)
-        END IF
         status=nf_fwrite3d_bry (ng, model, XTR(ng)%name,                &
      &                          XTR(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isUvel)),                &
      &                          XTR(ng)%pioVar(idSbry(isUvel)),         &
      &                          XTR(ng)%Rindex,                         &
-     &                          ioDesX,                                 &
      &                          LBij, UBij, 1, N(ng), Nbrec(ng), scale, &
      &                          BOUNDARY(ng) % u_obc(LBij:,:,:,:,       &
      &                                               Lbout(ng)),        &
@@ -3178,17 +3154,11 @@
 !
       IF (ANY(Lobc(:,isVvel,ng))) THEN
         scale=1.0_dp
-        IF (XTR(ng)%pioVar(idSbry(isVvel))%dkind.eq.PIO_double) THEN
-          ioDesX => ioDesX_dp_v3dobc(ng)
-        ELSE
-          ioDesX => ioDesX_sp_v3dobc(ng)
-        END IF
         status=nf_fwrite3d_bry (ng, model, XTR(ng)%name,                &
      &                          XTR(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isVvel)),                &
      &                          XTR(ng)%pioVar(idSbry(isVvel)),         &
      &                          XTR(ng)%Rindex,                         &
-     &                          ioDesX,                                 &
      &                          LBij, UBij, 1, N(ng), Nbrec(ng), scale, &
      &                          BOUNDARY(ng) % v_obc(LBij:,:,:,:,       &
      &                                               Lbout(ng)),        &
@@ -3438,17 +3408,11 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           ifield=idSbry(isTvar(itrc))
-          IF (XTR(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-            ioDesX => ioDesX_dp_r3dobc(ng)
-          ELSE
-            ioDesX => ioDesX_sp_r3dobc(ng)
-          END IF
           status=nf_fwrite3d_bry (ng, model, XTR(ng)%name,              &
      &                            XTR(ng)%pioFile,                      &
      &                            Vname(1,ifield),                      &
      &                            XTR(ng)%pioVar(ifield),               &
      &                            XTR(ng)%Rindex,                       &
-     &                            ioDesX,                               &
      &                            LBij, UBij, 1, N(ng), Nbrec(ng),      &
      &                            scale,                                &
      &                            BOUNDARY(ng) % t_obc(LBij:,:,:,:,     &

--- a/ROMS/Utility/wrt_extract.F
+++ b/ROMS/Utility/wrt_extract.F
@@ -151,19 +151,19 @@
         CASE (io_nf90)
           CALL wrt_extract_nf90 (ng, iNLM, tile,                        &
 # ifdef ADJUST_BOUNDARY
-     &                       LBij, UBij,                                &
+     &                           LBij, UBij,                            &
 # endif
-     &                       LBi, UBi, LBj, UBj,                        &
-     &                       iLB, iUB, jLB, jUB)
+     &                           LBi, UBi, LBj, UBj,                    &
+     &                           iLB, iUB, jLB, jUB)
 
 # if defined PIO_LIB && defined DISTRIBUTE
         CASE (io_pio)
           CALL wrt_extract_pio (ng, iNLM, tile,                         &
 #  ifdef ADJUST_BOUNDARY
-     &                      LBij, UBij,                                 &
+     &                          LBij, UBij,                             &
 #  endif
-     &                      LBi, UBi, LBj, UBj,                         &
-     &                      iLB, iUB, jLB, jUB)
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          iLB, iUB, jLB, jUB)
 # endif
         CASE DEFAULT
           IF (Master) WRITE (stdout,10) XTR(ng)%IOtype
@@ -180,10 +180,10 @@
 !***********************************************************************
       SUBROUTINE wrt_extract_nf90 (ng, model, tile,                     &
 # ifdef ADJUST_BOUNDARY
-     &                         LBij, UBij,                              &
+     &                             LBij, UBij,                          &
 # endif
-     &                         LBi, UBi, LBj, UBj,                      &
-     &                         iLB, iUB, jLB, jUB)
+     &                             LBi, UBi, LBj, UBj,                  &
+     &                             iLB, iUB, jLB, jUB)
 !***********************************************************************
 !
       USE mod_netcdf
@@ -2161,13 +2161,11 @@
 !
 !***********************************************************************
       SUBROUTINE wrt_extract_pio (ng, model, tile,                      &
-# ifdef ADJUST_BOUNDARY
-     &                        LBij, UBij,                               &
-     &                        ijLB, ijUB,                               &
-
-# endif
-     &                        LBi, UBi, LBj, UBj,                       &
-     &                        iLB, iUB, jLB, jUB)
+#  ifdef ADJUST_BOUNDARY
+     &                            LBij, UBij,                           &
+#  endif
+     &                            LBi, UBi, LBj, UBj,                   &
+     &                            iLB, iUB, jLB, jUB)
 !***********************************************************************
 !
       USE mod_pio_netcdf
@@ -2177,7 +2175,6 @@
       integer, intent(in) :: ng, model, tile
 #  ifdef ADJUST_BOUNDARY
       integer, intent(in) :: LBij, UBij
-      integer, intent(in) :: ijLB, ijUB
 #  endif
       integer, intent(in) :: LBi, UBi, LBj, UBj
       integer, intent(in) :: iLB, iUB, jLB, jUB
@@ -3417,7 +3414,7 @@
      &                            scale,                                &
      &                            BOUNDARY(ng) % t_obc(LBij:,:,:,:,     &
      &                                                 Lbout(ng),itrc), &
-     &                          ExtractField = ExtractFlag(ng))
+     &                            ExtractField = ExtractFlag(ng))
           IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
             IF (Master) THEN
               WRITE (stdout,20) TRIM(Vname(1,ifield)), XTR(ng)%Rindex

--- a/ROMS/Utility/wrt_hessian.F
+++ b/ROMS/Utility/wrt_hessian.F
@@ -690,18 +690,11 @@
 !
       IF (ANY(Lobc(:,isFsur,ng))) THEN
         scale=1.0_dp
-        IF (HSS(ng)%pioVar(idSbry(isFsur))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_r2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_r2dobc(ng)
-        END IF
-!
         status=nf_fwrite2d_bry (ng, iADM, HSS(ng)%name,                 &
      &                          HSS(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isFsur)),                &
      &                          HSS(ng)%pioVar(idSbry(isFsur)),         &
      &                          HSS(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % ad_zeta_obc(LBij:,:,:,   &
      &                                                     kout))
@@ -750,12 +743,6 @@
 !
       IF (ANY(Lobc(:,isUbar,ng))) THEN
         scale=1.0_dp
-        IF (HSS(ng)%pioVar(idSbry(isUbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u2dobc(ng)
-        END IF
-!
         status=nf_fwrite2d_bry (ng, iADM, HSS(ng)%name,                 &
      &                          HSS(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isUbar)),                &
@@ -810,18 +797,11 @@
 !
       IF (ANY(Lobc(:,isVbar,ng))) THEN
         scale=1.0_dp
-        IF (HSS(ng)%pioVar(idSbry(isVbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v2dobc(ng)
-        END IF
-!
         status=nf_fwrite2d_bry (ng, iADM, HSS(ng)%name,                 &
      &                          HSS(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isVbar)),                &
      &                          HSS(ng)%pioVar(idSbry(isVbar)),         &
      &                          HSS(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % ad_vbar_obc(LBij:,:,:,   &
      &                                                     kout))
@@ -872,18 +852,11 @@
 !
       IF (ANY(Lobc(:,isUvel,ng))) THEN
         scale=1.0_dp
-        IF (HSS(ng)%pioVar(idSbry(isUvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u3dobc(ng)
-        END IF
-!
         status=nf_fwrite3d_bry (ng, iADM, HSS(ng)%name,                 &
      &                          HSS(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isUvel)),                &
      &                          HSS(ng)%pioVar(idSbry(isUvel)),         &
      &                          HSS(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, 1, N(ng), Nbrec(ng), scale, &
      &                          BOUNDARY(ng) % ad_u_obc(LBij:,:,:,:,    &
      &                                                  nout))
@@ -932,18 +905,11 @@
 !
       IF (ANY(Lobc(:,isVvel,ng))) THEN
         scale=1.0_dp
-        IF (HSS(ng)%pioVar(idSbry(isVvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v3dobc(ng)
-        END IF
-!
         status=nf_fwrite3d_bry (ng, iADM, HSS(ng)%name,                 &
      &                          HSS(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isVvel)),                &
      &                          HSS(ng)%pioVar(idSbry(isVvel)),         &
      &                          HSS(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, 1, N(ng), Nbrec(ng), scale, &
      &                          BOUNDARY(ng) % ad_v_obc(LBij:,:,:,:,    &
      &                                                  nout))
@@ -997,18 +963,12 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           ifield=idSbry(isTvar(itrc))
-          IF (HSS(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-            ioDesc => ioDesc_dp_r3dobc(ng)
-          ELSE
-            ioDesc => ioDesc_sp_r3dobc(ng)
-          END IF
 !
           status=nf_fwrite3d_bry (ng, iADM, HSS(ng)%name,               &
      &                            HSS(ng)%pioFile,                      &
      &                            Vname(1,ifield),                      &
      &                            HSS(ng)%pioVar(ifield),               &
      &                            HSS(ng)%Rindex,                       &
-     &                            ioDesc,                               &
      &                            LBij, UBij, 1, N(ng), Nbrec(ng),      &
      &                            scale,                                &
      &                            BOUNDARY(ng) % ad_t_obc(LBij:,:,:,:,  &

--- a/ROMS/Utility/wrt_his.F
+++ b/ROMS/Utility/wrt_his.F
@@ -2779,17 +2779,11 @@
 !
       IF (ANY(Lobc(:,isFsur,ng))) THEN
         scale=1.0_dp
-        IF (HIS(ng)%pioVar(idSbry(isFsur))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_r2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_r2dobc(ng)
-        END IF
         status=nf_fwrite2d_bry (ng, model, HIS(ng)%name,                &
      &                          HIS(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isFsur)),                &
      &                          HIS(ng)%pioVar(idSbry(isFsur)),         &
      &                          HIS(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % zeta_obc(LBij:,:,:,      &
      &                                                  Lbout(ng)))
@@ -2940,17 +2934,11 @@
 !
       IF (ANY(Lobc(:,isUbar,ng))) THEN
         scale=1.0_dp
-        IF (HIS(ng)%pioVar(idSbry(isUbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u2dobc(ng)
-        END IF
         status=nf_fwrite2d_bry (ng, model, HIS(ng)%name,                &
      &                          HIS(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isUbar)),                &
      &                          HIS(ng)%pioVar(idSbry(isUbar)),         &
      &                          HIS(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % ubar_obc(LBij:,:,:,      &
      &                                                  Lbout(ng)))
@@ -3101,17 +3089,11 @@
 !
       IF (ANY(Lobc(:,isVbar,ng))) THEN
         scale=1.0_dp
-        IF (HIS(ng)%pioVar(idSbry(isVbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v2dobc(ng)
-        END IF
         status=nf_fwrite2d_bry (ng, model, HIS(ng)%name,                &
      &                          HIS(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isVbar)),                &
      &                          HIS(ng)%pioVar(idSbry(isVbar)),         &
      &                          HIS(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, Nbrec(ng), scale,           &
      &                          BOUNDARY(ng) % vbar_obc(LBij:,:,:,      &
      &                                                  Lbout(ng)))
@@ -3314,17 +3296,11 @@
 !
       IF (ANY(Lobc(:,isUvel,ng))) THEN
         scale=1.0_dp
-        IF (HIS(ng)%pioVar(idSbry(isUvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u3dobc(ng)
-        END IF
         status=nf_fwrite3d_bry (ng, model, HIS(ng)%name,                &
      &                          HIS(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isUvel)),                &
      &                          HIS(ng)%pioVar(idSbry(isUvel)),         &
      &                          HIS(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, 1, N(ng), Nbrec(ng), scale, &
      &                          BOUNDARY(ng) % u_obc(LBij:,:,:,:,       &
      &                                               Lbout(ng)))
@@ -3452,17 +3428,11 @@
 !
       IF (ANY(Lobc(:,isVvel,ng))) THEN
         scale=1.0_dp
-        IF (HIS(ng)%pioVar(idSbry(isVvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v3dobc(ng)
-        END IF
         status=nf_fwrite3d_bry (ng, model, HIS(ng)%name,                &
      &                          HIS(ng)%pioFile,                        &
      &                          Vname(1,idSbry(isVvel)),                &
      &                          HIS(ng)%pioVar(idSbry(isVvel)),         &
      &                          HIS(ng)%Rindex,                         &
-     &                          ioDesc,                                 &
      &                          LBij, UBij, 1, N(ng), Nbrec(ng), scale, &
      &                          BOUNDARY(ng) % v_obc(LBij:,:,:,:,       &
      &                                               Lbout(ng)))
@@ -4012,17 +3982,11 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           ifield=idSbry(isTvar(itrc))
-          IF (HIS(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-            ioDesc => ioDesc_dp_r3dobc(ng)
-          ELSE
-            ioDesc => ioDesc_sp_r3dobc(ng)
-          END IF
           status=nf_fwrite3d_bry (ng, model, HIS(ng)%name,              &
      &                            HIS(ng)%pioFile,                      &
      &                            Vname(1,ifield),                      &
      &                            HIS(ng)%pioVar(ifield),               &
      &                            HIS(ng)%Rindex,                       &
-     &                            ioDesc,                               &
      &                            LBij, UBij, 1, N(ng), Nbrec(ng),      &
      &                            scale,                                &
      &                            BOUNDARY(ng) % t_obc(LBij:,:,:,:,     &

--- a/ROMS/Utility/wrt_ini.F
+++ b/ROMS/Utility/wrt_ini.F
@@ -1421,17 +1421,12 @@
 !
       IF (ANY(Lobc(:,isFsur,ng))) THEN
         scale=1.0_dp
-        IF (INI(ng)%pioVar(idSbry(isFsur))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_r2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_r2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, iNLM, INI(ng)%name,                  &
      &                         INI(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isFsur)),                 &
      &                         INI(ng)%pioVar(idSbry(isFsur)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % zeta_obc(LBij:,:,:,       &
      &                                                 Tindex))
@@ -1449,17 +1444,12 @@
 !
       IF (ANY(Lobc(:,isUbar,ng))) THEN
         scale=1.0_dp
-        IF (INI(ng)%pioVar(idSbry(isUbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, iNLM, INI(ng)%name,                  &
      &                         INI(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isUbar)),                 &
      &                         INI(ng)%pioVar(idSbry(isUbar)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % ubar_obc(LBij:,:,:,       &
      &                                                 Tindex))
@@ -1477,17 +1467,12 @@
 !
       IF (ANY(Lobc(:,isVbar,ng))) THEN
         scale=1.0_dp
-        IF (INI(ng)%pioVar(idSbry(isVbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, iNLM, INI(ng)%name,                  &
      &                         INI(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isVbar)),                 &
      &                         INI(ng)%pioVar(idSbry(isVbar)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % vbar_obc(LBij:,:,:,       &
      &                                                 Tindex))
@@ -1507,17 +1492,12 @@
 !
       IF (ANY(Lobc(:,isUvel,ng))) THEN
         scale=1.0_dp
-        IF (INI(ng)%pioVar(idSbry(isUvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry(ng, iNLM, INI(ng)%name,                  &
      &                         INI(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isUvel)),                 &
      &                         INI(ng)%pioVar(idSbry(isUvel)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng), scale,  &
      &                         BOUNDARY(ng) % u_obc(LBij:,:,:,:,        &
      &                                              Tindex))
@@ -1535,17 +1515,12 @@
 !
       IF (ANY(Lobc(:,isVvel,ng))) THEN
         scale=1.0_dp
-        IF (INI(ng)%pioVar(idSbry(isVvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry(ng, iNLM, INI(ng)%name,                  &
      &                         INI(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isVvel)),                 &
      &                         INI(ng)%pioVar(idSbry(isVvel)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng), scale,  &
      &                         BOUNDARY(ng) % v_obc(LBij:,:,:,:,        &
      &                                              Tindex))
@@ -1565,17 +1540,12 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           ifield=idSbry(isTvar(itrc))
-          IF (INI(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-            ioDesc => ioDesc_dp_r3dobc(ng)
-          ELSE
-            ioDesc => ioDesc_sp_r3dobc(ng)
-          END IF
 !
           status=nf_fwrite3d_bry(ng, iNLM, INI(ng)%name,                &
      &                           INI(ng)%pioFile,                       &
      &                           Vname(1,ifield),                       &
      &                           INI(ng)%pioVar(ifield),                &
-     &                           OutRec, ioDesc,                        &
+     &                           OutRec,                                &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng),       &
      &                           scale,                                 &
      &                           BOUNDARY(ng) % t_obc(LBij:,:,:,:,      &
@@ -2126,17 +2096,12 @@
 !
       IF (ANY(Lobc(:,isFsur,ng))) THEN
         scale=1.0_dp
-        IF (INI(ng)%pioVar(idSbry(isFsur))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_r2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_r2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, iNLM, INI(ng)%name,                  &
      &                         INI(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isFsur)),                 &
      &                         INI(ng)%pioVar(idSbry(isFsur)),          &
-     &                         OutRec,ioDesc,                           &
+     &                         OutRec,                                  &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % ad_zeta_obc(LBij:,:,:,    &
      &                                                    Tindex))
@@ -2154,17 +2119,12 @@
 !
       IF (ANY(Lobc(:,isUbar,ng))) THEN
         scale=1.0_dp
-        IF (INI(ng)%pioVar(idSbry(isUbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, iNLM, INI(ng)%name,                  &
      &                         INI(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isUbar)),                 &
      &                         INI(ng)%pioVar(idSbry(isUbar)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % ad_ubar_obc(LBij:,:,:,    &
      &                                                    Tindex))
@@ -2182,17 +2142,12 @@
 !
       IF (ANY(Lobc(:,isVbar,ng))) THEN
         scale=1.0_dp
-        IF (INI(ng)%pioVar(idSbry(isVbar))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v2dobc(ng)
-        END IF
 !
         status=nf_fwrite2d_bry(ng, iNLM, INI(ng)%name,                  &
      &                         INI(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isVbar)),                 &
      &                         INI(ng)%pioVar(idSbry(isVbar)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, Nbrec(ng), scale,            &
      &                         BOUNDARY(ng) % ad_vbar_obc(LBij:,:,:,    &
      &                                                    Tindex))
@@ -2212,17 +2167,12 @@
 !
       IF (ANY(Lobc(:,isUvel,ng))) THEN
         scale=1.0_dp
-        IF (INI(ng)%pioVar(idSbry(isUvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry(ng, iNLM, INI(ng)%name,                  &
      &                         INI(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isUvel)),                 &
      &                         INI(ng)%pioVar(idSbry(isUvel)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng), scale,  &
      &                         BOUNDARY(ng) % ad_u_obc(LBij:,:,:,:,     &
      &                                                 Tindex))
@@ -2240,17 +2190,12 @@
 !
       IF (ANY(Lobc(:,isVvel,ng))) THEN
         scale=1.0_dp
-        IF (INI(ng)%pioVar(idSbry(isVvel))%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v3dobc(ng)
-        END IF
 !
         status=nf_fwrite3d_bry(ng, iNLM, INI(ng)%name,                  &
      &                         INI(ng)%pioFile,                         &
      &                         Vname(1,idSbry(isVvel)),                 &
      &                         INI(ng)%pioVar(idSbry(isVvel)),          &
-     &                         OutRec, ioDesc,                          &
+     &                         OutRec,                                  &
      &                         LBij, UBij, 1, N(ng), Nbrec(ng), scale,  &
      &                         BOUNDARY(ng) % ad_v_obc(LBij:,:,:,:,     &
      &                                                 Tindex))
@@ -2270,17 +2215,12 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           ifield=idSbry(isTvar(itrc))
-          IF (INI(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-            ioDesc => ioDesc_dp_r3dobc(ng)
-          ELSE
-            ioDesc => ioDesc_sp_r3dobc(ng)
-          END IF
 !
           status=nf_fwrite3d_bry(ng, iNLM, INI(ng)%name,                &
      &                           INI(ng)%pioFile,                       &
      &                           Vname(1,idSbry(isTvar(itrc))),         &
      &                           INI(ng)%pioVar(idSbry(isTvar(itrc))),  &
-     &                           OutRec, ioDesc,                        &
+     &                           OutRec,                                &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng),       &
      &                           scale,                                 &
      &                           BOUNDARY(ng) % ad_t_obc(LBij:,:,:,:,   &

--- a/ROMS/Utility/wrt_state.F
+++ b/ROMS/Utility/wrt_state.F
@@ -761,7 +761,7 @@
           status=nf_fwrite3d_bry(ng, model, S(ng)%name, ncid,           &
      &                           Vname(1,idSbry(isVvel)),               &
      &                           S(ng)%Vid(idSbry(isVvel)),             &
-     &                           OutRec , v3dvar,                       &
+     &                           OutRec, v3dvar,                        &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng), scale,&
      &                           BOUNDARY(ng) % ad_v_obc(LBij:,:,:,:,   &
      &                                                   Lbout(ng)),    &
@@ -771,7 +771,7 @@
           status=nf_fwrite3d_bry(ng, model, S(ng)%name, ncid,           &
      &                           Vname(1,idSbry(isVvel)),               &
      &                           S(ng)%Vid(idSbry(isVvel)),             &
-     &                           OutRec , v3dvar,                       &
+     &                           OutRec, v3dvar,                        &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng), scale,&
      &                           BOUNDARY(ng) % ad_v_obc(LBij:,:,:,:,   &
      &                                                   Lbout(ng)),    &
@@ -1148,17 +1148,11 @@
       IF (ANY(Lobc(:,isFsur,ng))) THEN
         scale=1.0_dp
         ifield=idSbry(isFsur)
-        IF (S(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_r2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_r2dobc(ng)
-        END IF
 !
         IF (model.eq.iTLM) THEN
           status=nf_fwrite2d_bry(ng, model, S(ng)%name, pioFile,        &
      &                           Vname(1,ifield),                       &
      &                           S(ng)%pioVar(ifield), OutRec,          &
-     &                           ioDesc,                                &
      &                           LBij, UBij, Nbrec(ng), scale,          &
      &                           BOUNDARY(ng) % tl_zeta_obc(LBij:,:,:,  &
      &                                                      Lbout(ng)), &
@@ -1168,7 +1162,6 @@
           status=nf_fwrite2d_bry(ng, model, S(ng)%name, pioFile,        &
      &                           Vname(1,ifield),                       &
      &                           S(ng)%pioVar(ifield), OutRec,          &
-     &                           ioDesc,                                &
      &                           LBij, UBij, Nbrec(ng), scale,          &
      &                           BOUNDARY(ng) % ad_zeta_obc(LBij:,:,:,  &
      &                                                      Lbout(ng)), &
@@ -1245,17 +1238,11 @@
       IF (ANY(Lobc(:,isUbar,ng))) THEN
         scale=1.0_dp
         ifield=idSbry(isUbar)
-        IF (S(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u2dobc(ng)
-        END IF
 !
         IF (model.eq.iTLM) THEN
           status=nf_fwrite2d_bry(ng, model, S(ng)%name, pioFile,        &
      &                           Vname(1,ifield),                       &
      &                           S(ng)%pioVar(ifield), OutRec,          &
-     &                           ioDesc,                                &
      &                           LBij, UBij, Nbrec(ng), scale,          &
      &                           BOUNDARY(ng) % tl_ubar_obc(LBij:,:,:,  &
      &                                                      Lbout(ng)), &
@@ -1265,7 +1252,6 @@
           status=nf_fwrite2d_bry(ng, model, S(ng)%name, pioFile,        &
      &                           Vname(1,ifield),                       &
      &                           S(ng)%pioVar(ifield), OutRec,          &
-     &                           ioDesc,                                &
      &                           LBij, UBij, Nbrec(ng), scale,          &
      &                           BOUNDARY(ng) % ad_ubar_obc(LBij:,:,:,  &
      &                                                      Lbout(ng)), &
@@ -1341,17 +1327,11 @@
       IF (ANY(Lobc(:,isVbar,ng))) THEN
         scale=1.0_dp
         ifield=idSbry(isVbar)
-        IF (S(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v2dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v2dobc(ng)
-        END IF
 !
         IF (model.eq.iTLM) THEN
           status=nf_fwrite2d_bry(ng, model, S(ng)%name, pioFile,        &
      &                           Vname(1,ifield),                       &
      &                           S(ng)%pioVar(ifield), OutRec,          &
-     &                           ioDesc,                                &
      &                           LBij, UBij, Nbrec(ng), scale,          &
      &                           BOUNDARY(ng) % tl_vbar_obc(LBij:,:,:,  &
      &                                                      Lbout(ng)), &
@@ -1361,7 +1341,6 @@
           status=nf_fwrite2d_bry(ng, model, S(ng)%name, pioFile,        &
      &                           Vname(1,ifield),                       &
      &                           S(ng)%pioVar(ifield), OutRec,          &
-     &                           ioDesc,                                &
      &                           LBij, UBij, Nbrec(ng), scale,          &
      &                           BOUNDARY(ng) % ad_vbar_obc(LBij:,:,:,  &
      &                                                      Lbout(ng)), &
@@ -1538,17 +1517,11 @@
       IF (ANY(Lobc(:,isUvel,ng))) THEN
         scale=1.0_dp
         ifield=idSbry(isUvel)
-        IF (S(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_u3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_u3dobc(ng)
-        END IF
 !
         IF (model.eq.iTLM) THEN
           status=nf_fwrite3d_bry(ng, model, S(ng)%name, pioFile,        &
      &                           Vname(1,ifield),                       &
      &                           S(ng)%pioVar(ifield), OutRec,          &
-     &                           ioDesc,                                &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng), scale,&
      &                           BOUNDARY(ng) % tl_u_obc(LBij:,:,:,:,   &
      &                                                   Lbout(ng)),    &
@@ -1558,7 +1531,6 @@
           status=nf_fwrite3d_bry(ng, model, S(ng)%name, pioFile,        &
      &                           Vname(1,ifield),                       &
      &                           S(ng)%pioVar(ifield), OutRec,          &
-     &                           ioDesc,                                &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng), scale,&
      &                           BOUNDARY(ng) % ad_u_obc(LBij:,:,:,:,   &
      &                                                   Lbout(ng)),    &
@@ -1634,17 +1606,11 @@
       IF (ANY(Lobc(:,isVvel,ng))) THEN
         scale=1.0_dp
         ifield=idSbry(isVvel)
-        IF (S(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-          ioDesc => ioDesc_dp_v3dobc(ng)
-        ELSE
-          ioDesc => ioDesc_sp_v3dobc(ng)
-        END IF
 !
         IF (model.eq.iTLM) THEN
           status=nf_fwrite3d_bry(ng, model, S(ng)%name, pioFile,        &
      &                           Vname(1,ifield),                       &
      &                           S(ng)%pioVar(ifield), OutRec,          &
-     &                           ioDesc,                                &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng), scale,&
      &                           BOUNDARY(ng) % ad_v_obc(LBij:,:,:,:,   &
      &                                                   Lbout(ng)),    &
@@ -1654,7 +1620,6 @@
           status=nf_fwrite3d_bry(ng, model, S(ng)%name, pioFile,        &
      &                           Vname(1,ifield),                       &
      &                           S(ng)%pioVar(ifield), OutRec,          &
-     &                           ioDesc,                                &
      &                           LBij, UBij, 1, N(ng), Nbrec(ng), scale,&
      &                           BOUNDARY(ng) % ad_v_obc(LBij:,:,:,:,   &
      &                                                   Lbout(ng)),    &
@@ -1734,17 +1699,12 @@
         IF (ANY(Lobc(:,isTvar(itrc),ng))) THEN
           scale=1.0_dp
           ifield=idSbry(isTvar(itrc))
-          IF (S(ng)%pioVar(ifield)%dkind.eq.PIO_double) THEN
-            ioDesc => ioDesc_dp_r3dobc(ng)
-          ELSE
-            ioDesc => ioDesc_sp_r3dobc(ng)
-          END IF
 !
           IF (model.eq.iTLM) THEN
             status=nf_fwrite3d_bry (ng, model, S(ng)%name, pioFile,     &
      &                              Vname(1,ifield),                    &
      &                              S(ng)%pioVar(ifield),               &
-     &                              OutRec, ioDesc,                     &
+     &                              OutRec,                             &
      &                              LBij, UBij, 1, N(ng), Nbrec(ng),    &
      &                              scale,                              &
      &                              BOUNDARY(ng) % tl_t_obc(LBij:,:,:,:,&
@@ -1755,7 +1715,7 @@
             status=nf_fwrite3d_bry (ng, model, S(ng)%name, pioFile,     &
      &                              Vname(1,ifield),                    &
      &                              S(ng)%pioVar(ifield),               &
-     &                              OutRec, ioDesc,                     &
+     &                              OutRec,                             &
      &                              LBij, UBij, 1, N(ng), Nbrec(ng),    &
      &                              scale,                              &
      &                              BOUNDARY(ng) % ad_t_obc(LBij:,:,:,:,&


### PR DESCRIPTION
# Description

This PR refactors the processing of 4D-Var open-boundary adjustments in input and output NetCDF files using the **PIO** NetCDF library.

- The **ioDesc** pointers for **PIO** are not needed in **ROMS** modules **`nf_fread2d_bry.F`**, **`nf_fread3d_bry.F`**, **`nf_fwrite2d_bry.F`**, and **`nf_fread3d_bry.F`** since we cannot use **PIO** library functions **`PIO_read_darray`** and **`PIO_write_darray`** because they only operate on distributed multidimensional arrays where all the processes have data. The open boundary arrays are sections of arrays that are serialized into a vector before being written to **NetCDF** files. That is, they cannot be processed in parallel. In this case, it will use the generic overloading functions in **`mod_pio_netcdf.F`**.
- In mixed-resolution 4D-Var, the extracted decimated, coarser background trajectory from the **NLM** kernel is written with the standard NetCDF library, but read by the **TLM** and **ADM** kernels with the **PIO** library.

## Issue(s) addressed

Fix the issues when **`ADJUST_BOUNDARY`** is activated with the **PIO** library. We can now run 4D-Var with the **PIO** library, which processes the input and output NetCDF files. In contrast, files such as boundary conditions, decimation, initial conditions, river runoff, and **IODA**-type observations are processed with the standard NetCDF library.

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR
- [x] I have run and tested the changes before creating the PR
