### PR TITLE
Jerlov water type index revisited

### DIFF
--- a/ROMS/Adjoint/ad_lmd_swfrac.F
+++ b/ROMS/Adjoint/ad_lmd_swfrac.F
@@ -84,7 +84,7 @@
 !
       DO j=Jstr,Jend
         DO i=Istr,Iend
-          Jindex=MAX(1, MIN(INT(MIXING(ng)%Jwtype(i,j)), 9))
+          Jindex=MAX(1, MIN(MIXING(ng)%Jwtype(i,j), 9))
           fac1(i)=Zscale/lmd_mu1(Jindex)
           fac2(i)=Zscale/lmd_mu2(Jindex)
           fac3(i)=lmd_r1(Jindex)

--- a/ROMS/Functionals/ana_wtype.h
+++ b/ROMS/Functionals/ana_wtype.h
@@ -98,11 +98,11 @@
       integer, intent(in) :: IminS, ImaxS, JminS, JmaxS
 !
 #ifdef ASSUMED_SHAPE
-      real(r8), intent(in)  :: h(LBi:,LBj:)
-      real(r8), intent(out) :: Jwtype(LBi:,LBj:)
+      integer, intent(out) :: Jwtype(LBi:,LBj:)
+      real(r8), intent(in) :: h(LBi:,LBj:)
 #else
-      real(r8), intent(in)  :: h(LBi:UBi,LBj:UBj)
-      real(r8), intent(out) :: Jwtype(LBi:UBi,LBj:UBj)
+      integer, intent(out) :: Jwtype(LBi:UBi,LBj:UBj)
+      real(r8), intent(in) :: h(LBi:UBi,LBj:UBj)
 #endif
 !
 !  Local variable declarations.
@@ -140,7 +140,7 @@
       fac=1.0/1000.0_r8                   ! Inverse bathymetry threshold
       DO j=JstrT,JendT
         DO i=IstrT,IendT
-          Jwtype(i,j)=ANINT(5.0_r8-4.5_r8*(TANH(h(i,j)*fac)))      ! 1:5
+          Jwtype(i,j)=NINT(5.0_r8-4.5_r8*(TANH(h(i,j)*fac)))       ! 1:5
         END DO
       END DO
 #else

--- a/ROMS/Modules/mod_mixing.F
+++ b/ROMS/Modules/mod_mixing.F
@@ -162,7 +162,7 @@
 #  endif
 # endif
 # if defined LMD_SKPP || defined SOLAR_SOURCE
-          real(r8),  pointer :: Jwtype(:,:)
+          integer,  pointer :: Jwtype(:,:)
 # endif
 #endif
 #if defined DIFF_3DCOEF && defined SOLVE3D
@@ -1524,7 +1524,7 @@
 # endif
 # if defined LMD_SKPP || defined SOLAR_SOURCE
           DO i=Imin,Imax
-            MIXING(ng) % Jwtype(i,j) = REAL(lmd_Jwt(ng),r8)
+            MIXING(ng) % Jwtype(i,j) = lmd_Jwt(ng)
           END DO
 # endif
 # if defined LMD_SKPP || defined LMD_BKPP

--- a/ROMS/Nonlinear/lmd_swfrac.F
+++ b/ROMS/Nonlinear/lmd_swfrac.F
@@ -70,7 +70,7 @@
 !
       DO j=Jstr,Jend
         DO i=Istr,Iend
-          Jindex=MAX(1, MIN(INT(MIXING(ng)%Jwtype(i,j)), 9))
+          Jindex=MAX(1, MIN(MIXING(ng)%Jwtype(i,j), 9))
           fac1(i)=Zscale/lmd_mu1(Jindex)
           fac2(i)=Zscale/lmd_mu2(Jindex)
           fac3(i)=lmd_r1(Jindex)

--- a/ROMS/Representer/rp_lmd_swfrac.F
+++ b/ROMS/Representer/rp_lmd_swfrac.F
@@ -77,7 +77,7 @@
 !
       DO j=Jstr,Jend
         DO i=Istr,Iend
