### PR TITLE
Improved multi-file NetCDF file management

### DIFF
--- a/ROMS/Modules/mod_netcdf.F
+++ b/ROMS/Modules/mod_netcdf.F
@@ -8984,14 +8984,11 @@
         DO i=1,LEN(my_ncname)
           my_ncname(i:i)=' '
         END DO
-
+!
+!  Get filename, if any.
+!
         IF (.not.PRESENT(ncname)) THEN
-!
-!  Get filename, if any. It will be nice if there is a function in
-!  the NetCDF library to do this. Fortunately, the filename is
-!  written as a global attribute.
-!
-          status=nf90_get_att(ncid, nf90_global, 'file', my_ncname)
+          my_ncname='Unknown'
         ELSE
           my_ncname=TRIM(ncname)
         END IF

--- a/ROMS/Modules/mod_pio_netcdf.F
+++ b/ROMS/Modules/mod_pio_netcdf.F
@@ -8884,13 +8884,10 @@
           my_ncname(i:i)=' '
         END DO
 !
+!  Get filename, if any.
+!
         IF (.not.PRESENT(ncname)) THEN
-!
-!  Get filename, if any. It will be nice if there is a function in
-!  the NetCDF library to do this. Fortunately, the filename is
-!  written as a global attribute.
-!
-          status=PIO_get_att(pioFile, PIO_global, 'file', my_ncname)
+          my_ncname='Unknown'
         ELSE
           my_ncname=TRIM(ncname)
         END IF

--- a/ROMS/Nonlinear/lmd_swfrac.F
+++ b/ROMS/Nonlinear/lmd_swfrac.F
@@ -65,12 +65,12 @@
 !
 !-----------------------------------------------------------------------
 !  Use Paulson and Simpson (1977) two wavelength bands solar
-!  absorption model.
+!  absorption model. Jerlov water type, Jwtype, has values 1 to 9.
 !-----------------------------------------------------------------------
 !
       DO j=Jstr,Jend
         DO i=Istr,Iend
-          Jindex=INT(MIXING(ng)%Jwtype(i,j))
+          Jindex=MAX(1, MIN(INT(MIXING(ng)%Jwtype(i,j)), 9))
           fac1(i)=Zscale/lmd_mu1(Jindex)
           fac2(i)=Zscale/lmd_mu2(Jindex)
           fac3(i)=lmd_r1(Jindex)

--- a/ROMS/Utility/inquiry.F
+++ b/ROMS/Utility/inquiry.F
@@ -92,7 +92,7 @@
       logical :: foundit, got_var, got_time, special
 !
       integer :: Fcount, Nrec, Tid, Tindex, Trec, Vid, Vtype
-      integer :: i, ifile, lstr, my_ncid, nvatt, nvdim
+      integer :: i, ic, ifile, lstr, my_ncid, nvatt, nvdim
       integer :: Vsize(4)
 !
       real(dp) :: Clength, Tend, Tmax, Tmin, Tmono, Tscale, Tstr, Tval
@@ -100,7 +100,7 @@
 !
       character (len=1  ), parameter :: blank = ' '
       character (len=3  ) :: label
-      character (len=256) :: Fname
+      character (len=256) :: Fname, Pname
 
       character (len=*), parameter :: MyFile =                          &
      &  __FILE__//", inquiry_nf90"
@@ -136,6 +136,8 @@
       IF (Lmulti) THEN
         DO ifile=1,nfiles
           IF (TRIM(Cinfo(ifield,ng)).eq.TRIM(S(ifile)%name)) THEN
+            ic=S(ifile)%Fcount
+            Pname=TRIM(S(ifile)%files(ic))            ! previous file
             IF (job.gt.0) THEN
               Fcount=S(ifile)%Fcount+1
             ELSE
@@ -152,7 +154,7 @@
             END IF
             S(ifile)%Fcount=Fcount
             S(ifile)%name=TRIM(S(ifile)%files(Fcount))
-            CALL netcdf_close (ng, model, ncid)
+            CALL netcdf_close (ng, model, ncid, Pname, .FALSE.)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
             IF (label(1:3).eq.'FRC') THEN
               FRCids(ifile,ng)=-1
