### PR TITLE
Updating for Spack-Stack 2.0 with LLVM Compilers

### DIFF
--- a/Compilers/compiler_flags_IntelLLVM_Fortran.cmake
+++ b/Compilers/compiler_flags_IntelLLVM_Fortran.cmake
@@ -1,0 +1,92 @@
+# git $Id$
+#:::::::::::::::::::::::::::::::::::::::::::::::::::::: David Robertson :::
+# Copyright (c) 2002-2025 The ROMS Group                                :::
+#   Licensed under a MIT/X style license                                :::
+#   See License_ROMS.md                                                 :::
+#::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+#
+# CMake Flags for the Intel-LLVM Fortran Compiler.
+
+###########################################################################
+# Set the name of the Fortran compiler based on FORT and USE_MPI
+###########################################################################
+
+if( MPI )
+  if( ${COMM} MATCHES "intel")
+    execute_process( COMMAND which mpiifort
+                     OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
+                     OUTPUT_STRIP_TRAILING_WHITESPACE )
+  else()
+    execute_process( COMMAND which mpif90
+                     OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
+                     OUTPUT_STRIP_TRAILING_WHITESPACE )
+  endif()
+else()
+  execute_process( COMMAND which ifort
+                   OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
+                   OUTPUT_STRIP_TRAILING_WHITESPACE )
+endif()
+
+###########################################################################
+# FLAGS COMMON TO ALL BUILD TYPES
+###########################################################################
+
+set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model precise" )
+
+###########################################################################
+# RELEASE FLAGS
+###########################################################################
+
+set( CMAKE_Fortran_FLAGS_RELEASE "-O3 -traceback" )
+
+###########################################################################
+# RELEASE WITH DEBUG INFORMATION FLAGS
+###########################################################################
+
+set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O3 -g -traceback -check all -check bounds" )
+
+###########################################################################
+# DEBUG FLAGS
+###########################################################################
+
+set( CMAKE_Fortran_FLAGS_DEBUG   "-g -check all -check bounds -traceback -warn interfaces,nouncalled -gen-interfaces" )
+
+###########################################################################
+# BIT REPRODUCIBLE FLAGS
+###########################################################################
+
+set( CMAKE_Fortran_FLAGS_BIT     "-O2" )
+
+###########################################################################
+# LINK FLAGS
+###########################################################################
+
+if( APPLE )
+  message( STATUS "MacOS so setting -Wl,-undefined dynamic_lookup linker flag" )
+  set( CMAKE_SHARED_LINKER_FLAGS    "-Wl,-undefined,dynamic_lookup" )
+endif()
+
+set( CMAKE_Fortran_LINK_FLAGS    "" )
+
+###########################################################################
+# ROMS Definitions
+###########################################################################
+
+# Special flags for files that may contain very long lines.
+
+set( ROMS_FREEFLAGS "-free" )
+
+# Special flag for if compiler is confused by "dimension(*)"
+
+set( ROMS_NOBOUNDSFLAG "" )
+
+# Special defines for "mod_strings.F"
+
+set( my_fort   "ifort" )
+set( my_fc     "${CMAKE_Fortran_COMPILER}" )
+
+# Flags for the C-preprocessor
+
+set( CPPFLAGS  "-P" "--traditional-cpp" "-w" )
+
+###########################################################################

--- a/Compilers/roms_compiler_flags.cmake
+++ b/Compilers/roms_compiler_flags.cmake
@@ -16,6 +16,8 @@ set( my_cpu    "${CMAKE_SYSTEM_PROCESSOR}" )
 
 if( CMAKE_Fortran_COMPILER_ID MATCHES "GNU" )
   include( compiler_flags_GNU_Fortran )
+elseif( CMAKE_Fortran_COMPILER_ID MATCHES "IntelLLVM" )
+  include( compiler_flags_IntelLLVM_Fortran )
 elseif( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
   include( compiler_flags_Intel_Fortran )
 else()

--- a/ROMS/Bin/cbuild_roms.csh
+++ b/ROMS/Bin/cbuild_roms.csh
@@ -436,6 +436,8 @@ endif
 if ( $?FORT ) then
   if ( "${FORT}" == "ifort" ) then
     set compiler="-DCMAKE_Fortran_COMPILER=ifort"
+  elif ( "${FORT}" == "ifx" ) then
+    set compiler="-DCMAKE_Fortran_COMPILER=ifort"
   else if ( "${FORT}" == "gfortran" ) then
     set compiler="-DCMAKE_Fortran_COMPILER=gfortran"
   else

--- a/ROMS/Bin/cbuild_roms.sh
+++ b/ROMS/Bin/cbuild_roms.sh
@@ -422,6 +422,8 @@ fi
 if [ ! -z "${FORT}" ]; then
   if [ ${FORT} == "ifort" ]; then
     compiler="-DCMAKE_Fortran_COMPILER=ifort"
+  elif [ ${FORT} == "ifx" ]; then
+    compiler="-DCMAKE_Fortran_COMPILER=ifx"
   elif [ ${FORT} == "gfortran" ]; then
     compiler="-DCMAKE_Fortran_COMPILER=gfortran"
   else


### PR DESCRIPTION
# Description

This PR updates the **ROMS CMake** files for **Spack-Stack 2.0** to use the latest version of the **Intel oneAPI** Toolkit, including the **LLVM**-based compiler infrastructure for **ifx** and **icx**, which are required by **ROMS-JEDI**.

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR
- [x] I have run and tested the changes before creating the PR
