### PR TITLE
Updating PIO Output Files Synchronization and Compression

### DIFF
--- a/ROMS/Drivers/i4dvar.F
+++ b/ROMS/Drivers/i4dvar.F
@@ -108,7 +108,8 @@
       USE cgradient_mod,      ONLY : cg_read_cgradient
 # endif
       USE close_io_mod,       ONLY : close_file
-# if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
+# if defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90 || \
+     defined PIO_LIB     && defined DELAYED_SYNC_PIO
       USE close_io_mod,       ONLY : close_forward
 # endif
       USE cost_grad_mod,      ONLY : cost_grad
@@ -747,9 +748,10 @@
         END DO
       END IF
 
-# if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
+# if defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90 || \
+     defined PIO_LIB     && defined DELAYED_SYNC_PIO
 !
-!  If delayed PIO file synchronization is required to maximize
+!  If delayed NetCDF4 file synchronization is required to maximize
 !  performance, close forward trajectory and forward fluxes file
 !  to allow the ADM and TLM kernels to access them within the
 !  inner loops.

--- a/ROMS/Drivers/i4dvar.F
+++ b/ROMS/Drivers/i4dvar.F
@@ -108,6 +108,9 @@
       USE cgradient_mod,      ONLY : cg_read_cgradient
 # endif
       USE close_io_mod,       ONLY : close_file
+# if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
+      USE close_io_mod,       ONLY : close_forward
+# endif
       USE cost_grad_mod,      ONLY : cost_grad
       USE def_hessian_mod,    ONLY : def_hessian
 # ifdef SPLIT_4DVAR
@@ -743,6 +746,16 @@
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END DO
       END IF
+
+# if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
+!
+!  If delayed PIO file synchronization is required to maximize
+!  performance, close forward trajectory and forward fluxes file
+!  to allow the ADM and TLM kernels to access them within the
+!  inner loops.
+!
+       CALL close_forward
+# endif
 
 # ifdef PROFILE
 !

--- a/ROMS/Drivers/r4dvar.F
+++ b/ROMS/Drivers/r4dvar.F
@@ -74,7 +74,8 @@
 # ifdef STD_MODEL
       USE background_std_mod, ONLY : background_std
 # endif
-# if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
+# if defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90 || \
+     defined PIO_LIB     && defined DELAYED_SYNC_PIO
       USE close_io_mod,       ONLY : close_forward
 # endif
       USE close_io_mod,       ONLY : close_file
@@ -360,9 +361,10 @@
         wrtObsScale(ng)=.FALSE.
       END DO
 
-# if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
+# if defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90 || \
+     defined PIO_LIB     && defined DELAYED_SYNC_PIO
 !
-!  If delayed PIO file synchronization is required to maximize
+!  If delayed NetCDF4 file synchronization is required to maximize
 !  performance, close forward trajectory and forward fluxes file
 !  to allow the ADM and TLM kernels to access them within the
 !  inner loops.

--- a/ROMS/Drivers/r4dvar.F
+++ b/ROMS/Drivers/r4dvar.F
@@ -74,6 +74,9 @@
 # ifdef STD_MODEL
       USE background_std_mod, ONLY : background_std
 # endif
+# if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
+      USE close_io_mod,       ONLY : close_forward
+# endif
       USE close_io_mod,       ONLY : close_file
       USE congrad_mod,        ONLY : congrad
 # ifdef SPLIT_4DVAR
@@ -356,6 +359,16 @@
         wrtNLmod(ng)=.FALSE.
         wrtObsScale(ng)=.FALSE.
       END DO
+
+# if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
+!
+!  If delayed PIO file synchronization is required to maximize
+!  performance, close forward trajectory and forward fluxes file
+!  to allow the ADM and TLM kernels to access them within the
+!  inner loops.
+!
+       CALL close_forward
+# endif
 
 # ifdef PROFILE
 !

--- a/ROMS/Drivers/rbl4dvar.F
+++ b/ROMS/Drivers/rbl4dvar.F
@@ -104,7 +104,8 @@
 # ifdef STD_MODEL
       USE background_std_mod, ONLY : background_std
 # endif
-# if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
+# if defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90 || \
+     defined PIO_LIB     && defined DELAYED_SYNC_PIO
       USE close_io_mod,       ONLY : close_forward
 # endif
 # ifndef RPCG
@@ -609,9 +610,10 @@
         END DO
       END IF
 
-# if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
+# if defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90 || \
+     defined PIO_LIB     && defined DELAYED_SYNC_PIO
 !
-!  If delayed PIO file synchronization is required to maximize
+!  If delayed NetCDF4 file synchronization is required to maximize
 !  performance, close forward trajectory and forward fluxes file
 !  to allow the ADM and TLM kernels to access them within the
 !  inner loops.

--- a/ROMS/Drivers/rbl4dvar.F
+++ b/ROMS/Drivers/rbl4dvar.F
@@ -104,6 +104,9 @@
 # ifdef STD_MODEL
       USE background_std_mod, ONLY : background_std
 # endif
+# if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
+      USE close_io_mod,       ONLY : close_forward
+# endif
 # ifndef RPCG
       USE congrad_mod,        ONLY : congrad
 #  ifdef SPLIT_4DVAR
@@ -605,6 +608,15 @@
           FOURDVAR(ng)%NLPenalty=0.0_r8
         END DO
       END IF
+
+# if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
+!
+!  If delayed PIO file synchronization for maximize performance, close
+!  forward trajectory and forward fluxes file to allow the ADM and TLM
+!  kernels to access then within the inner loops.
+!
+       CALL close_forward
+# endif
 
 # ifdef PROFILE
 !

--- a/ROMS/Drivers/rbl4dvar.F
+++ b/ROMS/Drivers/rbl4dvar.F
@@ -611,9 +611,10 @@
 
 # if defined PIO_LIB && defined PIO_DELAYED_SYNC && defined DISTRIBUTE
 !
-!  If delayed PIO file synchronization for maximize performance, close
-!  forward trajectory and forward fluxes file to allow the ADM and TLM
-!  kernels to access then within the inner loops.
+!  If delayed PIO file synchronization is required to maximize
+!  performance, close forward trajectory and forward fluxes file
+!  to allow the ADM and TLM kernels to access them within the
+!  inner loops.
 !
        CALL close_forward
 # endif

--- a/ROMS/Include/cppdefs.h
+++ b/ROMS/Include/cppdefs.h
@@ -620,12 +620,14 @@
 ** CHECKSUM                to report checksum when processing I/O            **
 ** CHECK_OPEN_FILES        to report number opened/closed/created files      **
 ** DEFLATE                 to set compression NetCDF-4/HDF5 format files     **
-** HDF5                    to create NetCDF-4/HDF5 format files              **
+** DELAYED_SYNC_NF90       if delayed NetCDF4 sychronization, NF90 library   **
+** DELAYED_SYNC_PIO        if delayed NetCDF4 sychronization, PIO library    **
 ** METADATA_REPORT         to report/dump YAML metadata dictionary           **
 ** NO_LBC_ATT              to not check NLM_LBC global attribute on restart  **
 ** NO_READ_GHOST           to not include ghost points during read/scatter   **
 ** NO_WRITE_GRID           if not writing grid arrays                        **
 ** OUT_DOUBLE              if writing double precision output fields         **
+** OUT_NETCDF4             to create ouput NetCDF4/HDF5 format files         **
 ** OUTPUT_STATS            to report NetCDF output fields statistics         **
 ** PARALLEL_IO             if parallel I/O via HDF5 or pnetcdf libraries     **
 ** PERFECT_RESTART         to include perfect restart variables              **

--- a/ROMS/Modules/mod_netcdf.F
+++ b/ROMS/Modules/mod_netcdf.F
@@ -212,6 +212,8 @@
 !
 #if defined HDF5 || defined PARALLEL_IO
       integer :: CMODE = nf90_netcdf4      ! NetCDF-4/HDF5 format file
+#elif defined OUT_NETCDF4
+      integer :: CMODE = nf90_netcdf4      ! NetCDF-4/HDF5 format file
 #else
       integer :: CMODE = nf90_64bit_offset ! NetCDF 64-bit offset format
 !                                            (large file support)
@@ -9125,6 +9127,10 @@
 !  OR(nf90_clobber, nf90_netcdf4)=nf90_netcdf.  Therefore, the default
 !  is to overwrite an existing file on disk with the same file name.
 !  This is what we usually do anyway.
+!
+!  Note that deflation cannot be used in parallel I/O for writing data.
+!  This is because the compression makes it impossible for the HDF5
+!  library to exactly map the data to the disk location.
 !
       my_cmode=IOR(CMODE, nf90_mpiio)
       my_cmode=IOR(my_cmode, nf90_clobber)

--- a/ROMS/Modules/mod_netcdf.F
+++ b/ROMS/Modules/mod_netcdf.F
@@ -216,12 +216,6 @@
       integer :: CMODE = nf90_64bit_offset ! NetCDF 64-bit offset format
 !                                            (large file support)
 #endif
-!
-!  Set NetCDF-4/HDF5 deflate (file compression) parameters.
-!
-      integer :: shuffle = 1
-      integer :: deflate = 1
-      integer :: deflate_level = 1
 
 #ifdef PARALLEL_IO
 !

--- a/ROMS/Modules/mod_netcdf.F
+++ b/ROMS/Modules/mod_netcdf.F
@@ -379,7 +379,7 @@
       integer :: myID, myValue
 
 #if !defined PARALLEL_IO && defined DISTRIBUTE
-      integer, dimension(5) :: ibuffer
+      integer, dimension(6) :: ibuffer
 #endif
 !
       character (len=*), parameter :: MyFile =                          &
@@ -417,7 +417,7 @@
 !  Inquire file.
 !
       IF (InpThread) THEN
-#ifdef HDF5
+#ifdef OUT_NETCDF4
         status=nf90_inquire(my_ncid, n_dim, n_var, n_gatt, rec_id,      &
      &                      ncformat)
 #else
@@ -429,6 +429,7 @@
           ibuffer(2)=n_var
           ibuffer(3)=n_gatt
           ibuffer(4)=rec_id
+          ibuffer(5)=ncformat
 #endif
 !
 !  Inquire about dimensions: names, ID, and size.
@@ -448,7 +449,7 @@
             IF (dim_id(i).eq.rec_id) THEN
               rec_size=dim_size(i)
 #if !defined PARALLEL_IO && defined DISTRIBUTE
-              ibuffer(5)=rec_size
+              ibuffer(6)=rec_size
 #endif
             END IF
           END DO
@@ -477,7 +478,8 @@
         n_var=ibuffer(2)
         n_gatt=ibuffer(3)
         rec_id=ibuffer(4)
-        rec_size=ibuffer(5)
+        ncformat=ibuffer(5)
+        rec_size=ibuffer(6)
         CALL mp_bcasti (ng, model, dim_id)
         CALL mp_bcasti (ng, model, dim_size)
         CALL mp_bcasts (ng, model, dim_name)