@@ -677,7 +679,7 @@
       logical :: foundit, got_var, got_time, special
 !
       integer :: Fcount, Nrec, Tindex, Trec, Vtype
-      integer :: i, ifile, lstr, nvatt, nvdim
+      integer :: i, ic, ifile, lstr, nvatt, nvdim
       integer :: Vsize(4)
 !
       real(dp) :: Clength, Tend, Tmax, Tmin, Tmono, Tscale, Tstr, Tval
@@ -685,7 +687,7 @@
 !
       character (len=1  ), parameter :: blank = ' '
       character (len=3  ) :: label
-      character (len=256) :: Fname
+      character (len=256) :: Fname, Pname
 
       character (len=*), parameter :: MyFile =                          &
      &  __FILE__//", inquiry_pio"
@@ -724,6 +726,8 @@
       IF (Lmulti) THEN
         DO ifile=1,nfiles
           IF (TRIM(Cinfo(ifield,ng)).eq.TRIM(S(ifile)%name)) THEN
+            ic=S(ifile)%Fcount
+            Pname=TRIM(S(ifile)%files(ic))            ! previous file
             IF (job.gt.0) THEN
               Fcount=S(ifile)%Fcount+1
             ELSE
@@ -740,7 +744,7 @@
             END IF
             S(ifile)%Fcount=Fcount
             S(ifile)%name=TRIM(S(ifile)%files(Fcount))
-            CALL pio_netcdf_close (ng, model, pioFile)
+            CALL pio_netcdf_close (ng, model, pioFile, Pname, .FALSE.)
             IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
             IF (label(1:3).eq.'FRC') THEN
               FRCdesc(ifile,ng)%fh=-1


### PR DESCRIPTION
# Description

This PR cleans up the logic in the **NetCDF** overloading in **ROMS** routines **`netcdf_close`** and **`pio_netcdf_close`** when the optional argument **ncname** is omitted.

- Previously, it was assumed that every multi-file included the **NetCDF** global attribute **`file`** containing its filename, which was used to report if errors occurred when closing a **NetCDF** file. As a result, **ROMS** sometimes hangs if the global attribute is missing.
``` f90
        IF (.not.PRESENT(ncname)) THEN
!
!  Get filename, if any. It will be nice if there is a function in
! the NetCDF library to do this. Fortunately, the filename is
! written as a global attribute.
!
          status=PIO_get_att(pioFile, PIO_global, 'file', my_ncname)
        ELSE
          my_ncname=TRIM(ncname)
        END IF
```
   Changed to:
``` f90
!
!  Get filename, if any.
!
        IF (.not.PRESENT(ncname)) THEN
          my_ncname='Unknown'
        ELSE
          my_ncname=TRIM(ncname)
        END IF
```
-  The **`inquiry.F`** module is changed to include the optional values to **`pio_netcdf_close`** call to avoid issues with uknow file reporting.
``` f90  
            ic=S(ifile)%Fcount
            Pname=TRIM(S(ifile)%files(ic))            ! previous file
            ...
            S(ifile)%Fcount=Fcount
            S(ifile)%name=TRIM(S(ifile)%files(Fcount))
            CALL pio_netcdf_close (ng, model, pioFile, Pname, .FALSE.)
```

- Corrected subroutine **`lmd_swfrac_tile`** to limit the variable **Jerlow** water indices between 1 and 9. Note land-masked values have a value of zero, resulting in the out-of-bounds value when **`Jindex=0`**.
``` f90
      DO j=Jstr,Jend
        DO i=Istr,Iend
          Jindex=MAX(1, MIN(INT(MIXING(ng)%Jwtype(i,j)), 9))
          fac1(i)=Zscale/lmd_mu1(Jindex)
          fac2(i)=Zscale/lmd_mu2(Jindex)
          fac3(i)=lmd_r1(Jindex)
        END DO
        DO i=Istr,Iend
          swdk(i,j)=EXP(Z(i,j)*fac1(i))*fac3(i)+                        &
     &              EXP(Z(i,j)*fac2(i))*(1.0_r8-fac3(i))
        END DO
      END DO
```
## Dependencies

None.

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR
- [x] I have run and tested the changes before creating the PR