-          Jindex=MAX(1, MIN(INT(MIXING(ng)%Jwtype(i,j)), 9))
+          Jindex=MAX(1, MIN(MIXING(ng)%Jwtype(i,j), 9))
           fac1(i)=Zscale/lmd_mu1(Jindex)
           fac2(i)=Zscale/lmd_mu2(Jindex)
           fac3(i)=lmd_r1(Jindex)

--- a/ROMS/Tangent/tl_lmd_swfrac.F
+++ b/ROMS/Tangent/tl_lmd_swfrac.F
@@ -77,7 +77,7 @@
 !
       DO j=Jstr,Jend
         DO i=Istr,Iend
-          Jindex=MAX(1, MIN(INT(MIXING(ng)%Jwtype(i,j)), 9))
+          Jindex=MAX(1, MIN(MIXING(ng)%Jwtype(i,j), 9))
           fac1(i)=Zscale/lmd_mu1(Jindex)
           fac2(i)=Zscale/lmd_mu2(Jindex)
           fac3(i)=lmd_r1(Jindex)

--- a/ROMS/Utility/close_io.F
+++ b/ROMS/Utility/close_io.F
@@ -359,6 +359,16 @@
         CALL close_file (ng, iNLM, XTR(ng), XTR(ng)%name, Lupdate)
 #endif
 !
+!  Close several input files that may be open.
+!
+#ifdef FOUR_DVAR
+        CALL close_file (ng, iNLM, INI(ng), INI(ng)%name, .FALSE.)
+#endif
+        CALL close_file (ng, iNLM, NUD(ng), NUD(ng)%name, .FALSE.)
+        CALL close_file (ng, iNLM, OBS(ng), OBS(ng)%name, .FALSE.)
+        CALL close_file (ng, iNLM, SSF(ng), SSF(ng)%name, .FALSE.)
+        CALL close_file (ng, iNLM, TIDE(ng), TIDE(ng)%name, .FALSE.)
+!
 !  Report number of time records written.
 !
         IF (Master) THEN
@@ -404,6 +414,18 @@
           IF (associated(TLM(ng)%Nrec)) THEN
             IF (ANY(TLM(ng)%Nrec.gt.0)) THEN
               WRITE (stdout,20) 'TANGENT', SUM(TLM(ng)%Nrec)
+            END IF
+          END IF
+
+          IF (associated(ITL(ng)%Nrec)) THEN
+            IF (ANY(ITL(ng)%Nrec.gt.0)) THEN
+              WRITE (stdout,20) 'TLM ITL', SUM(ITL(ng)%Nrec)
+            END IF
+          END IF
+
+          IF (associated(TLF(ng)%Nrec)) THEN
+            IF (ANY(TLF(ng)%Nrec.gt.0)) THEN
+              WRITE (stdout,20) 'TLM TLF', SUM(TLF(ng)%Nrec)
             END IF
           END IF
 #endif

--- a/ROMS/Utility/close_io.F
+++ b/ROMS/Utility/close_io.F
@@ -123,7 +123,7 @@
 #endif
 !
 !  Close forward trajectory and fluxes files.
-
+!
       DO ng=1,Ngrids
 #if defined FORWARD_WRITE
         IF (FWD(ng)%IOtype.eq.io_nf90) THEN
@@ -188,7 +188,11 @@
 !  to closed state.
 !
       DO i=1,nFfiles(ng)
-        IF ((FRC(i,ng)%Nfiles.gt.0).and.(FRC(i,ng)%ncid.ne.-1)) THEN
+        IF ((FRC(i,ng)%Nfiles.gt.0).and.                                &
+     &      (((FRC(i,ng)%IOtype.eq.io_nf90).and.                        &
+     &        (FRC(i,ng)%ncid.ne.-1)).or.                               &
+     &       ((FRC(i,ng)%IOtype.eq.io_pio).and.                         &
+     &        (FRC(i,ng)%pioFile%fh.ne.-1)))) THEN
           Fcount=FRC(i,ng)%Fcount
           CALL close_file (ng, model, FRC(i,ng),                        &
      &                     FRC(i,ng)%files(Fcount), .FALSE.)