--- a/ROMS/Modules/mod_pio_netcdf.F
+++ b/ROMS/Modules/mod_pio_netcdf.F
@@ -416,7 +416,7 @@
 !    PIO_iotype_netcdf4c => parallel read/serial write of NetCDF4 (HDF5)
 !    PIO_iotype_netcdf4p => parallel read/write of NETCDF4 (HDF5)
 !
-      integer pio_method
+      integer :: pio_method
 !
 !  PIO supported method names:
 !

--- a/ROMS/Modules/mod_scalars.F
+++ b/ROMS/Modules/mod_scalars.F
@@ -547,6 +547,13 @@
         logical, allocatable :: LwSrc(:)             ! mass
         logical, allocatable :: LtracerSrc(:,:)      ! tracers
 !
+!  Initialize NetCDF-4/HDF5 deflate (file compression) parameters. They
+!  overwritten with standard input values.
+!
+        integer :: shuffle = 1
+        integer :: deflate = 1
+        integer :: deflate_level = 1
+!
 !  Execution termination flag.
 !
 !    exit_flag = 0   No error

--- a/ROMS/Tangent/tl_get_data.F
+++ b/ROMS/Tangent/tl_get_data.F
@@ -1395,7 +1395,7 @@
      &                OCEAN(ng) % uG)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
-      CALL get_3dfld (ng, iRPM, idVvel, FWD(ng)%ncid,                   &
+      CALL get_3dfld (ng, iTLM, idVvel, FWD(ng)%ncid,                   &
 #   if defined PIO_LIB && defined DISTRIBUTE
      &                FWD(ng)%pioFile,                                  &
 #   endif

--- a/ROMS/Utility/checkdefs.F
+++ b/ROMS/Utility/checkdefs.F
@@ -2120,6 +2120,13 @@
       idriver=idriver+1
 #endif
 #if defined PIO_LIB && defined DISTRIBUTE
+# ifdef PIO_DELAYED_SYNC
+!
+      IF (Master) WRITE (stdout,20) 'PIO_DELAYED_SYNC',                  &
+     &   'Delaying file disk synchonization until calling PIO_closefile'
+      is=LEN_TRIM(Coptions)+1
+      Coptions(is:is+18)=' PIO_DELAYED_SYNC,'
+# endif
 !
       IF (Master) WRITE (stdout,20) 'PIO_LIB',                          &
      &   'Using Parallel-IO from the PIO library'

--- a/ROMS/Utility/checkdefs.F
+++ b/ROMS/Utility/checkdefs.F
@@ -975,7 +975,7 @@
       is=LEN_TRIM(Coptions)+1
       Coptions(is:is+17)=' DEEPWATER_WAVES,'
 #endif
-#if defined DEFLATE && defined HDF5
+#if defined DEFLATE && (PARALLEL_IO || defined PIO_LIB)
 !
       IF (Master) WRITE (stdout,20) 'DEFLATE',                          &
      &   'Setting compression in output NetCDF-4/HDF5 files'

--- a/ROMS/Utility/checkdefs.F
+++ b/ROMS/Utility/checkdefs.F
@@ -975,7 +975,7 @@
       is=LEN_TRIM(Coptions)+1
       Coptions(is:is+17)=' DEEPWATER_WAVES,'
 #endif
-#if defined DEFLATE && (PARALLEL_IO || defined PIO_LIB)
+#if defined DEFLATE && (defined PARALLEL_IO || defined PIO_LIB)
 !
       IF (Master) WRITE (stdout,20) 'DEFLATE',                          &
      &   'Setting compression in output NetCDF-4/HDF5 files'

--- a/ROMS/Utility/checkdefs.F
+++ b/ROMS/Utility/checkdefs.F
@@ -975,12 +975,27 @@
       is=LEN_TRIM(Coptions)+1
       Coptions(is:is+17)=' DEEPWATER_WAVES,'
 #endif
-#if defined DEFLATE && (defined PARALLEL_IO || defined PIO_LIB)
+#if defined DEFLATE && (defined OUT_NETCDF4 || defined PARALLEL_IO || \
+                        defined PIO_LIB)
 !
       IF (Master) WRITE (stdout,20) 'DEFLATE',                          &
      &   'Setting compression in output NetCDF-4/HDF5 files'
       is=LEN_TRIM(Coptions)+1
       Coptions(is:is+9)=' DEFLATE,'
+#endif
+#if defined DELAYED_SYNC_NF90 && defined OUT_NETCDF4
+!
+      IF (Master) WRITE (stdout,20) 'DELAYED_SYNC_NF90',                &
+     &   'Delaying file disk synchonization until calling nf90_close'
+      is=LEN_TRIM(Coptions)+1
+      Coptions(is:is+18)=' DELAYED_SYNC_NF90,'
+#endif
+#if defined DELAYED_SYNC_PIO && defined PIO_LIB
+!
+      IF (Master) WRITE (stdout,20) 'DELAYED_SYNC_PIO',                 &
+     &   'Delaying file disk synchonization until calling PIO_closefile'
+      is=LEN_TRIM(Coptions)+1
+      Coptions(is:is+18)=' DELAYED_SYNC_PIO,'
 #endif
 #if defined DENITRIFICATION && (defined BIO_FENNEL || defined ECB)
 !
@@ -2010,6 +2025,17 @@
       is=LEN_TRIM(Coptions)+1
       Coptions(is:is+12)=' OUT_DOUBLE,'
 #endif
+#ifdef OUT_NETCDF4
+!
+      IF (Master) WRITE (stdout,20) 'OUT_NETCDF4',                      &
+# ifdef DEFLATE
+     &   'Creating output compressed Netcdf4/HDF5 files'
+# else
+     &   'Creating output Netcdf4/HDF5 files'
+# endif
+      is=LEN_TRIM(Coptions)+1
+      Coptions(is:is+13)=' OUT_NETCDF4,'
+#endif
 #ifdef OUTPUT_STATS
 !
       IF (Master) WRITE (stdout,20) 'OUTPUT_STATS',                     &
@@ -2120,13 +2146,6 @@
       idriver=idriver+1
 #endif
 #if defined PIO_LIB && defined DISTRIBUTE
-# ifdef PIO_DELAYED_SYNC
-!
-      IF (Master) WRITE (stdout,20) 'PIO_DELAYED_SYNC',                  &
-     &   'Delaying file disk synchonization until calling PIO_closefile'
-      is=LEN_TRIM(Coptions)+1
-      Coptions(is:is+18)=' PIO_DELAYED_SYNC,'
-# endif
 !
       IF (Master) WRITE (stdout,20) 'PIO_LIB',                          &
      &   'Using Parallel-IO from the PIO library'

--- a/ROMS/Utility/close_io.F
+++ b/ROMS/Utility/close_io.F
@@ -33,6 +33,7 @@
       implicit none
 !
       PUBLIC :: close_file
+      PUBLIC :: close_forward
       PUBLIC :: close_inp
       PUBLIC :: close_out
 !
@@ -86,6 +87,69 @@
 !
       RETURN
       END SUBROUTINE close_file
+!
+!***********************************************************************
+      SUBROUTINE close_forward
+!***********************************************************************
+!
+!  Local variable declarations.
+!
+      logical :: Lupdate
+!
+      integer :: ng
+!
+      character (len=*), parameter :: MyFile =                          &
+     &  __FILE__//", close_inp"
+!
+      SourceFile=MyFile
+!
+!-----------------------------------------------------------------------
+!  When the split 4D-Var scheme is employed, it is necessary to close
+!  the background forward trajectory, forward fluxes, and quicksave
+!  files if delayed synchronization is enabled for the output NetCDF
+!  files processed by the PIO library. This approach maximizes
+!  performance by retaining data in memory. Subsequently, these files
+!  must be closed and synchronized to disk via PIO_closefile, which
+!  allows the ADM and TLM kernels to access them within the inner loops.
+!-----------------------------------------------------------------------
+!
+!  If appropriate, set switch for updating biology header file global
+!  attribute in output NetCDF files.
+!
+#ifdef BIOLOGY
+      Lupdate=.TRUE.
+#else
+      Lupdate=.FALSE.
+#endif
+!
+!  Close forward trajectory and fluxes files.
+
+      DO ng=1,Ngrids
+#if defined FORWARD_WRITE
+        IF (FWD(ng)%IOtype.eq.io_nf90) THEN
+          IF ((FWD(ng)%ncid.ne.-1).and.                                 &
+     &        (FWD(ng)%ncid.eq.HIS(ng)%ncid)) THEN
+            FWD(ng)%ncid=-1
+          END IF
+# if defined PIO_LIB && defined DISTRIBUTE
+        ELSE IF (FWD(ng)%IOtype.eq.io_pio) THEN
+          IF ((FWD(ng)%pioFile%fh.ne.-1).and.                           &
+     &        (FWD(ng)%pioFile%fh.eq.HIS(ng)%pioFile%fh)) THEN
+            FWD(ng)%pioFile%fh=-1
+          END IF
+# endif
+        END IF
+        CALL close_file (ng, iNLM, FWD(ng), FWD(ng)%name, Lupdate)
+#endif
+        CALL close_file (ng, iNLM, HIS(ng), HIS(ng)%name, Lupdate)
+        CALL close_file (ng, iNLM, QCK(ng), QCK(ng)%name, Lupdate)
+#ifdef AVERAGES
+        CALL close_file (ng, iNLM, AVG(ng), AVG(ng)%name, Lupdate)
+#endif
+      END DO
+!
+      RETURN
+      END SUBROUTINE close_forward
 !
 !***********************************************************************
       SUBROUTINE close_inp (ng, model)
@@ -232,6 +296,11 @@
 # endif
         END IF
         CALL close_file (ng, iNLM, FWD(ng), FWD(ng)%name, Lupdate)
+#endif
+        CALL close_file (ng, iNLM, RST(ng), RST(ng)%name, Lupdate)
+#if defined FOUR_DVAR || defined ENKF_RESTART || defined VERIFICATION
+        CALL close_file (ng, iNLM, DAI(ng), DAI(ng)%name, Lupdate)
+        CALL close_file (ng, iNLM, DAV(ng), DAV(ng)%name, Lupdate)
 #endif
         CALL close_file (ng, iNLM, HIS(ng), HIS(ng)%name, Lupdate)
         CALL close_file (ng, iNLM, QCK(ng), QCK(ng)%name, Lupdate)
@@ -465,5 +534,5 @@
 !
       RETURN
       END SUBROUTINE close_out
-
+!
       END MODULE close_io_mod

--- a/ROMS/Utility/close_io.F
+++ b/ROMS/Utility/close_io.F
@@ -149,6 +149,9 @@
 #ifdef DIAGNOSTICS
         CALL close_file (ng, iNLM, DIA(ng), DIA(ng)%name, Lupdate)
 #endif
+#ifdef GRID_EXTRACT
+        CALL close_file (ng, iNLM, XTR(ng), XTR(ng)%name, Lupdate)
+#endif
       END DO
 !
       RETURN
@@ -352,6 +355,9 @@
    (defined POSTERIOR_ERROR_F || defined POSTERIOR_ERROR_I)
         CALL close_file (ng, iTLM, ERR(ng), ERR(ng)%name, Lupdate)
 #endif
+#ifdef GRID_EXTRACT
+        CALL close_file (ng, iNLM, XTR(ng), XTR(ng)%name, Lupdate)
+#endif
 !
 !  Report number of time records written.
 !
@@ -426,6 +432,14 @@
           IF (associated(ERR(ng)%Nrec)) THEN
             IF (ANY(ERR(ng)%Nrec.gt.0)) THEN
               WRITE (stdout,20) 'ERROR  ', SUM(ERR(ng)%Nrec)
+            END IF
+          END IF
+#endif
+
+#ifdef GRID_EXTRACT
+          IF (associated(XTR(ng)%Nrec)) THEN
+            IF (ANY(XTR(ng)%Nrec.gt.0)) THEN
+              WRITE (stdout,20) 'EXTRACT', SUM(XTR(ng)%Nrec)
             END IF
           END IF
 #endif

--- a/ROMS/Utility/close_io.F
+++ b/ROMS/Utility/close_io.F
@@ -146,6 +146,9 @@
 #ifdef AVERAGES
         CALL close_file (ng, iNLM, AVG(ng), AVG(ng)%name, Lupdate)
 #endif
+#ifdef DIAGNOSTICS
+        CALL close_file (ng, iNLM, DIA(ng), DIA(ng)%name, Lupdate)
+#endif
       END DO
 !
       RETURN

--- a/ROMS/Utility/def_info.F
+++ b/ROMS/Utility/def_info.F
@@ -250,20 +250,19 @@
 !  Define NetCDF format type.
 !
         IF (exit_flag.eq.NoError) THEN
-# ifdef HDF5
-          status=nf90_put_att(ncid, nf90_global, 'format',              &
-     &                        'netCDF-4/HDF5 file')
-# else
-          status=nf90_put_att(ncid, nf90_global, 'format',              &
-     &                        'netCDF-3 64bit offset file')
-# endif
+          IF (CMODE.eq.nf90_netcdf4) THEN
+            status=nf90_put_att(ncid, nf90_global, 'format',            &
+     &                          'netCDF-4/HDF5 file')
+          ELSE IF (CMODE.eq.nf90_64bit_offset) THEN
+            status=nf90_put_att(ncid, nf90_global, 'format',            &
+     &                          'netCDF-3 64bit offset file')
+          END IF
           IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
             IF (Master) WRITE (stdout,20) 'format', TRIM(ncname)
             exit_flag=3
             ioerror=status
           END IF
         END IF
-
 #endif
 !
 !  Define file climate and forecast metadata convention global
@@ -3804,20 +3803,20 @@
 !  Define NetCDF format type.
 !
       IF (exit_flag.eq.NoError) THEN
-#  ifdef HDF5
+        SELECT CASE (pio_method)
+          CASE (1, 2)
+            type='netCDF-3 64bit offset file'
+          CASE (3, 4)
+            type='netCDF-4/HDF5 file'
+        END SELECT
         status=PIO_put_att(pioFile, PIO_global, 'format',               &
-     &                     'netCDF-4/HDF5 file')
-#  else
-        status=PIO_put_att(pioFile, PIO_global, 'format',               &
-     &                     'netCDF-3 64bit offset file')
-#  endif
+     &                     TRIM(type))
         IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
           IF (Master) WRITE (stdout,20) 'format', TRIM(ncname)
           exit_flag=3
           ioerror=status
         END IF
       END IF
