### PR TITLE
Updating output land/sea masks

### DIFF
--- a/ROMS/Nonlinear/wetdry.F
+++ b/ROMS/Nonlinear/wetdry.F
@@ -290,14 +290,29 @@
             pmask_full(i,j)=MAX(pmask_wet(i,j)*pmask(i,j), 2.0_r8)
           END DO
         END DO
+!
+!  The umask_full and vmask_full arrays require a different rationale to
+!  properly address the normal component when LandFill=TRUE at output,
+!  which replace land values with _FillValue. 
+!
         DO j=JstrR,JendR
           DO i=Istr,IendR
-            umask_full(i,j)=umask_wet(i,j)*umask(i,j)
+            IF ((rmask_wet(i-1,j).eq.0.0_r8).or.                        &
+     &          (rmask_wet(i  ,j).eq.0.0_r8)) THEN
+              umask_full(i,j)=1.0_r8
+            ELSE
+              umask_full(i,j)=1.0_r8
+            END IF
           END DO
         END DO
         DO j=Jstr,JendR
           DO i=IstrR,IendR
-            vmask_full(i,j)=vmask_wet(i,j)*vmask(i,j)
+            IF ((rmask_wet(i,j-1).eq.0.0_r8).or.                        &
+     &          (rmask_wet(i,j  ).eq.0.0_r8)) THEN
+              vmask_full(i,j)=1.0_r8
+            ELSE
+              vmask_full(i,j)=1.0_r8
+            END IF
           END DO
         END DO
 !

--- a/ROMS/Utility/set_masks.F
+++ b/ROMS/Utility/set_masks.F
@@ -14,6 +14,12 @@
 !  are replaced by the _FillValue in the output files to  facilitate   !
 !  post-processing with generic tools.                                 !
 !                                                                      !
+!  Note the *_full masks are added to simplify logic in applications   !
+!  involving wetting and drying, including the time-independent and    !
+!  time-dependent parts of the mask. They are onlu used for output     !
+!  and umask_full and vmask_full require a different rationale to      !
+!  properly address the normal component when LandFill=TRUE.           !
+!                                                                      !
 !  If point sources, insure that masks at point source locations are   !
 !  set to water to avoid masking with _FillValue at those locations.   !
 # ifdef WET_DRY
@@ -203,14 +209,26 @@
           rmask_full(i,j)=rmask(i,j)
         END DO
       END DO
+!
+!  The U- and V-grid variables with LandFill=.TRUE. require a
+!  different rationale to properly address the normal component. 
+!
       DO j=JstrT,JendT
         DO i=IstrP,IendT
-          umask_full(i,j)=umask(i,j)
+          IF ((rmask(i-1,j).eq.0.0_r8).or.(rmask(i,j).eq.0.0_r8)) THEN
+            umask_full(i,j)=0.0_r8
+          ELSE
+            umask_full(i,j)=1.0_r8
+          END IF
         END DO
       END DO
       DO j=JstrP,JendT
         DO i=IstrT,IendT
-          vmask_full(i,j)=vmask(i,j)
+          IF ((rmask(i,j-1).eq.0.0_r8).or.(rmask(i,j).eq.0.0_r8)) THEN
+            vmask_full(i,j)=0.0_r8
+          ELSE
+            vmask_full(i,j)=1.0_r8
+          END IF
         END DO
       END DO
 !


### PR DESCRIPTION
# Description

**ROMS** uses several different land/sea masking arrays. The numerical kernels apply the constant, time-independent masks (**rmask**, **pmask**, **umask**, and **vmask**) at the staggered C-grid locations. The wetting and drying algorithm, activated with the **`WET_DRY`** option, apply the time-dependent masks (**rmask_wet**, **pmask_wet**, **umask_wet**, and **vmask_wet)**.  To simplify output, **ROMS** uses the **`full`** mask arrays (**rmask_full**, **pmask_full**, **umask_full**, and **vmask_full**), which combine the time-independent and time-dependent components of the mask.

This PR updates the **umask_full** and **vmask_full** arrays, requiring a different rationale to properly address the normal component at the land/sea interface. During output, the land is replaced with the **`_FillValue`** when the switch **`LandFill=TRUE`** is used to facilitate post-processing with generic tools.
``` f90
!
!  The U- and V-grid variables with LandFill=.TRUE. require a
!  different rationale to properly address the normal component.
!
      DO j=JstrT,JendT
        DO i=IstrP,IendT
          IF ((rmask(i-1,j).eq.0.0_r8).or.(rmask(i,j).eq.0.0_r8)) THEN
            umask_full(i,j)=0.0_r8
          ELSE
            umask_full(i,j)=1.0_r8
          END IF
        END DO
      END DO
      DO j=JstrP,JendT
        DO i=IstrT,IendT
          IF ((rmask(i,j-1).eq.0.0_r8).or.(rmask(i,j).eq.0.0_r8)) THEN
            vmask_full(i,j)=0.0_r8
          ELSE
            vmask_full(i,j)=1.0_r8
          END IF
        END DO
      END DO
```
Many thanks to Sasha Shchepetkin for bringing this issue to our attention.

## Impacts

None.

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR
- [x] I have run and tested the changes before creating the PR
