### PR TITLE
Corrected TLM/RPM/ADJ usage of gridded Jerlow water type

### DIFF
--- a/ROMS/Adjoint/ad_lmd_swfrac.F
+++ b/ROMS/Adjoint/ad_lmd_swfrac.F
@@ -79,12 +79,12 @@
 !
 !-----------------------------------------------------------------------
 !  Use Paulson and Simpson (1977) two wavelength bands solar
-!  absorption model.
+!  absorption model. Jerlov water type, Jwtype, has values 1 to 9.
 !-----------------------------------------------------------------------
 !
       DO j=Jstr,Jend
         DO i=Istr,Iend
-          Jindex=INT(MIXING(ng)%Jwtype(i,j))
+          Jindex=MAX(1, MIN(INT(MIXING(ng)%Jwtype(i,j)), 9))
           fac1(i)=Zscale/lmd_mu1(Jindex)
           fac2(i)=Zscale/lmd_mu2(Jindex)
           fac3(i)=lmd_r1(Jindex)

--- a/ROMS/Representer/rp_lmd_swfrac.F
+++ b/ROMS/Representer/rp_lmd_swfrac.F
@@ -72,12 +72,12 @@
 !
 !-----------------------------------------------------------------------
 !  Use Paulson and Simpson (1977) two wavelength bands solar
-!  absorption model.
+!  absorption model. Jerlov water type, Jwtype, has values 1 to 9.
 !-----------------------------------------------------------------------
 !
       DO j=Jstr,Jend
         DO i=Istr,Iend
-          Jindex=INT(MIXING(ng)%Jwtype(i,j))
+          Jindex=MAX(1, MIN(INT(MIXING(ng)%Jwtype(i,j)), 9))
           fac1(i)=Zscale/lmd_mu1(Jindex)
           fac2(i)=Zscale/lmd_mu2(Jindex)
           fac3(i)=lmd_r1(Jindex)

--- a/ROMS/Tangent/tl_lmd_swfrac.F
+++ b/ROMS/Tangent/tl_lmd_swfrac.F
@@ -72,12 +72,12 @@
 !
 !-----------------------------------------------------------------------
 !  Use Paulson and Simpson (1977) two wavelength bands solar
-!  absorption model.
+!  absorption model. Jerlov water type, Jwtype, has values 1 to 9.
 !-----------------------------------------------------------------------
 !
       DO j=Jstr,Jend
         DO i=Istr,Iend
-          Jindex=INT(MIXING(ng)%Jwtype(i,j))
+          Jindex=MAX(1, MIN(INT(MIXING(ng)%Jwtype(i,j)), 9))
           fac1(i)=Zscale/lmd_mu1(Jindex)
           fac2(i)=Zscale/lmd_mu2(Jindex)
           fac3(i)=lmd_r1(Jindex)

--- a/ROMS/Utility/read_phypar.F
+++ b/ROMS/Utility/read_phypar.F
@@ -740,8 +740,9 @@
               Npts=load_i(Nval, Rval, Ngrids, ndefXTR)
             CASE ('NQCK')
               Npts=load_i(Nval, Rval, Ngrids, nQCK)
-#if defined FORWARD_FLUXES && \
-   (defined BULK_FLUXES    || defined FRC_COUPLING)
+#if !(defined GRID_EXTRACT   && defined SPLIT_EXECUTABLE) && \
+      defined FORWARD_FLUXES && \
+     (defined BULK_FLUXES    || defined FRC_COUPLING)
               DO ng=1,Ngrids
                 IF (nQCK(ng).le.0) THEN
                   WRITE (text,'(a,i2.2,a)') 'nQCK(', ng, ') = '


### PR DESCRIPTION
# Description

- Corrected modules **`tl_lmd_swfrac.F`**, **`rp_lmd_swfrac.F`**, and **`ad_lmd_swfrac.F`** to limit the variable **Jerlow** water indices to the **1:9** range. Note land-masked values have a value of zero, resulting in the out-of-bounds value when **`Jindex=0`** for parameters for the reciprocal of the absorption coefficient for solar wavelength bands 1 and 2 (**lmd_mu1** and **lmd_mu2**, respectively) as a function of the Jerlov water type.

``` f90
      DO j=Jstr,Jend
        DO i=Istr,Iend
          Jindex=MAX(1, MIN(INT(MIXING(ng)%Jwtype(i,j)), 9))
          fac1(i)=Zscale/lmd_mu1(Jindex)
          fac2(i)=Zscale/lmd_mu2(Jindex)
          fac3(i)=lmd_r1(Jindex)
        END DO
        ...
```

## Dependencies

None.

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR
- [x] I have run and tested the changes before creating the PR