-
 # endif
 !
 !  Define file climate and forecast metadata convention global

--- a/ROMS/Utility/def_ini.F
+++ b/ROMS/Utility/def_ini.F
@@ -151,6 +151,20 @@
       CALL netcdf_check_dim (ng, iNLM, ncname,                          &
      &                       ncid = INI(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+
+# ifdef OUT_NETCDF4
+!
+!  If writing output NetCDF4/HDF5 files, ensure that the INI(ng)%name
+!  is a NetCDF4/HDF5 file. Otherwise, ROMS I/O will fail because
+!  inconsistent file processing with library calls.
+!
+      IF (ncformat.ne.nf90_format_netcdf4) THEN
+        IF (Master) WRITE (stdout,20) ncformat, nf90_format_netcdf4,    &
+     &                                TRIM(ncname)
+        exit_flag=2
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      END IF
+# endif
 !
 !  Inquire about the variables.
 !
@@ -205,7 +219,7 @@
           INI(ng)%Vid(idUsms)=var_id(i)
           IF (var_ndim(i).ne.4) THEN
             IF (Master) THEN
-              WRITE (stdout,20) TRIM(Vname(1,idUsms)),                  &
+              WRITE (stdout,30) TRIM(Vname(1,idUsms)),                  &
      &                          var_ndim(i), 'frc_adjust',              &
      &                          TRIM(ncname)
             END IF
@@ -217,7 +231,7 @@
           INI(ng)%Vid(idVsms)=var_id(i)
           IF (var_ndim(i).ne.4) THEN
             IF (Master) THEN
-              WRITE (stdout,20) TRIM(Vname(1,idUsms)),                  &
+              WRITE (stdout,30) TRIM(Vname(1,idUsms)),                  &
      &                          var_ndim(i), 'frc_adjust',              &
      &                          TRIM(ncname)
             END IF
@@ -234,7 +248,7 @@
               INI(ng)%Vid(idTsur(itrc))=var_id(i)
               IF (var_ndim(i).ne.4) THEN
                 IF (Master) THEN
-                  WRITE (stdout,20) TRIM(Vname(1,idTsur(itrc))),        &
+                  WRITE (stdout,30) TRIM(Vname(1,idTsur(itrc))),        &
      &                              var_ndim(i), 'frc_adjust',          &
      &                              TRIM(ncname)
                  END IF
@@ -277,7 +291,7 @@
       IF (Ldefine) THEN
         CALL netcdf_redef (ng, iNLM, ncname, INI(ng)%ncid)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) THEN
-          IF (Master) WRITE (stdout,30) TRIM(ncname)
+          IF (Master) WRITE (stdout,40) TRIM(ncname)
           RETURN
         END IF
       END IF
@@ -638,6 +652,20 @@
         CALL netcdf_check_dim (ng, iNLM, ncname,                        &
      &                         ncid = INI(ng)%ncid)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+
+# ifdef OUT_NETCDF4
+!
+!  If writing output NetCDF4/HDF5 files, ensure that the INI(ng)%name
+!  is a NetCDF4/HDF5 file. Otherwise, ROMS I/O will fail because
+!  inconsistent file processing with library calls.
+!
+      IF (ncformat.ne.nf90_format_netcdf4) THEN
+        IF (Master) WRITE (stdout,20) ncformat, nf90_format_netcdf4,    &
+     &                                TRIM(ncname)
+        exit_flag=2
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      END IF
+# endif
 !
 !  Inquire about the variables.
 !
@@ -746,25 +774,25 @@
 !  file.
 !
         IF (.not.got_var(idtime)) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idtime)),          &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idtime)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
         END IF
         IF (.not.got_var(idFsur)) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idFsur)),          &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idFsur)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
         END IF
         IF (.not.got_var(idUbar)) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idUbar)),          &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idUbar)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
         END IF
         IF (.not.got_var(idVbar)) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idVbar)),          &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idVbar)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
@@ -772,21 +800,21 @@
 # if defined ADJUST_BOUNDARY && !defined RBL4DVAR_FCT_SENSITIVITY
         IF (.not.got_var(idSbry(isFsur)).and.                           &
      &      ANY(Lobc(:,isFsur,ng))) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idSbry(isFsur))),  &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idSbry(isFsur))),  &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
         END IF
         IF (.not.got_var(idSbry(isUbar)).and.                           &
      &      ANY(Lobc(:,isUbar,ng))) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idSbry(isUbar))),  &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idSbry(isUbar))),  &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
         END IF
         IF (.not.got_var(idSbry(isVbar)).and.                           &
      &      ANY(Lobc(:,isVbar,ng))) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idSbry(isVbar))),  &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idSbry(isVbar))),  &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
@@ -794,13 +822,13 @@
 # endif
 # ifdef ADJUST_WSTRESS
         IF (.not.got_var(idUsms)) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idUsms)),          &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idUsms)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
         END IF
         IF (.not.got_var(idVsms)) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idVsms)),          &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idVsms)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
@@ -808,13 +836,13 @@
 # endif
 # ifdef SOLVE3D
         IF (.not.got_var(idUvel)) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idUvel)),          &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idUvel)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
         END IF
         IF (.not.got_var(idVvel)) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idVvel)),          &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idVvel)),          &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
@@ -822,14 +850,14 @@
 #  if defined ADJUST_BOUNDARY && !defined RBL4DVAR_FCT_SENSITIVITY
         IF (.not.got_var(idSbry(isUvel)).and.                           &
      &      ANY(Lobc(:,isUvel,ng))) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idSbry(isUvel))),  &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idSbry(isUvel))),  &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
         END IF
         IF (.not.got_var(idSbry(isVvel)).and.                           &
      &      ANY(Lobc(:,isVvel,ng))) THEN
-          IF (Master) WRITE (stdout,40) TRIM(Vname(1,idSbry(isVvel))),  &
+          IF (Master) WRITE (stdout,50) TRIM(Vname(1,idSbry(isVvel))),  &
      &                                  TRIM(ncname)
           exit_flag=3
           RETURN
@@ -837,7 +865,7 @@
 #  endif
         DO itrc=1,NT(ng)
           IF (.not.got_var(idTvar(itrc))) THEN
-            IF (Master) WRITE (stdout,40) TRIM(Vname(1,idTvar(itrc))),  &
+            IF (Master) WRITE (stdout,50) TRIM(Vname(1,idTvar(itrc))),  &
      &                                    TRIM(ncname)
             exit_flag=3
             RETURN
@@ -845,7 +873,7 @@
 #  if defined ADJUST_BOUNDARY && !defined RBL4DVAR_FCT_SENSITIVITY
           IF (.not.got_var(idSbry(isTvar(itrc))).and.                   &
      &        ANY(Lobc(:,isTvar(itrc),ng))) THEN
-            IF (Master) WRITE (stdout,40)                               &
+            IF (Master) WRITE (stdout,50)                               &
      &                        TRIM(Vname(1,idSbry(isTvar(itrc)))),      &
      &                        TRIM(ncname)
             exit_flag=3