@@ -206,7 +210,11 @@
 !
       IF (ObcData(ng)) THEN
         DO i=1,nBCfiles(ng)
-          IF ((BRY(i,ng)%Nfiles.gt.0).and.(BRY(i,ng)%ncid.ne.-1)) THEN
+          IF ((BRY(i,ng)%Nfiles.gt.0).and.                              &
+     &        (((BRY(i,ng)%IOtype.eq.io_nf90).and.                      &
+     &          (BRY(i,ng)%ncid.ne.-1)).or.                             &
+     &         ((BRY(i,ng)%IOtype.eq.io_pio).and.                       &
+     &          (BRY(i,ng)%pioFile%fh.ne.-1)))) THEN
             Fcount=BRY(i,ng)%Fcount
             CALL close_file (ng, model, BRY(i,ng),                      &
      &                       BRY(i,ng)%files(Fcount), .FALSE.)
@@ -224,7 +232,11 @@
 !
       IF (CLM_FILE(ng)) THEN
         DO i=1,nCLMfiles(ng)
-          IF ((CLM(i,ng)%Nfiles.gt.0).and.(CLM(i,ng)%ncid.ne.-1)) THEN
+          IF ((CLM(i,ng)%Nfiles.gt.0).and.                              &
+     &        (((CLM(i,ng)%IOtype.eq.io_nf90).and.                      &
+     &          (CLM(i,ng)%ncid.ne.-1)).or.                             &
+     &         ((CLM(i,ng)%IOtype.eq.io_pio).and.                       &
+     &          (CLM(i,ng)%pioFile%fh.ne.-1)))) THEN
             Fcount=CLM(i,ng)%Fcount
             CALL close_file (ng, model, CLM(i,ng),                      &
      &                       CLM(i,ng)%files(Fcount), .FALSE.)

--- a/ROMS/Utility/get_grid.F
+++ b/ROMS/Utility/get_grid.F
@@ -120,9 +120,9 @@
 # if defined UV_DRAG_GRID && !defined ANA_DRAG
       integer :: varid_dragL, varid_dragQ, varid_ZoBL
 # endif
-#if defined UV_WAVEDRAG
+# if defined UV_WAVEDRAG
       integer :: varid_dragW
-#endif
+# endif
       integer :: Vsize(4)
 # ifdef CHECKSUM
       integer(i8b) :: Fhash
@@ -131,6 +131,12 @@
       real(dp), parameter :: Fscl = 1.0_dp
 
       real(r8) :: Fmax, Fmin
+
+# if defined WTYPE_GRID && \
+    (defined LMD_SKPP   || defined SOLAR_SOURCE) && \
+    !defined ANA_WTYPE
+      real(r8) :: wtype(LBi:UBi,LBj:UBj)
+# endif
 !
       character (len=256) :: ncname
 
@@ -696,10 +702,10 @@
      &                        GRID(ng) % rmask,                         &
 #  endif
 #  ifdef CHECKSUM
-     &                        MIXING(ng) % Jwtype,                      &
+     &                        wtype,                                    &
      &                        checksum = Fhash)
 #  else
-     &                        MIXING(ng) % Jwtype)
+     &                        wtype)
 #  endif
             IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
               exit_flag=2
@@ -717,15 +723,16 @@
             IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
               CALL exchange_r2d_tile (ng, tile,                         &
      &                                LBi, UBi, LBj, UBj,               &
-     &                                MIXING(ng) % Jwtype)
+     &                                wtype)
             END IF
 #  ifdef DISTRIBUTE
             CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
-     &                          MIXING(ng) % Jwtype)
+     &                          wtype)
 #  endif
+            MIXING(ng) % Jwtype = NINT(wtype)   ! nearest integer
 # endif
 # ifndef ANA_SPONGE
 !
@@ -2531,6 +2538,12 @@
       real(dp), parameter :: Fscl = 1.0_dp
 
       real(r8) :: Fmax, Fmin