@@ -854,7 +882,7 @@
 #  endif
 #  ifdef ADJUST_STFLUX
           IF (.not.got_var(idTsur(itrc)).and.Lstflux(itrc,ng)) THEN
-            IF (Master) WRITE (stdout,40) TRIM(Vname(1,idTsur(itrc))),  &
+            IF (Master) WRITE (stdout,50) TRIM(Vname(1,idTsur(itrc))),  &
      &                                    TRIM(ncname)
             exit_flag=3
             RETURN
@@ -872,13 +900,16 @@
 !
   10  FORMAT (/,' DEF_INI_NF90 - unable to open initial NetCDF',        &
      &        ' file: ',a)
-  20  FORMAT (/,' DEF_INI_NF90 - illegal dimensions for variable : ',a, &
+  20  FORMAT (/,' DEF_INI_NF90 - inconsistent NetCDF file format: ',    &
+     &        'ncformat = ',i0,' instead of ',i0,/,16x,'infile: ',a,    &
+     &        /,16x,'A NetCDF4/HDF5 is needed for modifications')
+  30  FORMAT (/,' DEF_INI_NF90 - illegal dimensions for variable : ',a, &
      &        /,16x,'Nvardims = ',i0,', missing dimension: ''',a,'''',  &
      &        /,16x,'in file: ',a,                                      &
      &        /,16x,'Remove such variable from input file.')
-  30  FORMAT (/,' DEF_INI_NF90 - unable to put in define mode initial', &
+  40  FORMAT (/,' DEF_INI_NF90 - unable to put in define mode initial', &
      &        ' NetCDF file: ',a)
-  40  FORMAT (/,' DEF_INI_NF90 - unable to find variable: ',a,2x,       &
+  50  FORMAT (/,' DEF_INI_NF90 - unable to find variable: ',a,2x,       &
      &        ' in file: ',a)
 !
       RETURN

--- a/ROMS/Utility/def_var.F
+++ b/ROMS/Utility/def_var.F
@@ -172,13 +172,9 @@
           END IF
         END IF
 
-#if !defined PARALLEL_IO && (defined HDF5 && defined DEFLATE)
+#if defined DEFLATE && defined OUT_NETCDF4
 !
-!  Define deflate (file compression) parameters. Notice that deflation
-!  cannot be used in parallel I/O for writing data. This is because
-!  the compression makes it impossible for the HDF5 library to exactly
-!  map the data to the disk location. However, deflated data can be
-!  read with parallel I/O
+!  Define deflate (file compression) parameters.
 !
         IF (exit_flag.eq.NoError) THEN
           IF (LEN_TRIM(Vinfo(1)).gt.0) THEN

--- a/ROMS/Utility/def_var.F
+++ b/ROMS/Utility/def_var.F
@@ -174,7 +174,7 @@
 
 #if !defined PARALLEL_IO && (defined HDF5 && defined DEFLATE)
 !
-!  Define deflate (file compresion) parameters. Notice that deflation
+!  Define deflate (file compression) parameters. Notice that deflation
 !  cannot be used in parallel I/O for writing data. This is because
 !  the compression makes it impossible for the HDF5 library to exactly
 !  map the data to the disk location. However, deflated data can be
@@ -1187,7 +1187,7 @@
 
 # ifdef DEFLATE
 !
-!  Define deflate (file compresion) parameters. It is only possible for
+!  Define deflate (file compression) parameters. It is only possible for
 !  output NetCDF4/HD5 files (pio_method=3 or pio_method=4).
 !
       IF (exit_flag.eq.NoError) THEN

--- a/ROMS/Utility/def_var.F
+++ b/ROMS/Utility/def_var.F
@@ -83,6 +83,8 @@
       USE mod_ncparam
       USE mod_scalars
 !
+      USE strings_mod, ONLY : FoundError
+!
       implicit none
 !
       INTERFACE def_var
@@ -106,7 +108,6 @@
 #if !defined PARALLEL_IO  && defined DISTRIBUTE
       USE distribute_mod, ONLY : mp_bcasti
 #endif
-      USE strings_mod,    ONLY : FoundError
 !
 !  Imported variable declarations.
 !
@@ -1114,9 +1115,7 @@
      &                      SetFillVal, SetParAccess) RESULT (status)
 !***********************************************************************
 !
-      USE pio
-!
-      USE strings_mod, ONLY : FoundError
+      USE mod_pio_netcdf
 !
 !  Imported variable declarations.
 !
@@ -1185,6 +1184,28 @@
           END IF
         END IF
       END IF
+
+# ifdef DEFLATE
+!
+!  Define deflate (file compresion) parameters. It is only possible for
+!  output NetCDF4/HD5 files (pio_method=3 or pio_method=4).
+!
+      IF (exit_flag.eq.NoError) THEN
+        IF (LEN_TRIM(Vinfo(1)).gt.0) THEN
+          IF ((nVdim.gt.1).and.(Vdim(1).ne.0).and.                      &
+     &        (pio_method.gt.2)) THEN
+            status=PIO_def_var_deflate(pioFile, pioVar, shuffle,        &
+     &                                 deflate, deflate_level)
+            IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
+              IF (Master) WRITE (stdout,20) TRIM(Vinfo(1)),             &
+     &                                      TRIM(ncname)
+              exit_flag=3
+              ioerror=status
+            END IF
+          END IF
+        END IF
+      END IF
+# endif
 !
 !  Define special attributes for SGRID conventions variable "grid".
 !

--- a/ROMS/Utility/obs_write.F
+++ b/ROMS/Utility/obs_write.F
@@ -1769,6 +1769,8 @@
         wrtZetaRef(ng)=.FALSE.
       END IF
 # endif
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize observations NetCDF file to disk.
@@ -1778,13 +1780,14 @@
         CALL netcdf_sync (ng, model, DAV(ng)%name, DAV(ng)%ncid)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
-# ifdef SOLVE3D
+#  ifdef SOLVE3D
         IF (Nrun.eq.1) THEN
           CALL netcdf_sync (ng, model, OBS(ng)%name, OBS(ng)%ncid)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
-# endif
+#  endif
       END IF
+# endif
       IF (Master.and.(Mstr.eq.1)) WRITE (stdout,'(1x)')
 !
  10   FORMAT (2x,'OBS_WRITE_NF90   - procesing and writing, outer = ',  &
@@ -2268,6 +2271,8 @@
         wrtZetaRef(ng)=.FALSE.
       END IF
 #  endif
+
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize observations NetCDF file to disk.
@@ -2278,14 +2283,15 @@
      &                        DAV(ng)%pioFile)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
-#  ifdef SOLVE3D
+#   ifdef SOLVE3D
         IF (Nrun.eq.1) THEN
           CALL pio_netcdf_sync (ng, model, OBS(ng)%name,                &
      &                          OBS(ng)%pioFile)
           IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
         END IF
-#  endif
+#   endif
       END IF
+#  endif
       IF (Master.and.(Mstr.eq.1)) WRITE (stdout,'(1x)')
 !
  10   FORMAT (2x,'OBS_WRITE_PIO    - procesing and writing, outer = ',  &

--- a/ROMS/Utility/read_phypar.F
+++ b/ROMS/Utility/read_phypar.F
@@ -7633,7 +7633,7 @@
           WRITE (out,120) pio_rearr_I2C_PR, 'pio_rearr_I2C_PR',         &
      &          'Maximum I2C rearranger pending requests.'
 #endif
-#if defined HDF5 && defined DEFLATE
+#if defined DEFLATE && (defined PARALLEL_IO || defined PIO_LIB)
           WRITE (out,120) shuffle, 'shuffle',                           &
      &          'NetCDF-4/HDF5 file format shuffle filer flag.'
           WRITE (out,120) deflate, 'deflate',                           &

--- a/ROMS/Utility/stats_modobs.F
+++ b/ROMS/Utility/stats_modobs.F
@@ -785,11 +785,14 @@
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
       END IF
 # endif
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !  Synchronize NetCDF file to disk.
 !
       CALL netcdf_sync (ng, iNLM, DAV(ng)%name, DAV(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
 !  Reset "exit_flag" to its saved value when entering this routine.
 !
@@ -1480,11 +1483,13 @@
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
       END IF
 # endif
+# ifndef DELAYED_SYNC_PIO
 !
 !  Synchronize NetCDF file to disk.
 !
       CALL pio_netcdf_sync (ng, iNLM, DAV(ng)%name, DAV(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
 !  Reset "exit_flag" to its saved value when entering this routine.
 !

--- a/ROMS/Utility/wrt_aug_imp.F
+++ b/ROMS/Utility/wrt_aug_imp.F
@@ -266,6 +266,8 @@
         END IF
       END DO
 # endif
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize impulse NetCDF file to disk to allow other processes
@@ -274,6 +276,7 @@
 !
       CALL netcdf_sync (ng, model, TLF(ng)%name, TLF(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_AUG_IMP_NF90 - writing augmented adjoint',        &
      &        ' impulses, record: ',i0,/,22x,'file: ',a)
@@ -491,7 +494,8 @@
         END IF
       END DO
 #  endif
-#  ifndef PIO_DELAYED_SYNC
+
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize impulse NetCDF file to disk to allow other processes

--- a/ROMS/Utility/wrt_aug_imp.F
+++ b/ROMS/Utility/wrt_aug_imp.F
@@ -491,6 +491,7 @@
         END IF
       END DO
 #  endif
+#  ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize impulse NetCDF file to disk to allow other processes
@@ -499,6 +500,7 @@
 !
       CALL pio_netcdf_sync (ng, model, TLF(ng)%name, TLF(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#  endif
 !
   10  FORMAT (2x,'WRT_AUG_IMP_PIO  - writing augmented adjoint',        &
      &        ' impulses, record: ',i0,/,22x,'file: ',a)

--- a/ROMS/Utility/wrt_avg.F
+++ b/ROMS/Utility/wrt_avg.F
@@ -3817,6 +3817,8 @@
     &                   Aout, AVG)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #  endif
+
+#  ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize time-average NetCDF file to disk to allow other processes
@@ -3825,6 +3827,7 @@
 !
       CALL pio_netcdf_sync (ng, model, AVG(ng)%name, AVG(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#  endif
 !
   10  FORMAT (2x,'WRT_AVG_PIO      - writing averaged',t42,'fields',t61,&
 #  ifdef NESTING

--- a/ROMS/Utility/wrt_avg.F
+++ b/ROMS/Utility/wrt_avg.F
@@ -1805,6 +1805,8 @@
     &                    Aout, AVG)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize time-average NetCDF file to disk to allow other processes
@@ -1813,6 +1815,7 @@
 !
       CALL netcdf_sync (ng, model, AVG(ng)%name, AVG(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_AVG_NF90     - writing averaged',t42,'fields',t61,&
 # ifdef NESTING
@@ -3818,7 +3821,7 @@
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #  endif
 
-#  ifndef PIO_DELAYED_SYNC
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize time-average NetCDF file to disk to allow other processes

--- a/ROMS/Utility/wrt_dai.F
+++ b/ROMS/Utility/wrt_dai.F
@@ -499,6 +499,8 @@
       END IF
 #  endif
 # endif
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize restart NetCDF file to disk.
@@ -506,6 +508,7 @@
 !
       CALL netcdf_sync (ng, iNLM, DAI(ng)%name, DAI(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_DAI_NF90     - writing DA INI/RST', t42,          &
 # ifdef SOLVE3D
@@ -1017,7 +1020,8 @@
       END IF
 #   endif
 #  endif
-#  ifndef PIO_DELAYED_SYNC
+
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize restart NetCDF file to disk.

--- a/ROMS/Utility/wrt_dai.F
+++ b/ROMS/Utility/wrt_dai.F
@@ -1017,6 +1017,7 @@
       END IF
 #   endif
 #  endif
+#  ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize restart NetCDF file to disk.
@@ -1024,6 +1025,7 @@
 !
       CALL pio_netcdf_sync (ng, iNLM, DAI(ng)%name, DAI(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#  endif
 !
   10  FORMAT (2x,'WRT_DAI_PIO      - writing DA INI/RST', t42,          &
 #  ifdef SOLVE3D

--- a/ROMS/Utility/wrt_diags.F
+++ b/ROMS/Utility/wrt_diags.F
@@ -438,12 +438,17 @@
       END DO
 #  endif
 # endif
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
+!-----------------------------------------------------------------------
 !  Synchronize time-average NetCDF file to disk to allow other processes
 !  to access data immediately after it is written.
+!-----------------------------------------------------------------------
 !
       CALL netcdf_sync (ng, iNLM, DIA(ng)%name, DIA(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_DIAGS_NF90   - writing diagnostics fields',t61,   &
 # ifdef NESTING
@@ -848,7 +853,8 @@
       END DO
 #   endif
 #  endif
-#  ifndef PIO_DELAYED_SYNC
+
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize time-average NetCDF file to disk to allow other processes

--- a/ROMS/Utility/wrt_diags.F
+++ b/ROMS/Utility/wrt_diags.F
@@ -848,12 +848,16 @@
       END DO
 #   endif
 #  endif
+#  ifndef PIO_DELAYED_SYNC
 !
+!-----------------------------------------------------------------------
 !  Synchronize time-average NetCDF file to disk to allow other processes
 !  to access data immediately after it is written.
+!-----------------------------------------------------------------------
 !
       CALL pio_netcdf_sync (ng, iNLM, DIA(ng)%name, DIA(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#  endif
 !
   10  FORMAT (2x,'WRT_DIAGS_PIO    - writing diagnostics fields',t61,   &
 #  ifdef NESTING

--- a/ROMS/Utility/wrt_error.F
+++ b/ROMS/Utility/wrt_error.F
@@ -1124,6 +1124,7 @@
         RETURN
       END IF
 #  endif
+#  ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize posterior error covariance NetCDF file to disk to allow
@@ -1132,6 +1133,7 @@
 !
       CALL pio_netcdf_sync (ng, iTLM, ERR(ng)%name, ERR(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#  endif
 !
   10  FORMAT (2x,'WRT_ERROR_PIO    - writing error', t42,               &
 #  ifdef SOLVE3D

--- a/ROMS/Utility/wrt_error.F
+++ b/ROMS/Utility/wrt_error.F
@@ -575,6 +575,8 @@
         RETURN
       END IF
 # endif
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize posterior error covariance NetCDF file to disk to allow
@@ -583,6 +585,7 @@
 !
       CALL netcdf_sync (ng, iTLM, ERR(ng)%name, ERR(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_ERROR_NF90   - writing error', t42,               &
 #  ifdef SOLVE3D
@@ -1124,7 +1127,8 @@
         RETURN
       END IF
 #  endif
-#  ifndef PIO_DELAYED_SYNC
+
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize posterior error covariance NetCDF file to disk to allow

--- a/ROMS/Utility/wrt_evolved.F
+++ b/ROMS/Utility/wrt_evolved.F
@@ -548,6 +548,8 @@
         RETURN
       END IF
 # endif
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize evolved vectors NetCDF file to disk to allow other
@@ -556,6 +558,7 @@
 !
       CALL netcdf_sync (ng, iADM, LZE(ng)%name, LZE(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_EVOLVED_NF90 - writing evolved LCZ',t42,          &
 # ifdef SOLVE3D
@@ -1077,7 +1080,8 @@
         RETURN
       END IF
 #  endif
-#  ifndef PIO_DELAYED_SYNC
+
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize evolved vectors NetCDF file to disk to allow other

--- a/ROMS/Utility/wrt_evolved.F
+++ b/ROMS/Utility/wrt_evolved.F
@@ -1077,6 +1077,7 @@
         RETURN
       END IF
 #  endif
+#  ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize evolved vectors NetCDF file to disk to allow other
@@ -1085,6 +1086,7 @@
 !
       CALL pio_netcdf_sync (ng, iADM, LZE(ng)%name, LZE(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#  endif
 !
   10  FORMAT (2x,'WRT_EVOLVED_PIO  - writing evolved LCZ',t42,          &
 #  ifdef SOLVE3D

--- a/ROMS/Utility/wrt_extract.F
+++ b/ROMS/Utility/wrt_extract.F
@@ -4436,6 +4436,7 @@
     &                   Hout, XTR)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #  endif
+#  ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize decimate NetCDF file to disk to allow other processes
@@ -4444,6 +4445,7 @@
 !
       CALL pio_netcdf_sync (ng, model, XTR(ng)%name, XTR(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#  endif
 !
   10  FORMAT (2x,'WRT_EXTRACT_PIO  - writing extract', t42,             &
 #  ifdef SOLVE3D

--- a/ROMS/Utility/wrt_extract.F
+++ b/ROMS/Utility/wrt_extract.F
@@ -2128,6 +2128,8 @@
     &                    Hout, XTR)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize decimate NetCDF file to disk to allow other processes
@@ -2136,6 +2138,7 @@
 !
       CALL netcdf_sync (ng, model, XTR(ng)%name, XTR(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_EXTRACT_NF90 - writing decimate', t42,            &
 # ifdef SOLVE3D
@@ -4436,7 +4439,8 @@
     &                   Hout, XTR)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #  endif
-#  ifndef PIO_DELAYED_SYNC
+
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize decimate NetCDF file to disk to allow other processes

--- a/ROMS/Utility/wrt_floats.F
+++ b/ROMS/Utility/wrt_floats.F
@@ -330,12 +330,16 @@
      &                      varid = FLT(ng)%Vid(idwsin))
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize floats NetCDF file to disk.
 !-----------------------------------------------------------------------
 !
       CALL netcdf_sync (ng, iNLM, FLT(ng)%name, FLT(ng)%ncid)
+      IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
       RETURN
       END SUBROUTINE wrt_floats_nf90
@@ -614,13 +618,15 @@
      &                          pioVar = FLT(ng)%pioVar(idwsin)%vd)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #  endif
-#  ifndef PIO_DELAYED_SYNC
+
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize floats NetCDF file to disk.
 !-----------------------------------------------------------------------
 !
       CALL pio_netcdf_sync (ng, iNLM, FLT(ng)%name, FLT(ng)%pioFile)
+      IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #  endif
 !
       RETURN

--- a/ROMS/Utility/wrt_floats.F
+++ b/ROMS/Utility/wrt_floats.F
@@ -614,12 +614,14 @@
      &                          pioVar = FLT(ng)%pioVar(idwsin)%vd)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #  endif
+#  ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize floats NetCDF file to disk.
 !-----------------------------------------------------------------------
 !
       CALL pio_netcdf_sync (ng, iNLM, FLT(ng)%name, FLT(ng)%pioFile)
+#  endif
 !
       RETURN
       END SUBROUTINE wrt_floats_pio

--- a/ROMS/Utility/wrt_gst.F
+++ b/ROMS/Utility/wrt_gst.F
@@ -306,6 +306,8 @@
      &                      SworkL(:,ng), (/1/), (/LworkL/),            &
      &                      ncid = GST(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize GST checkpointing NetCDF file to disk so the file
@@ -314,6 +316,7 @@
 !
       CALL netcdf_sync (ng, model, GST(ng)%name, GST(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_GST_NF90     - writing GST checkpointing fields', &
      &        ' at iteration: ', i0)
@@ -593,7 +596,7 @@
      &                          pioFile = GST(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
-#  ifndef PIO_DELAYED_SYNC
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize GST checkpointing NetCDF file to disk so the file

--- a/ROMS/Utility/wrt_gst.F
+++ b/ROMS/Utility/wrt_gst.F
@@ -592,6 +592,8 @@
      &                          SworkL(:,ng), (/1/), (/LworkL/),        &
      &                          pioFile = GST(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+
+#  ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize GST checkpointing NetCDF file to disk so the file
@@ -600,6 +602,7 @@
 !
       CALL pio_netcdf_sync (ng, model, GST(ng)%name, GST(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#  endif
 !
   10  FORMAT (2x,'WRT_GST_PIO      - writing GST checkpointing fields', &
      &        ' at iteration: ', i0)

--- a/ROMS/Utility/wrt_hessian.F
+++ b/ROMS/Utility/wrt_hessian.F
@@ -555,6 +555,7 @@
         RETURN
       END IF
 # endif
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize Hessian eigenvectors NetCDF file to disk to allow other
@@ -563,6 +564,7 @@
 !
       CALL netcdf_sync (ng, iADM, HSS(ng)%name, HSS(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_HESSIAN_NF90 - writing Hessian', t42,             &
 # ifdef SOLVE3D
@@ -1080,7 +1082,7 @@
         RETURN
       END IF
 #  endif
-#  ifndef PIO_DELAYED_SYNC
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize Hessian eigenvectors NetCDF file to disk to allow other

--- a/ROMS/Utility/wrt_hessian.F
+++ b/ROMS/Utility/wrt_hessian.F
@@ -1080,6 +1080,7 @@
         RETURN
       END IF
 #  endif
+#  ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize Hessian eigenvectors NetCDF file to disk to allow other
@@ -1088,6 +1089,7 @@
 !
       CALL pio_netcdf_sync (ng, iADM, HSS(ng)%name, HSS(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#  endif
 !
   10  FORMAT (2x,'WRT_HESSIAN_PIO  - writing Hessian', t42,            &
 #  ifdef SOLVE3D

--- a/ROMS/Utility/wrt_his.F
+++ b/ROMS/Utility/wrt_his.F
@@ -4969,6 +4969,7 @@
     &                   Hout, HIS)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
+# ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize history NetCDF file to disk to allow other processes
@@ -4977,6 +4978,7 @@
 !
       CALL pio_netcdf_sync (ng, model, HIS(ng)%name, HIS(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_HIS_PIO      - writing history', t42,             &
 # ifdef SOLVE3D

--- a/ROMS/Utility/wrt_his.F
+++ b/ROMS/Utility/wrt_his.F
@@ -2356,6 +2356,8 @@
     &                    Hout, HIS)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #endif
+
+#if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize history NetCDF file to disk to allow other processes
@@ -2364,6 +2366,7 @@
 !
       CALL netcdf_sync (ng, model, HIS(ng)%name, HIS(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#endif
 !
   10  FORMAT (2x,'WRT_HIS_NF90     - writing history', t42,             &
 #ifdef SOLVE3D
@@ -4969,7 +4972,8 @@
     &                   Hout, HIS)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
-# ifndef PIO_DELAYED_SYNC
+
+# ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize history NetCDF file to disk to allow other processes

--- a/ROMS/Utility/wrt_impulse.F
+++ b/ROMS/Utility/wrt_impulse.F
@@ -1249,6 +1249,8 @@
         WRITE (stdout,70) TRIM(INPncname)
         RETURN
       END IF
+
+#  ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize impulse NetCDF file to disk to allow other processes
@@ -1257,6 +1259,7 @@
 !
       CALL pio_netcdf_sync (ng, model, INPncname, TLF(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#  endif
 !
   10  FORMAT (2x,'WRT_IMPULSE_PIO  - processing convolved adjoint',     &
      &        ' impulses, records: 1 to ',i0,/,21x,'file: ',a)

--- a/ROMS/Utility/wrt_impulse.F
+++ b/ROMS/Utility/wrt_impulse.F
@@ -611,6 +611,8 @@
         WRITE (stdout,70) TRIM(INPncname)
         RETURN
       END IF
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize impulse NetCDF file to disk to allow other processes
@@ -619,6 +621,7 @@
 !
       CALL netcdf_sync (ng, model, INPncname, TLF(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_IMPULSE_NF90 - processing convolved adjoint',     &
      &        ' impulses, records: 1 to ',i0,/,21x,'file: ',a)
@@ -1250,7 +1253,7 @@
         RETURN
       END IF
 
-#  ifndef PIO_DELAYED_SYNC
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize impulse NetCDF file to disk to allow other processes

--- a/ROMS/Utility/wrt_info.F
+++ b/ROMS/Utility/wrt_info.F
@@ -6165,6 +6165,8 @@
         END IF
 # endif
       END IF GRID_VARS
+
+# ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize NetCDF file to disk to allow other processes to access
@@ -6173,6 +6175,7 @@
 !
       CALL pio_netcdf_sync (ng, model, ncname, pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (/,' WRT_INFO_PIO - error while writing variable: ',a,/,   &
      &        16x,'into file: ',a)

--- a/ROMS/Utility/wrt_info.F
+++ b/ROMS/Utility/wrt_info.F
@@ -3391,6 +3391,8 @@
         END IF
 #endif
       END IF GRID_VARS
+
+#if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize NetCDF file to disk to allow other processes to access
@@ -3399,7 +3401,7 @@
 !
       CALL netcdf_sync (ng, model, ncname, ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-
+#endif
 #if !defined PARALLEL_IO  && defined DISTRIBUTE
 !
 !  Broadcast error flags to all processors in the group.
@@ -6166,7 +6168,7 @@
 # endif
       END IF GRID_VARS
 
-# ifndef PIO_DELAYED_SYNC
+# ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize NetCDF file to disk to allow other processes to access

--- a/ROMS/Utility/wrt_ini.F
+++ b/ROMS/Utility/wrt_ini.F
@@ -516,6 +516,7 @@
 #   endif
 #  endif
 # endif
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize initial NetCDF file to disk to allow other processes
@@ -524,6 +525,7 @@
 !
       CALL netcdf_sync (ng, iNLM, INI(ng)%name, INI(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (/,' WRT_INI_NF90 - error while writing variable: ',a,     &
      &        /,16x,'into initial NetCDF file for time record: ',i0)
@@ -980,7 +982,7 @@
 #    endif
 #   endif
 #  endif
-#  ifndef PIO_DELAYED_SYNC
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize initial NetCDF file to disk to allow other processes

--- a/ROMS/Utility/wrt_ini.F
+++ b/ROMS/Utility/wrt_ini.F
@@ -980,6 +980,7 @@
 #    endif
 #   endif
 #  endif
+#  ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize initial NetCDF file to disk to allow other processes
@@ -988,6 +989,7 @@
 !
       CALL pio_netcdf_sync (ng, iNLM, INI(ng)%name, INI(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#  endif
 !
   10  FORMAT (/,' WRT_INI_PIO - error while writing variable: ',a,      &
      &        /,15x,'into initial NetCDF file for time record: ',i0)

--- a/ROMS/Utility/wrt_quick.F
+++ b/ROMS/Utility/wrt_quick.F
@@ -4001,6 +4001,7 @@
     &                   Qout, QCK)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
+# ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize quicksave NetCDF file to disk to allow other processes
@@ -4009,6 +4010,7 @@
 !
       CALL pio_netcdf_sync (ng, model, QCK(ng)%name, QCK(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_QUICK_PIO    - writing quicksave', t42,           &
 # ifdef SOLVE3D

--- a/ROMS/Utility/wrt_quick.F
+++ b/ROMS/Utility/wrt_quick.F
@@ -1887,6 +1887,7 @@
     &                    Qout, QCK)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #endif
+#if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize quicksave NetCDF file to disk to allow other processes
@@ -1895,6 +1896,7 @@
 !
       CALL netcdf_sync (ng, model, QCK(ng)%name, QCK(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#endif
 !
   10  FORMAT (2x,'WRT_QUICK_NF90   - writing quicksave', t42,           &
 #ifdef SOLVE3D
@@ -4001,7 +4003,7 @@
     &                   Qout, QCK)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
-# ifndef PIO_DELAYED_SYNC
+# ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize quicksave NetCDF file to disk to allow other processes

--- a/ROMS/Utility/wrt_rst.F
+++ b/ROMS/Utility/wrt_rst.F
@@ -2549,6 +2549,7 @@
      &                    Hout, RST)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
+# ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize restart NetCDF file to disk.
@@ -2556,6 +2557,7 @@
 !
       CALL pio_netcdf_sync (ng, model, RST(ng)%name, RST(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_RST_PIO      - writing re-start', t42,            &
 # ifdef SOLVE3D

--- a/ROMS/Utility/wrt_rst.F
+++ b/ROMS/Utility/wrt_rst.F
@@ -1203,6 +1203,7 @@
      &                     Hout, RST)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #endif
+#if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize restart NetCDF file to disk.
@@ -1210,6 +1211,7 @@
 !
       CALL netcdf_sync (ng, model, RST(ng)%name, RST(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#endif
 !
   10  FORMAT (2x,'WRT_RST_NF90     - writing re-start', t42,            &
 #ifdef SOLVE3D
@@ -2549,7 +2551,7 @@
      &                    Hout, RST)
         IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
-# ifndef PIO_DELAYED_SYNC
+# ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize restart NetCDF file to disk.

--- a/ROMS/Utility/wrt_station.F
+++ b/ROMS/Utility/wrt_station.F
@@ -1984,13 +1984,17 @@
     &                           Sout, STA)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #  endif
+
+#  ifndef PIO_DELAYED_SYNC
+
 !
 !-----------------------------------------------------------------------
 !  Synchronize stations NetCDF file to disk.
 !-----------------------------------------------------------------------
 !
       CALL pio_netcdf_sync (ng, model, STA(ng)%name, STA(ng)%pioFile)
-
+#  endif
+!
       RETURN
       END SUBROUTINE wrt_station_pio
 # endif

--- a/ROMS/Utility/wrt_station.F
+++ b/ROMS/Utility/wrt_station.F
@@ -1033,13 +1033,16 @@
     &                            Sout, STA)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 # endif
+
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize stations NetCDF file to disk.
 !-----------------------------------------------------------------------
 !
       CALL netcdf_sync (ng, model, STA(ng)%name, STA(ng)%ncid)
-
+# endif
+!
       RETURN
       END SUBROUTINE wrt_station_nf90
 
@@ -1985,8 +1988,7 @@
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 #  endif
 
-#  ifndef PIO_DELAYED_SYNC
-
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize stations NetCDF file to disk.

--- a/ROMS/Utility/wrt_std.F
+++ b/ROMS/Utility/wrt_std.F
@@ -295,6 +295,7 @@
         END IF
       END DO
 # endif
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize Background standard deviation NetCDF file to disk to
@@ -303,6 +304,7 @@
 !
       CALL netcdf_sync (ng, iNLM, STD(5,ng)%name, STD(5,ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_STD_NF90     - writing standard deviation', t42,  &
 #  ifdef SOLVE3D
@@ -561,7 +563,7 @@
         END IF
       END DO
 #  endif
-#  ifndef PIO_DELAYED_SYNC
+#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize Background standard deviation NetCDF file to disk to

--- a/ROMS/Utility/wrt_std.F
+++ b/ROMS/Utility/wrt_std.F
@@ -561,6 +561,7 @@
         END IF
       END DO
 #  endif
+#  ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize Background standard deviation NetCDF file to disk to
@@ -570,6 +571,7 @@
       CALL pio_netcdf_sync (ng, iNLM, STD(5,ng)%name,                   &
      &                      STD(5,ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+#  endif
 !
   10  FORMAT (2x,'WRT_STD_PIO      - writing standard deviation', t42,  &
 #  ifdef SOLVE3D

--- a/ROMS/Utility/wrt_tides.F
+++ b/ROMS/Utility/wrt_tides.F
@@ -664,6 +664,7 @@
         END IF
       END DO
 # endif
+# ifndef PIO_DELAYED_SYNC
 !
 !-----------------------------------------------------------------------
 !  Synchronize tide forcing NetCDF file to disk to allow other processes
@@ -672,6 +673,7 @@
 !
       CALL pio_netcdf_sync (ng, iNLM, HAR(ng)%name, HAR(ng)%pioFile)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_TIDES_PIO    - writing time-accumulated tide ',   &
      &        'harmonics, Grid ',i2.2)

--- a/ROMS/Utility/wrt_tides.F
+++ b/ROMS/Utility/wrt_tides.F
@@ -349,6 +349,7 @@
         END IF
       END DO
 # endif
+# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
 !  Synchronize tide forcing NetCDF file to disk to allow other processes
@@ -357,6 +358,7 @@
 !
       CALL netcdf_sync (ng, iNLM, HAR(ng)%name, HAR(ng)%ncid)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+# endif
 !
   10  FORMAT (2x,'WRT_TIDES_NF90   - writing time-accumulated tide ',   &
      &        'harmonics, Grid ',i2.2)
@@ -664,7 +666,7 @@
         END IF
       END DO
 # endif
-# ifndef PIO_DELAYED_SYNC
+# ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
 !  Synchronize tide forcing NetCDF file to disk to allow other processes


### PR DESCRIPTION
# Description

This PR outdates how **ROMS** output **NetCDF4/HDF5** files using the **PIO** library are synchronized to disk. It also implements file compression with the **PIO** library. Please review the following [documentation](https://github.com/myroms/roms/wiki/ROMS-Parallel-IO) on configuring **PIO** in **ROMS**.

- It is only relevant for options **`PIO_METHOD=3`** (Parallel read and serial write of compressed **NetCDF4** files) or **`PIO_METHOD=4`** (parallel read and parallel write of compressed **NetCDF4** files).
> [!CAUTION]
> If a program terminates abnormally before calling **`PIO_closefile`**, as discussed below, the data in the buffer may be lost.

- A new **CPP** option **`DELAYED_SYNC_PIO`** is introduced to avoid synchronization during writing of each time record into output **NetCDF4** files. The reason why **PIO** and **NetCDF4** do not synchronize data (**I/O** buffering and caching) to disk until the file is closed is primarily to maximize performance by keeping data in memory. However, the output files keep growing because **NetCDF-4** and **HDF5**  libraries determine when to flush buffers internally. Writing to disk is **slow**; buffering allows multiple write operations to be batched into a single, efficient operation. Data is automatically synchronized when **`PIO_enddef`** (ending definition) or  **PIO_closefile** (closing) are called.

> [!NOTE]
> If you issue an **`ncdump -k`** command while the model is running, you get the following error because the file is not properly closed yet. For example:
>
> % **ncdump -k** usec3km_roms_his_20190827.nc.
> % ncdump: usec3km_roms_his_20190827.nc: NetCDF: HDF error 

> [!IMPORTANT]  
>  If the **DELAYED_SYNC_PIO** is **not** activated, **ROMS** calls the internal routine **`pio_netcdf_sync`**  (which calls  **`PIO_syncfile`**) after writing each time record into output **NetCDF4** files. The output files grow in size but remain inaccessible until the **`PIO_closefile`** call in **`ROMS_finalize`**. For example, in **`wrt_his.F`**, we **may** or **may not** synchronize after writing files for a given time record:
>
``` d
 # ifndef DELAYED_SYNC_PIO
!
!-----------------------------------------------------------------------
! Synchronize the history NetCDF file to disk to allow other processes
! to access data immediately after it is written.
!-----------------------------------------------------------------------
!
      CALL pio_netcdf_sync (ng, model, HIS(ng)%name, HIS(ng)%pioFile)
      IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
# endif
```
> [!WARNING]
> Thus, the users must test if **`DELAYED_SYNC_PIO`** is more efficient or **not** for their particular **ROMS**
> application in their computer system. This option is complex, and a  few questions need to be answered:
>
> Is it cheaper to synchronize the file to disk during closing or when flushing buffers is needed? 
> Is it cheaper to partially synchronize multiple times for each time record in the file?
> Is there enough buffer memory for a single synchronization during closing?

- Similarly, **two** new **CPP** options **`OUT_NETCDF4`** and **`DELAYED_SYNC_NF90`** are introduced to create **NetCDF4/HDF5** output files and to delay synchronization until **`nf90_enddef`** or **`nf90_close`** is called.
> [!CAUTION]
> When activating **`OUT_NETCDF4`**, any input files that **ROMS** will modify **must be** of type **NetCDF4/HDF5**!  Otherwise, **ROMS** will **fail** when writing into them. This is relevant in any of the **4D-Var** algorithms in which **ROMS** will add two additional time records to the nonlinear initial condition (**ININAME**) file.
>
> It is trivial to convert such files to **NetCDF4** format:
>
> **ncks** `-4 -L 1 -h -O --no_abc` **old_filename.nc `new_filename.nc4`**



- In **4D-Var**, we need to issue a **`PIO_closefile`** for the forward trajectory and forward forcing fields so that they can be accessed in the inner loops by the **ADM** and **TLM** kernel. Thus, at the end of the **4D-Var** background phase routine, you will find:
``` f90
# if defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90 || \
     defined PIO_LIB     && defined DELAYED_SYNC_PIO
!
! If delayed NetCDF4 file synchronization is required to maximize
! performance, close forward trajectory and forward fluxes file
! to allow the ADM and TLM kernels to access them within the
! inner loops.
!
       CALL close_forward
# endif
```
- Implemented compression in output **NetCDF4** files with the **PIO** library with the **`DEFLATE`** option.  In routine **`def_var_pio`**.  It is only possible with **PIO_METHOD=3** or **PIO_METHOD=4**.
``` f90
# ifdef DEFLATE
!
!  Define deflate (file compression) parameters. It is only possible for
!  output NetCDF4/HD5 files (pio_method=3 or pio_method=4).
!
      IF (exit_flag.eq.NoError) THEN
        IF (LEN_TRIM(Vinfo(1)).gt.0) THEN
          IF ((nVdim.gt.1).and.(Vdim(1).ne.0).and.                      &
     &        (pio_method.gt.2)) THEN
            status=PIO_def_var_deflate(pioFile, pioVar, shuffle,        &
     &                                 deflate, deflate_level)
            IF (FoundError(status, PIO_noerr, __LINE__, MyFile)) THEN
              IF (Master) WRITE (stdout,20) TRIM(Vinfo(1)),             &
     &                                      TRIM(ncname)
              exit_flag=3
              ioerror=status
            END IF
          END IF
        END IF
      END IF
# endif
```
> [!NOTE]
> The user needs to have the following parameters in the **ROMS** standard input file (**`roms.in`**):
>
``` d
! NetCDF-4/HDF5 compression parameters for output files.

  NC_SHUFFLE =  1                 ! if non-zero, turn on shuffle filter
  NC_DEFLATE =  1                 ! if non-zero, turn on deflate filter
   NC_DLEVEL =  1                 ! deflate level [0-9]
```
> [!WARNING]
> The higher of the **`NC_DLEVEL`** value the less efficient the **I/O** becomes.  We recommend **`NC_DLEVEL=1`**, > which results in a **~40%** overall decrease in file size.

## Issue(s) addressed

None.

## Impacts

It may improve efficiency in some computer clusters and supercomputers with appropriate hardware and MPI-IO optimizations.

## USEC Benchmark

The Nonlinear forward solution for the [USEC 3km](https://github.com/myroms/roms_test/blob/main/USEC/RBL4DVAR_mixres/Readme.md) application (**561x243x50**) is used to benchmark **ROMS I/O** with the NetCDF **NF90** and **PIO** libraries. It is run on a desktop Linux box (16 CPUs and 1 GPU with 384 CUDA cores, NVIDIA), with **12** CPUs and a **3x4** partition, compiled with **ifort** (Spack-Stack 1.9). Please investigate the proper configuration for your computer systems. The **USEC 3km** configuration has the following characteristics:

- The **ROMS NLM** kernel is run in double precision, and the output files are written in double precision.
- A three-day simulation with **720** timesteps.
- The option **`GRID_EXTRACT`** is activated to extract a coarser **6km** trajectory (**281x122x50**) by decimation to be used as a background trajectory in the **4D-Var** data assimilation algorithm and written into **`usec6km_roms_fwd_20190827.nc`**.
- The option **`OUT_NETCDF4`** activates writing all output files with the **NetCDF4/HDF5** format in **ROMS**. These files can be compressed by activating **`DEFLATE`**. In addition, the user can activate **`DELAYED_SYNC_NF90`** to avoid flushing the buffers to disk each time an unlimited-dimension record is written, thereby improving efficiency. It is up to the **NetCDF4/HDF5** libraries to determine their flushing frequency for performance. The files are accessible after they are closed.
- The option **`VERIFICATION`** is activated to interpolate the model solution at the observation location, **H(x)** operator. They are written into the output file **`usec3km_roms_mod_20190827.nc`**.
- The option **`DEFLATE`** may or may not be activated to compress only output **NetCDF4/HDF5** files. It is not possible to compress **NetCDF-3** files with a **64-bit offset**.
- The options **`DELAYED_SYNC_NF90`** and **`DELAYED_SYNC_NF90`** are activated to avoid synchronization to disk for each output unlimited time dimension records for efficiency. They are only possible on **NetCDF-4/HDF5** output files.
- **ROMS** supports both NetCDF **NF90** (**`OUT_NETCDF4`**) and **PIO** (**`PIO_LIB`**) libraries which are controlled by the **`inp_lib`** and **`out_lib`** configuration parameters.
- The history, quicksave, and extracted fields by decimation are saved hourly (**73** records).
- The table below shows the effects of file compression with the **`DEFLATE`** option and delayed synchronization. In **Case 1**, the size of all output files is reduced by **35%** to **26.593 GB**, down from **41.163 GB**. However, the CPU (elapsed time) takes about **8.5** minutes longer, resulting in a **44%** increase. Thus, the decision is about what is more important: disk space, file transfer bandwidth to storage, CPU time, or pricing in cloud computer services. As the applications become larger, the CPU penalty in compression tends to decrease. However, you'll need to evaluate your application benchmarks.

| Case  | inp_lib | out_lib | PIO <br>Method | File Type     | Deflate   | Delayed Sync | Files Size  | Elapsed Time <br> mm:ss | 
:-------|:--------:|:--------:|:----------:|---------------|:-------------:|:------------:|:-----------:|:-----------------:
| 1   | 2<br>PIO  | 2<br>PIO   | 3    | netCDF-4      | Yes    |  PIO, NF90   |  26.593 GB  | 36:56    |
| 2   | 2<br>PIO  | 2<br>PIO   | 3    | netCDF-4      | No     |  PIO, NF90   |  41.163 GB  | 25:36     |
| 3   | 2<br>PIO  | 2<br>PIO   | 2    | 64-bit offset | N/A    |  N/A              |  38.126 GB  | 28:12     |
| 4   | 2<br> PIO | 1<br>NF90 | 2   | netCDF-4      | No     |  N/A, NF90   |  41.163 GB  | 25:47      |
| 5   | 2<br>PIO  | 1<br>NF90 | 2   | 64-bit offset | N/A    |  N/A              |  40.721 GB  | 25:59       |

## ECCOFS Benchmark

The **NLM** (forward trajectory) for the East Coast Community Ocean Forecast System (**ECCOFS**) 3km application (**1667x1443x50**) was run in double-precision with single-precision output fields, and **`DEFLATE`**, **`DELAYED_SYNC_PIO`**, **`GRID_EXTRACT`** ( decimation),  and **`VERIFICATION`** options. As in the **USEC** application above, it was run on a desktop Linux box (16 CPUs and 1 GPU with 384 CUDA cores, NVIDIA), using **12** CPUs with a **3x4** partition, compiled with **ifort** (Spack-Stack 1.9).

| Filename       | Compressed Size  <br> (NetCDF4)  | Uncompressed Size  <br> (NetCDF3 64-bit) | 
:---------------------------------------------|:------------------:|:--------------------:
| eccofs3km_roms_his_20190101.nc               |  40G                       |   88G                        |
| eccofs3km_roms_qck_20190101.nc              |  7.9G                       |   17G                         |
| eccofs3km_roms_mod_20190101.nc             |  39M                      |   39M                        |
| eccofs3km_roms_rst_20190101.nc                |  4.2G                      |   8.5G                       |
|  |
| eccofs6km_roms_fwd_20190101.nc              |  60G                       |  60G                         |
| |
| TOTAL                                                              |  112G                      |  173.5G                     |
| **CPU** (Elapsed) time, 12 PETs                   | 13:02:41                 |   N/A                          | 

The size of all the output files is reduced by **35.55%** to **112 GB** from **173.5 GB**.


## 4D-Var Results

The update was tested with the [USEC](https://github.com/myroms/roms_test/blob/main/USEC/RBL4DVAR_mixres/Readme.md) split, mixed-resolution **RBL4D-Var** application. It was run on a desktop Linux box (16 CPUs and 1 GPU with 384 CUDA cores, NVIDIA), using **12** CPUs with a **3x4** partition, compiled with **ifort** (Spack-Stack 1.9).

``` d
::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ROMS Split RBL4D-Var Data Assimilation: USEC
::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

                    ROMS Root: /home/arango/ocean/repository/git/roms
            ROMS Executable A: romsM_nl  (background, analysis)
            ROMS Executable B: romsM_da  (increment, post_error)

      RBL4D-Var Starting Date: 2019-08-27  datenum = 737664
   First RBL4D-Var Cycle Date: 2019-08-27  datenum = 737664
    Last RBL4D-Var Cycle Date: 2019-08-30  datenum = 737667
          ROMS Reference Date: 2006-01-01  datenum = 732678
       RBL4D-Var Cycle Window: 3 days
      Number of parallel PETs: 12  (3x4)
   Current Starting Directory: /home/arango/ROMS/Projects/USEC/RBL4DVAR_mixres
         ROMS Application CPP: USEC
      Descriptor in filenames: usec3km  (outer loops grid)
      Descriptor in filenames: usec6km  (inner loops grid)

----------------------------------------------------------------------------------------------------

       RBL4D-Var Cycle Date: 2019-08-27 00  DayOfYear = 239  Cycle = 1
         Data sub-directory: ../../Data
          Run sub-directory: 2019.08.27
      Number of outer loops: 1
      Number of inner loops: 16
    NLM trajectory  writing: 30, 15 timesteps
    NLM quicksave   writing: 30, 15 timesteps
    NLM decimation  writing: 30, 15 timesteps
    TLM trajectory  writing: 30, 15 timesteps
    ADM trajectory  writing: 2160, 1080 timesteps
    SFF adjustment  writing: 30, 15 timesteps
    OBC adjustment  writing: 30, 15 timesteps
  NLM multi-file trajectory: 0, 0 timesteps
                ROMS DSTART: 4986.0d0
     Outer Loops Resolution: 3 km
     Inner Loops Resolution: 6 km
           I/O Files Prefix: usec3km  (outer loops grid)
           I/O Files Prefix: usec6km  (inner loops grid)
           I/O Files Suffix: 20190827
              ReferenceTime: 2006 01 01 00 00 00
        RBL4D-Var StartTime: 2019 08 27 00 00 00
        RBL4D-Var  StopTime: 2019 08 30 00 00 00
   ROMS outer loops Grid IC: ../../Data/INI/usec3km_roms_ini_20190827.nc
   ROMS inner loops Grid IC: ../../Data/INI/usec6km_roms_ini_20190827.nc
   NL Standard Input Script: roms_nl_usec_era5_20190827.in   (outer loops grid)
   DA Standard Input Script: roms_da_usec_era5_20190827.in   (inner loops grid)
  NL RBL4D-Var Input Script: rbl4dvar_nl.in  (outer loops grid)
  DA RBL4D-Var Input Script: rbl4dvar_da.in  (inner loops grid)

Cycle 1, Creating run sub-directory: 2019.08.27

Changing to directory: /home/arango/ROMS/Projects/USEC/RBL4DVAR_mixres/2019.08.27

   Creating NL ROMS Standard Input Script: roms_nl_usec_era5_20190827.in
   Creating DA ROMS Standard Input Script: roms_da_usec_era5_20190827.in
   Copying NLM IC file ../../Data/INI/usec3km_roms_ini_20190827.nc  as  usec3km_roms_ini_20190827.nc
   Copying NLM IC file ../../Data/INI/usec6km_roms_ini.nc  as  usec6km_roms_ini_20190827.nc
   Copying OBS    file ../../Data/OBS/usec3km_roms_obs_20190827.nc  as  usec3km_roms_obs_20190827.nc
   Copying OBS    file ../../Data/OBS/usec6km_roms_obs_20190827.nc  as  usec6km_roms_obs_20190827.nc

Running 4D-Var System:  Cycle = 1   Outer = 0   Phase = background

   Creating 4D-Var Input Script from Template: rbl4dvar_nl.in   Outer = 0  Phase = background
     (Resolution = 3 km, Fprefix = usec3km, Fsuffix = 20190827)

   mpirun -np 12 romsM_nl roms_nl_usec_era5_20190827.in

   Renaming NLM trajectory usec6km_roms_fwd_20190827.nc  to  usec6km_roms_fwd_20190827_outer0.nc

Running 4D-Var System:  Cycle = 1   Outer = 1   Phase = increment

   Creating 4D-Var Input Script from Template: rbl4dvar_da.in   Outer = 1  Phase = increment
     (Resolution = 6 km, Fprefix = usec6km, Fsuffix = 20190827)

   mpirun -np 12 romsM_da roms_da_usec_era5_20190827.in

Running 4D-Var System:  Cycle = 1   Outer = 1   Phase = analysis

   Creating 4D-Var Input Script from Template: rbl4dvar_nl.in   Outer = 1  Phase = analysis
     (Resolution = 3 km, Fprefix = usec3km, Fsuffix = 20190827)

   mpirun -np 12 romsM_nl roms_nl_usec_era5_20190827.in

   Renaming NLM trajectory usec6km_roms_fwd_20190827.nc  to  usec6km_roms_fwd_20190827_outer1.nc

Finished 4D-Var outer loops iterations

Finished RBL4D-Var Cycle 1,  Elapsed time = 03:06:17
```
**ROMS** is configured with PIO for input and output NetCDF4 files and the options **`DEFLATE`** and **`DELAYED_SYNC_PIO`** are activated. It is run on 12 processors.   The **PIO** library parameters are as follows:
``` d
          2  inp_lib           Using the Parallel-IO (PIO) library for input files.
          2  out_lib           Using the Parallel-IO (PIO) library for output files.
          3  pio_method        Parallel read and serial write of compressed NetCDF4 (HDF5) files.
          2  pio_NumIOtasks    Number of mpi-processors used for I/O.
          5  pio_stride        Stride step in the mpi-rank between I/O tasks.
          0  pio_base          Offset for the first I/O task.
          1  pio_aggregator    Number of mpi-aggregators for intra-communications.
          1  pio_rearranger    Box rearrangement method.
          1  pio_rearr_comm    Collective rearranger communications.
          0  pio_rearr_fcd     Enabled C2I flow control, and vice versa.
          T  pio_rearr_C2I_HS  Enabled C2I rearranger handshake.
          T  pio_rearr_I2C_HS  Enabled I2C rearranger handshake.
          T  pio_rearr_C2I_iS  Enabled C2I rearranger mpi-Isends.
          T  pio_rearr_I2C_iS  Enabled I2C rearranger mpi-Isends.
         64  pio_rearr_C2I_PR  Maximum C2I rearranger pending requests.
         65  pio_rearr_I2C_PR  Maximum I2C rearranger pending requests.

          1  shuffle           NetCDF-4/HDF5 file format shuffle filer flag.
          1  deflate           NetCDF-4/HDF5 file format deflate filer flag.
          1  defalte_level     NetCDF-4/HDF5 file format deflate level parameter.
```
The size of all the output files is reduced by **42.55%** to **81 GB** from **141 GB**. However, the CPU (elapsed time) takes about **20** minutes longer, resulting in a **12%** increase. Thus, the decision is about what is more important: disk space, file transfer to storage, or CPU time. The numerical kernel runs in double precision, and the output files are also in double precision. In the table below, some files have the same size because they are **NetCDF3** (64-bit offset) and not **NetCDF4**.

| Filename       | Compressed Size  <br> (NetCDF4)  | Uncompressed Size  <br> (NetCDF3 64-bit) | 
:---------------------------------------------|:------------------:|:--------------------:
| usec3km_roms_dai_20190827.nc                 | 379M                     | 597M                         |
| usec3km_roms_fwd_20190827_outer0.nc   | 22G                        | 50G                           |
| usec3km_roms_fwd_20190827_outer1.nc    | 22G                        | 50G                           |
| usec3km_roms_ini_20190827.nc                  | 2.0G                       | 2.0G                           |
| usec3km_roms_itl_20190827.nc                   | 191M                      | 2.3G                           |
| usec3km_roms_mod_20190827.nc               | 162M                      | 176M                         |
| usec3km_roms_obs_20190827.nc                 | 31M                        | 31M                           |
| usec3km_roms_qck_20190827_outer0.nc     | 583M                     | 928M                        |
| usec3km_roms_qck_20190827_outer1.nc      | 583M                     | 928M                        |
| usec3km_roms_rst_20190827.nc                    | 276M                     | 440M                        |
|  |
| usec6km_roms_adj_20190827.nc                    | 165M                     | 335M                        |
| usec6km_roms_fwd_20190827_outer0.nc       | 17G                       | 17G                            |
| usec6km_roms_fwd_20190827_outer1.nc        | 17G                       | 17G                            |
| usec6km_roms_ini_20190827.nc                      | 331M                    | 331M                         |
| usec6km_roms_itl_20190827.nc                       | 145 M                   | 455M                        |
| usec6km_roms_obs_20190827.nc                    | 31M                       | 31M                          |
| usec6km_roms_tlf_20190827.nc                       | 40M                     | 57M                           |
|  |
| **TOTAL**                                                            | **81G**                | **141G**                   |
| **CPU** (Elapsed) time, 12 PETs                        | 03:06:17              | 02:45:51                   |

> [!NOTE]
> If one considers that data transferring can be costly and takes a lot of bandwidth and time, the penalty in CP time is more advantageous in large applications. This decision will be easier when running in the cloud, such as **AWS**.

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR
- [x] I have run and tested the changes before creating the PR