+
+# if defined WTYPE_GRID && \
+    (defined LMD_SKPP   || defined SOLAR_SOURCE) && \
+    !defined ANA_WTYPE
+      real(r8) :: wtype(LBi:UBi,LBj:UBj)
+# endif
 !
       character (len=256) :: ncname
 
@@ -3152,7 +3165,7 @@
           CASE ('wtype_grid')
             pioVar%vd=var_desc(i)
             pioVar%gtype=r2dvar
-            IF (KIND(MIXING(ng)%Jwtype).eq.8) THEN
+            IF (KIND(wtype).eq.8) THEN
               pioVar%dkind=PIO_double
               ioDesc => ioDesc_dp_r2dvar(ng)
             ELSE
@@ -3169,10 +3182,10 @@
      &                        GRID(ng) % rmask,                         &
 #   endif
 #   ifdef CHECKSUM
-     &                        MIXING(ng) % Jwtype,                      &
+     &                        wtype,                                    &
      &                        checksum = Fhash)
 #   else
-     &                        MIXING(ng) % Jwtype)
+     &                        wtype)
 #   endif
             IF (FoundError(status, nf90_noerr, __LINE__, MyFile)) THEN
               exit_flag=2
@@ -3190,15 +3203,16 @@
             IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
               CALL exchange_r2d_tile (ng, tile,                         &
      &                                LBi, UBi, LBj, UBj,               &
-     &                                MIXING(ng) % Jwtype)
+     &                                wtype)
             END IF
 #   ifdef DISTRIBUTE
             CALL mp_exchange2d (ng, tile, model, 1,                     &
      &                          LBi, UBi, LBj, UBj,                     &
      &                          NghostPoints,                           &
      &                          EWperiodic(ng), NSperiodic(ng),         &
-     &                          MIXING(ng) % Jwtype)
+     &                          wtype)
 #   endif
+            MIXING(ng) % Jwtype = NINT(wtype)   ! nearest integer
 #  endif
 #  ifndef ANA_SPONGE
 !

--- a/ROMS/Utility/get_state.F
+++ b/ROMS/Utility/get_state.F
@@ -8043,6 +8043,9 @@
       ELSE IF (model.eq.17) THEN
         string='NRM: '                     ! normalization factor
         IDmod=iNLM                         ! surface forcing
+      ELSE IF (model.eq.19) THEN
+        string='ITL: '                     ! cummulative increments for
+        IDmod=iTLM                         ! Incremental Analysis Update
       END IF
 
 # ifdef PROFILE

--- a/ROMS/Utility/obs_initial.F
+++ b/ROMS/Utility/obs_initial.F
@@ -100,7 +100,7 @@
       real(r8) :: tend
 !
       character (len=*), parameter :: MyFile =                          &
-     &  __FILE__//"obs_initial_nf90"
+     &  __FILE__//", obs_initial_nf90"
 !
       SourceFile=MyFile
 !
@@ -408,7 +408,7 @@
       real(r8) :: tend
 !
       character (len=*), parameter :: MyFile =                          &
-     &  __FILE__//"obs_initial_nf90"
+     &  __FILE__//", obs_initial_pio"
 !
       SourceFile=MyFile
 !
@@ -417,7 +417,7 @@
 !  the dimensions and variables.
 !-----------------------------------------------------------------------
 !
-      QUERY : IF (OBS(ng)%ncid.eq.-1) THEN
+      QUERY : IF (OBS(ng)%pioFile%fh.eq.-1) THEN
 !
 !  Open observations NetCDF file.
 !

--- a/ROMS/Utility/roms_interp.F
+++ b/ROMS/Utility/roms_interp.F
@@ -813,7 +813,7 @@
 !  If appropriate, open source NetCDF, inquire about dimesions and
 !  variables.
 !
-      IF (self%pioFile%fh.eq.0) THEN
+      IF (self%pioFile%fh.eq.-1) THEN
         IF (FoundError(assign_string(self%ncname, ncname),              &
      &                 NoError, __LINE__, MyFile)) RETURN
 !

--- a/User/Functionals/ana_wtype.h
+++ b/User/Functionals/ana_wtype.h
@@ -96,11 +96,11 @@
       integer, intent(in) :: IminS, ImaxS, JminS, JmaxS
 !
 #ifdef ASSUMED_SHAPE
-      real(r8), intent(in)  :: h(LBi:,LBj:)
-      real(r8), intent(out) :: Jwtype(LBi:,LBj:)
+      integer, intent(out) :: Jwtype(LBi:,LBj:)
+      real(r8), intent(in) :: h(LBi:,LBj:)
 #else
-      real(r8), intent(in)  :: h(LBi:UBi,LBj:UBj)
-      real(r8), intent(out) :: Jwtype(LBi:UBi,LBj:UBj)
+      integer, intent(out) :: Jwtype(LBi:UBi,LBj:UBj)
+      real(r8), intent(in) :: h(LBi:UBi,LBj:UBj)
 #endif
 !
 !  Local variable declarations.


### PR DESCRIPTION
# Description

- TheJerlov water type ROMS internal variable **`Jwtype`** is changed to an integer:
``` f90
# if defined LMD_SKPP || defined SOLAR_SOURCE
          integer,  pointer :: Jwtype(:,:)
# endif
```
Thus, the call to **`lmd_swfrac.F`** and associated **ADM**, **TLM**, and **RPM** versions becomes:
``` f90
      DO j=Jstr,Jend
        DO i=Istr,Iend
          Jindex=MAX(1, MIN(MIXING(ng)%Jwtype(i,j), 9))
          ...
        END DO
      END DO
```
The input spatially varying variable **`wtype_grid`** in the grid NetCDF file can be an integer or a floating-point array.  Currently, **ROMS** reads into a floating-point temporary variable, **`wtype`**, and then loads it into the **`Jwtype`** state variable using the **NINT** operator.

``` f90
!
!  Read in Jerlov water type.
!
          CASE ('wtype_grid')
            gtype=r2dvar
            status=nf_fread2d(ng, model, ncname, GRD(ng)%ncid,          &
     &                        var_name(i), var_id(i),                   &
     &                        0, gtype, Vsize,                          &
     &                        LBi, UBi, LBj, UBj,                       &
     &                        Fscl, Fmin, Fmax,                         &
#  ifdef MASKING
     &                        GRID(ng) % rmask,                         &
#  endif
#  ifdef CHECKSUM
     &                        wtype,                                    &
     &                        checksum = Fhash)
#  else
     &                        wtype)
#  endif
            ...

            MIXING(ng) % Jwtype = NINT(wtype)   ! nearest integer
```
For the **ECCOFS** 3km application, we get:

<img width="1850" height="1778" alt="Jerlov_usec6km_round" src="https://github.com/user-attachments/assets/5ee28bfc-2153-4a48-b341-aeaaf0336fcd" />


---

- Ensured that the number of opened must be the same or less than closed **NetCDF** files in **ROMS** to avoid weird errors when **ROMS** finishes the computations due to the delayed synchronization options introduced in #72.
>[!NOTE]
>The CPP option **`CHECK_OPEN_FILES`** can be used to write a summary of the **NetCDF** files opened and closed in **ROMS**, which is written in a text file **` fort.1000`**:
>
>NLM PIO: OPEN    =>      128  ../Data/GRD/usec3km_roms_tides.nc4  ROMS/Utility/inp_decode.F, find_file
>NLM PIO: CLOSE  <=      128  ../Data/GRD/usec3km_roms_tides.nc4  ROMS/Utility/inp_decode.F, find_file
>...
>
>Then, we can use the **`ROM/Bin/check_openfiles.sh`**, to get:
>...
>*** Number of opened  files = 23
>*** Number of closed  files = 28
>*** Number of created files = 5
>
> Here, files closed are equal to files opened plus created.

## Issue(s) addressed
None.

## Dependencies
None

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR
- [x] I have run and tested the changes before creating the PR
