### PR TITLE
Forcing the closing of the INI and ITL files in 4D-Var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ endif()
 
 # NetCDF Library.
 
-if(DEFINED ENV{SINGULARITY_COMMAND} AND IN_ECBUILD )
+if( DEFINED ENV{SINGULARITY_COMMAND} AND IN_ECBUILD )
   find_package( NetCDF REQUIRED COMPONENTS Fortran )
   include_directories( ${NETCDF_INCLUDE_DIRS} )
   list( APPEND netcdf_libs "netcdff" "netcdf" )
@@ -182,7 +182,6 @@ add_subdirectory( "ROMS/Utility" )
 include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
   "/usr/local/include"
-  "$ENV{NETCDF}/include"
   "Master"
   "ROMS/Drivers"
   "ROMS/Functionals"
@@ -201,7 +200,6 @@ include_directories(
 link_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
   "/usr/local/lib"
-  "$ENV{NETCDF}/lib"
 )
 
 list(APPEND srcs
@@ -294,6 +292,13 @@ set_property(
     ${CMAKE_CURRENT_BINARY_DIR}/f90/biology.f90
   APPEND_STRING PROPERTY COMPILE_FLAGS ${ROMS_FREEFLAGS}
 )
+
+if( CMAKE_Fortran_COMPILER_ID MATCHES "GNU" )
+  set_property(
+    SOURCE ${CMAKE_CURRENT_BINARY_DIR}/f90/ran_state.f90
+    APPEND_STRING PROPERTY COMPILE_FLAGS "-fno-strict-overflow"
+  )
+endif()
 
 ###########################################################################
 # Clean-up the dependencies

--- a/Compilers/Linux-ifx.mk
+++ b/Compilers/Linux-ifx.mk
@@ -176,6 +176,11 @@ ifdef USE_PIO
 endif
 
 ifdef USE_NETCDF4
+        NC_CONFIG ?= nc-config
+   TEST_NC_CONFIG := $(shell which $(NC_CONFIG))
+  ifneq ($(TEST_NC_CONFIG),)
+             LIBS += $(shell $(NC_CONFIG) --libs)
+  endif
         NF_CONFIG ?= nf-config
     NETCDF_INCDIR ?= $(shell $(NF_CONFIG) --prefix)/include
              LIBS += $(shell $(NF_CONFIG) --flibs)

--- a/Compilers/roms_functions.cmake
+++ b/Compilers/roms_functions.cmake
@@ -173,13 +173,40 @@ endfunction()
 
 function(link_netcdf)
   if( DEFINED ENV{NF_CONFIG} )
-    Message( STATUS "Using $ENV{NF_CONFIG}" )
+    set( NF_CONFIG_PATH "$ENV{NF_CONFIG}" )
+  endif()
+
+  if( DEFINED ENV{NC_CONFIG} )
+    set( NC_CONFIG_PATH "$ENV{NC_CONFIG}" )
+  endif()
+
+  if( NOT DEFINED NF_CONFIG_PATH )
+    find_program( NF_CONFIG_PATH "nf-config" )
+    if( NF_CONFIG_PATH )
+      Message( STATUS "nf-config command found at: ${NF_CONFIG_PATH}" )
+    else()
+      Message( WARNING "nf-config command NOT found" )
+    endif()
+  endif()
+
+  if( NOT DEFINED NC_CONFIG_PATH )
+    find_program( NC_CONFIG_PATH "nc-config" )
+    if( NC_CONFIG_PATH )
+      Message( STATUS "nc-config command found at: ${NC_CONFIG_PATH}" )
+    else()
+      Message( WARNING "nc-config command NOT found" )
+    endif()
+  endif()
+
+  if( DEFINED NF_CONFIG_PATH )
+    Message( STATUS "Using ${NF_CONFIG_PATH}" )
 
     # Get link line to break down below
 
-    execute_process( COMMAND $ENV{NF_CONFIG} --flibs
+    execute_process( COMMAND ${NF_CONFIG_PATH} --flibs
                      OUTPUT_VARIABLE tmp
-    )
+                   )
+    string( STRIP "${tmp}" tmp )
 
     if( DEFINED ENV{NETCDF_INCDIR} )
       set( idir "$ENV{NETCDF_INCDIR}" )                          # Set include directory
@@ -187,12 +214,26 @@ function(link_netcdf)
 
       # Retrieve include direcotry
 
-      execute_process( COMMAND $ENV{NF_CONFIG} --includedir
+      execute_process( COMMAND ${NF_CONFIG_PATH} --includedir
                        OUTPUT_VARIABLE idir
-      )
+                     )
     endif()
 
-    string( STRIP "${tmp}" linkline )                            # Strip trailing whitespace
+    if( DEFINED NC_CONFIG_PATH )
+      Message( STATUS "Using ${NC_CONFIG_PATH}" )
+
+      # Get link line to break down below
+
+      execute_process( COMMAND ${NC_CONFIG_PATH} --libs
+                       OUTPUT_VARIABLE tmp2
+                     )
+    string( STRIP "${tmp2}" tmp2 )
+    else()
+      Message( WARNING "nf-config command found but NOT nc-config. This will likely result in linking errors" )
+    endif()
+
+    # Combine the two link lines to break down below
+    string( STRIP "${tmp} ${tmp2}" linkline )                    # Strip trailing whitespace
     string( REGEX MATCHALL "-L[^ \t]*" ldirs ${linkline} )       # Create list of dirs
     string( REGEX MATCHALL "-l[^ \t]*" libs ${linkline} )        # Create list of libs
 
@@ -206,18 +247,19 @@ function(link_netcdf)
     else()
       Message( FATAL_ERROR "NetCDF includes not found!" )
     endif()
+  elseif( DEFINED ENV{NETCDF_INCDIR} AND DEFINED ENV{NETCDF_LIBDIR} )
+    set( ldirs "$ENV{NETCDF_LIBDIR}" )                         # Set lib directory
+    set( libs  "netcdf" )                                      # Set NetCDF3 lib name
+    set( idir  "$ENV{NETCDF_INCDIR}" )                         # Set include directory
   else()
-    if( DEFINED ENV{NETCDF_INCDIR} AND DEFINED ENV{NETCDF_LIBDIR} )
-      set( ldirs "$ENV{NETCDF_LIBDIR}" )                         # Set lib directory
-      set( libs  "netcdf" )                                      # Set NetCDF3 lib name
-      set( idir  "$ENV{NETCDF_INCDIR}" )                         # Set include directory
-    else()
-      Message( FATAL_ERROR "No NetCDF found!" )
-    endif()
+    Message( FATAL_ERROR "No NetCDF found!" )
   endif()
 
   list( TRANSFORM libs  REPLACE "-l([^ \t]*)" "\\1" )           # remove "-l" from libs
   list( TRANSFORM ldirs REPLACE "-L([^ \t]*)" "\\1" )           # remove "-L" from dirs
+
+  list( REMOVE_DUPLICATES libs )
+  list( REMOVE_DUPLICATES ldirs )
 
   if( "${libs}" STREQUAL "" )
     message( FATAL_ERROR "NetCDF library name not found" )

--- a/ROMS/Bin/submit_mixres_rbl4dvar.sh
+++ b/ROMS/Bin/submit_mixres_rbl4dvar.sh
@@ -84,113 +84,6 @@
 #SBATCH --error=err.%N.%j                # STDERR output file (optional)
 #SBATCH --export=ALL                     # Export you current env to the job env
 
-########################################################################
-## RBL4D-Var data assimilation input script function.  It generates    #
-## 'rbl4dvar_nl.in' or 'rbl4dvar_nl.in' from the 's4dvar.in' template. #
-########################################################################
-
-## Start of My4DVarScript() function definition
-
-My4DVarScript() {
-
-     DataDir=${1}              # Data directory
-  SUBSTITUTE=${2}              # ROMS Perl subtitution function
-   OuterLoop=${3}              # current outer loop counter
-  Phase4DVAR=${4}              # current 4D-Var computation phase
-     TimeIAU=${5}              # Incremental Analysis Update window
-     OBSname=${6}              # 4D-Var observations NetCDF file
-     Fprefix=${7}              # ROMS output files prefix (use roms_app)
-     Fsuffix=${8}              # ROMS output files suffix
-    Inp4DVAR=${9}              # 4D-Var standard input
-         res=${10}             # Grid resolution
-
-  echo
-  echo "   Creating 4D-Var Input Script from Template: ${Inp4DVAR}" \
-       "  Outer = ${OuterLoop}  Phase = ${Phase4DVAR}"
-  echo "     (Resolution = ${res} km, Fprefix = ${Fprefix}, Fsuffix = ${Fsuffix})"
-  echo
-
-## Set model, initial conditions, boundary conditions and surface
-## forcing error covariance standard deviations files. For model
-## error, use the same as initial condition since we are not
-## running in weak-constraint mode.
-
-if [[ $res -eq 6 ]]; then
- STDnameM=${DataDir}/STD/usec6km_roms_std_i_${Fsuffix}.nc
- STDnameI=${DataDir}/STD/usec6km_roms_std_i_${Fsuffix}.nc
- STDnameB=${DataDir}/STD/usec6km_roms_std_b_${Fsuffix}.nc
- STDnameF=${DataDir}/STD/usec6km_roms_std_f_${Fsuffix}.nc
-else
- STDnameM=${DataDir}/STD/usec3km_roms_std_i_${Fsuffix}.nc
- STDnameI=${DataDir}/STD/usec3km_roms_std_i_${Fsuffix}.nc
- STDnameB=${DataDir}/STD/usec3km_roms_std_b_${Fsuffix}.nc
- STDnameF=${DataDir}/STD/usec3km_roms_std_f_${Fsuffix}.nc
-fi
-
-## Set output file for standard deviation computed/modeled from background
-## (prior) state.
-
-if [[ $res -eq 6 ]]; then
- STDnameC=usec6km_roms_std_computed.nc
-else
- STDnameC=usec3km_roms_std_computed.nc
-fi
-
-## Set model, initial conditions, boundary conditions and surface
-## forcing error covariance normalization factors files. For model
-## error, use the same as initial condition since we are not
-## running in weak-constraint mode.
-
-if [[ $res -eq 6 ]]; then
- NRMnameM=${DataDir}/NRM/usec6km_roms_nrm_i.nc
- NRMnameI=${DataDir}/NRM/usec6km_roms_nrm_i.nc
- NRMnameB=${DataDir}/NRM/usec6km_roms_nrm_b.nc
- NRMnameF=${DataDir}/NRM/usec6km_roms_nrm_f.nc
-else
- NRMnameM=${DataDir}/NRM/usec3km_roms_nrm_i.nc
- NRMnameI=${DataDir}/NRM/usec3km_roms_nrm_i.nc
- NRMnameB=${DataDir}/NRM/usec3km_roms_nrm_b.nc
- NRMnameF=${DataDir}/NRM/usec3km_roms_nrm_f.nc
-fi
-
-## Modify 4D-Var template input script and specify above files.
-
- if [ -f $Inp4DVAR ]; then
-   /bin/rm ${Inp4DVAR}
- fi
-
- cp ../s4dvar.in ${Inp4DVAR}
-
- $SUBSTITUTE $Inp4DVAR MyOuterLoop   ${OuterLoop}
- $SUBSTITUTE $Inp4DVAR MyPhase4DVAR  ${Phase4DVAR}
- $SUBSTITUTE $Inp4DVAR MyTimeIAU     ${TimeIAU}
- $SUBSTITUTE $Inp4DVAR roms_std_i.nc ${STDnameI}
- $SUBSTITUTE $Inp4DVAR roms_std_m.nc ${STDnameM}
- $SUBSTITUTE $Inp4DVAR roms_std_b.nc ${STDnameB}
- $SUBSTITUTE $Inp4DVAR roms_std_f.nc ${STDnameF}
- $SUBSTITUTE $Inp4DVAR roms_std_c.nc ${STDnameC}
- $SUBSTITUTE $Inp4DVAR roms_nrm_i.nc ${NRMnameI}
- $SUBSTITUTE $Inp4DVAR roms_nrm_m.nc ${NRMnameM}
- $SUBSTITUTE $Inp4DVAR roms_nrm_b.nc ${NRMnameB}
- $SUBSTITUTE $Inp4DVAR roms_nrm_f.nc ${NRMnameF}
- $SUBSTITUTE $Inp4DVAR roms_obs.nc   ${OBSname}
- $SUBSTITUTE $Inp4DVAR roms_hss.nc   ${Fprefix}_roms_hss_${Fsuffix}.nc
- $SUBSTITUTE $Inp4DVAR roms_lcz.nc   ${Fprefix}_roms_lcz_${Fsuffix}.nc
- $SUBSTITUTE $Inp4DVAR roms_lze.nc   ${Fprefix}_roms_lze_${Fsuffix}.nc
-
- if [[ $res -eq 6 ]]; then           # same as outer loops grid
-   $SUBSTITUTE $Inp4DVAR roms_mod.nc usec3km_roms_mod_${Fsuffix}.nc
-   $SUBSTITUTE $Inp4DVAR roms_inc.nc ${Fprefix}_roms_inc_${Fsuffix}.nc
- else
-   $SUBSTITUTE $Inp4DVAR roms_mod.nc ${Fprefix}_roms_mod_${Fsuffix}.nc
-   $SUBSTITUTE $Inp4DVAR roms_inc.nc usec6km_roms_itl_${Fsuffix}.nc
- fi
-
- $SUBSTITUTE $Inp4DVAR roms_err.nc   ${Fprefix}_roms_err_${Fsuffix}.nc
-}
-
-## End of My4DVarScript() function definition
-
 ##---------------------------------------------------------------------
 ## Control switches: What do you want to do?
 ##---------------------------------------------------------------------
@@ -199,10 +92,15 @@ fi
        DRYRUN=0                # Run 4D-Var cycle
 
         BATCH=0                # No batch system submission
-#       BATCH=1                # Use batch system SLURM to submit
+#       BATCH=1                # Use batch system SLURM to submit:
+                               #   "sbatch submit_mixres_rbl4dvar.sh"
+
+    ROMS_ROOT=${HOME}/ocean/repository/git/roms    # Set ROMS location:
+                                                   # uses ROMS/Bin
+                                                   # Perl scripts
 
 ##---------------------------------------------------------------------
-## User tunable parameters. If you follow recommendations, this is
+## USER TUNABLE PARAMETERS. If you follow recommendations, this is
 ## the only section that you need to customize..
 ##---------------------------------------------------------------------
 
@@ -215,8 +113,6 @@ fi
 
           ResF=3                       # outer loop resolution
           ResC=6                       # innet loop resolution
-
-     ROMS_ROOT=${HOME}/ocean/repository/git/roms
 
        HereDir=${PWD}                  # current directory
 
@@ -279,9 +175,9 @@ fi
 
      MyINP_LIB=2                       # reading library: [1] standard [2] PIO
      MyOUT_LIB=2                       # writing library: [1] standard [2] PIO
-  MyPIO_METHOD=2                       # [1] NetCDF3, ...
- MyPIO_IOTASKS=1                       # number of I/O processes
-  MyPIO_STRIDE=1                       # stride in MPI-rank between I/O tasks
+  MyPIO_METHOD=3                       # [1] NetCDF3, ...
+ MyPIO_IOTASKS=2                       # number of I/O processes
+  MyPIO_STRIDE=5                       # stride in MPI-rank between I/O tasks
     MyPIO_BASE=0                       # offset for the first I/O task
    MyPIO_REARR=1                       # rearranger method: [1] box [2] subset
 MyPIO_REARRCOM=1                       # rearranger communications: [0] p2p [1] coll
@@ -299,8 +195,8 @@ MyPIO_REARRDIR=0                       # rearranger direction: [0] I2C/C2I, ... 
     ROMS_DAtmp="${ROMS_DApre}.tmpl"                # ROMS ADM/TLM stdinp template
 
  if [[ ${restart} -eq 0 ]]; then
-      ROMSiniF="usec3km_roms_ini_20190827.nc"      # ROMS outer loop IC
-   ROMSgeniniC="usec6km_roms_ini.nc"               # ROMS Generic inner loop IC
+      ROMSiniF="usec3km_roms_ini_20190827.nc4"     # ROMS outer loop IC
+   ROMSgeniniC="usec6km_roms_ini.nc4"              # ROMS Generic inner loop IC
     ROMSiniDir=${DataDir}/INI                      # ROMS IC directory
  else
        ROMSini="usec3km_roms_dai_20190827.nc"      # restart ROMS IC
@@ -351,6 +247,117 @@ MyPIO_REARRDIR=0                       # rearranger direction: [0] I2C/C2I, ... 
      MyNOBC_da=$(( ${MyNOBC_nl} / 2 ))
  fi
 
+##---------------------------------------------------------------------
+## END OF USER TUNABLE PARAMETERS.
+##---------------------------------------------------------------------
+
+########################################################################
+## RBL4D-Var data assimilation input script FUNCTION.  It generates    #
+## 'rbl4dvar_nl.in' or 'rbl4dvar_nl.in' from the 's4dvar.in' template. #
+########################################################################
+
+## Start of My4DVarScript() FUNCTION definition
+
+My4DVarScript() {
+
+     DataDir=${1}              # Data directory
+  SUBSTITUTE=${2}              # ROMS Perl substitution function
+   OuterLoop=${3}              # current outer loop counter
+  Phase4DVAR=${4}              # current 4D-Var computation phase
+     TimeIAU=${5}              # Incremental Analysis Update window
+     OBSname=${6}              # 4D-Var observations NetCDF file
+     Fprefix=${7}              # ROMS output files prefix (use roms_app)
+     Fsuffix=${8}              # ROMS output files suffix
+    Inp4DVAR=${9}              # 4D-Var standard input
+         res=${10}             # Grid resolution
+
+  echo
+  echo "   Creating 4D-Var Input Script from Template: ${Inp4DVAR}" \
+       "  Outer = ${OuterLoop}  Phase = ${Phase4DVAR}"
+  echo "     (Resolution = ${res} km, Fprefix = ${Fprefix}, Fsuffix = ${Fsuffix})"
+  echo
+
+## Set model, initial conditions, boundary conditions and surface
+## forcing error covariance standard deviations files. For model
+## error, use the same as initial condition since we are not
+## running in weak-constraint mode.
+
+if [[ $res -eq 6 ]]; then
+ STDnameM=${DataDir}/STD/usec6km_roms_std_i_${Fsuffix}.nc4
+ STDnameI=${DataDir}/STD/usec6km_roms_std_i_${Fsuffix}.nc4
+ STDnameB=${DataDir}/STD/usec6km_roms_std_b_${Fsuffix}.nc4
+ STDnameF=${DataDir}/STD/usec6km_roms_std_f_${Fsuffix}.nc4
+else
+ STDnameM=${DataDir}/STD/usec3km_roms_std_i_${Fsuffix}.nc4
+ STDnameI=${DataDir}/STD/usec3km_roms_std_i_${Fsuffix}.nc4
+ STDnameB=${DataDir}/STD/usec3km_roms_std_b_${Fsuffix}.nc4
+ STDnameF=${DataDir}/STD/usec3km_roms_std_f_${Fsuffix}.nc4
+fi
+
+## Set output file for standard deviation computed/modeled from background
+## (prior) state.
+
+if [[ $res -eq 6 ]]; then
+ STDnameC=usec6km_roms_std_computed.nc4
+else
+ STDnameC=usec3km_roms_std_computed.nc4
+fi
+
+## Set model, initial conditions, boundary conditions and surface
+## forcing error covariance normalization factors files. For model
+## error, use the same as initial condition since we are not
+## running in weak-constraint mode.
+
+if [[ $res -eq 6 ]]; then
+ NRMnameM=${DataDir}/NRM/usec6km_roms_nrm_i.nc4
+ NRMnameI=${DataDir}/NRM/usec6km_roms_nrm_i.nc4
+ NRMnameB=${DataDir}/NRM/usec6km_roms_nrm_b.nc4
+ NRMnameF=${DataDir}/NRM/usec6km_roms_nrm_f.nc4
+else
+ NRMnameM=${DataDir}/NRM/usec3km_roms_nrm_i.nc4
+ NRMnameI=${DataDir}/NRM/usec3km_roms_nrm_i.nc4
+ NRMnameB=${DataDir}/NRM/usec3km_roms_nrm_b.nc4
+ NRMnameF=${DataDir}/NRM/usec3km_roms_nrm_f.nc4
+fi
+
+## Modify 4D-Var template input script and specify above files.
+
+ if [ -f $Inp4DVAR ]; then
+   /bin/rm ${Inp4DVAR}
+ fi
+
+ cp ../s4dvar.in ${Inp4DVAR}
+
+ $SUBSTITUTE $Inp4DVAR MyOuterLoop   ${OuterLoop}
+ $SUBSTITUTE $Inp4DVAR MyPhase4DVAR  ${Phase4DVAR}
+ $SUBSTITUTE $Inp4DVAR MyTimeIAU     ${TimeIAU}
+ $SUBSTITUTE $Inp4DVAR roms_std_i.nc ${STDnameI}
+ $SUBSTITUTE $Inp4DVAR roms_std_m.nc ${STDnameM}
+ $SUBSTITUTE $Inp4DVAR roms_std_b.nc ${STDnameB}
+ $SUBSTITUTE $Inp4DVAR roms_std_f.nc ${STDnameF}
+ $SUBSTITUTE $Inp4DVAR roms_std_c.nc ${STDnameC}
+ $SUBSTITUTE $Inp4DVAR roms_nrm_i.nc ${NRMnameI}
+ $SUBSTITUTE $Inp4DVAR roms_nrm_m.nc ${NRMnameM}
+ $SUBSTITUTE $Inp4DVAR roms_nrm_b.nc ${NRMnameB}
+ $SUBSTITUTE $Inp4DVAR roms_nrm_f.nc ${NRMnameF}
+ $SUBSTITUTE $Inp4DVAR roms_obs.nc   ${OBSname}
+ $SUBSTITUTE $Inp4DVAR roms_hss.nc   ${Fprefix}_roms_hss_${Fsuffix}.nc
+ $SUBSTITUTE $Inp4DVAR roms_lcz.nc   ${Fprefix}_roms_lcz_${Fsuffix}.nc
+ $SUBSTITUTE $Inp4DVAR roms_lze.nc   ${Fprefix}_roms_lze_${Fsuffix}.nc
+
+ if [[ $res -eq 6 ]]; then           # same as outer loops grid
+   $SUBSTITUTE $Inp4DVAR roms_mod.nc usec3km_roms_mod_${Fsuffix}.nc
+   $SUBSTITUTE $Inp4DVAR roms_inc.nc ${Fprefix}_roms_inc_${Fsuffix}.nc
+ else
+   $SUBSTITUTE $Inp4DVAR roms_mod.nc ${Fprefix}_roms_mod_${Fsuffix}.nc
+   $SUBSTITUTE $Inp4DVAR roms_inc.nc usec6km_roms_itl_${Fsuffix}.nc
+ fi
+
+ $SUBSTITUTE $Inp4DVAR roms_err.nc   ${Fprefix}_roms_err_${Fsuffix}.nc
+}
+
+## End of My4DVarScript() FUNCTION definition
+
 #######################################################################
 ## Main body of script starts here. It is very unlikely that the USER
 ## needs to modify it.
@@ -374,7 +381,7 @@ echo
 
 ##---------------------------------------------------------------------
 ## Compute date number for reference date, and first and last
-## initialization dates.
+## initialization dates. It uses ROMS/Bin/dates Perl script.
 ##---------------------------------------------------------------------
 
          S_DN=`${ROMS_ROOT}/ROMS/Bin/dates datenum ${START_DATE}`
@@ -430,7 +437,7 @@ while [ $SDAY -le $L_DN ]; do
         Fsuffix=`${DATE_EXE} -d "${SDATE}" '+%Y%m%d'`
          RunDir=`${DATE_EXE} -d "${SDATE}" '+%Y.%m.%d'`
      ROMS_INI_F="${ROMSiniF}"
-     ROMS_INI_C="${FprefixC}_roms_ini_${Fsuffix}.nc"
+     ROMS_INI_C="${FprefixC}_roms_ini_${Fsuffix}.nc4"
 
   echo "${separator2}"
   echo
@@ -572,8 +579,8 @@ while [ $SDAY -le $L_DN ]; do
 
 ## Set observations NetCDF filename.
 
-  OBSnameF="${FprefixF}_roms_obs_${Fsuffix}.nc"
-  OBSnameC="${FprefixC}_roms_obs_${Fsuffix}.nc"
+  OBSnameF="${FprefixF}_roms_obs_${Fsuffix}.nc4"
+  OBSnameC="${FprefixC}_roms_obs_${Fsuffix}.nc4"
 
 ## Copy outer loops nonlinear model initial conditions file.
 
@@ -644,7 +651,7 @@ while [ $SDAY -le $L_DN ]; do
     nl_log="log_outer${OuterLoop}.nl"
 
     if [ ${BATCH} -eq 1 ]; then
-      ${SRUN} ${ROMS_EXE_A} ${ROMS_NLinp}
+      ${SRUN} ${ROMS_EXE_A} ${ROMS_NLinp} > ${nl_log}
     else
       ${MPIrun} ${nPETs} ${ROMS_EXE_A} ${ROMS_NLinp} > ${nl_log}
     fi
@@ -654,7 +661,7 @@ while [ $SDAY -le $L_DN ]; do
       echo "Error while running 4D-Var System:  Cycle = ${Cycle}" \
                                              "  Outer = ${OuterLoop}" \
                                              "  Phase = ${Phase4DVAR}"
-      echo "Check ${RunDir}/log.roms for details ..."
+      echo "Check ${nl_log} for details ..."
       exit 1
     fi
   fi
@@ -702,7 +709,7 @@ while [ $SDAY -le $L_DN ]; do
       da_log="log_outer${OuterLoop}.da"
 
       if [ ${BATCH} -eq 1 ]; then
-        ${SRUN} ${ROMS_EXE_B} ${ROMS_DAinp}
+        ${SRUN} ${ROMS_EXE_B} ${ROMS_DAinp} > ${da_log}
       else
         ${MPIrun} ${nPETs} ${ROMS_EXE_B} ${ROMS_DAinp} > ${da_log}
       fi
@@ -712,7 +719,7 @@ while [ $SDAY -le $L_DN ]; do
         echo "Error while running 4D-Var System:  Cycle = ${Cycle}" \
                                                "  Outer = ${OuterLoop}" \
 			                       "  Phase = ${Phase4DVAR}"
-        echo "Check ${RunDir}/log.roms for details ..."
+        echo "Check ${da_log} for details ..."
         exit 1
       fi
     fi
@@ -737,7 +744,7 @@ while [ $SDAY -le $L_DN ]; do
       nl_log="log_outer${OuterLoop}.nl"
 
       if [ ${BATCH} -eq 1 ]; then
-        ${SRUN} ${ROMS_EXE_A} ${ROMS_NLinp}
+        ${SRUN} ${ROMS_EXE_A} ${ROMS_NLinp} > ${nl_log}
       else
         ${MPIrun} ${nPETs} ${ROMS_EXE_A} ${ROMS_NLinp} > ${nl_log}
       fi
@@ -747,7 +754,7 @@ while [ $SDAY -le $L_DN ]; do
         echo "Error while running 4D-Var System:  Cycle = ${Cycle}" \
                                                "  Outer = ${OuterLoop}" \
 			                       "  Phase = ${Phase4DVAR}"
-        echo "Check ${RunDir}/log.roms for details ..."
+        echo "Check ${nl_log} for details ..."
         exit 1
       fi
     fi

--- a/ROMS/Tangent/tl_wrt_ini.F
+++ b/ROMS/Tangent/tl_wrt_ini.F
@@ -148,7 +148,7 @@
 !
 !  Local variable declarations.
 !
-      integer :: gfactor, gtype, i, itrc, status, varid
+      integer :: gfactor, gtype, i, itrc, omode, status, varid
 !
       real(dp) :: my_time, scale
 !
@@ -213,6 +213,14 @@
 # endif
       END IF
 !
+!  If appropriate, open ITL NetCDF for writing.
+!
+      IF (ITL(ng)%ncid.eq.-1) THEN
+        omode=1
+        CALL netcdf_open (ng, iTLM, ITL(ng)%name, omode, ITL(ng)%ncid)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      END IF
+!
 !  Set grid type factor to write full (gfactor=1) fields or water
 !  points (gfactor=-1) fields only.
 !
@@ -227,7 +235,7 @@
 !
       my_time=tdays(ng)*day2sec
 
-      CALL netcdf_put_fvar (ng, iTLM, ITL(ng)%name,                     &
+      CALL netcdf_put_fvar (ng, iTLM,  ITL(ng)%name,                    &
      &                      TRIM(Vname(1,idtime)), my_time,             &
      &                      (/OutRec/), (/1/),                          &
      &                      ncid = ITL(ng)%ncid,                        &
@@ -647,11 +655,15 @@
 # endif
 !
 !-----------------------------------------------------------------------
-!  Synchronize tangent linear initial NetCDF file to disk to allow other
-!  processes to access data immediately after it is written.
+!  In split 4D-Var and NetCDF4/HDF5 files, it is advantegeous to always
+!  close the tangent linear initial NetCDF file to automatically to
+!  to force buffering and caching and allow other access to data
+!  immediately after it is written. Synchronization with "netcdf_sync"
+!  does not work well with NetCDF4/HDF5 files in various computer
+!  architectures.
 !-----------------------------------------------------------------------
 !
-      CALL netcdf_sync (ng, iTLM, ITL(ng)%name, ITL(ng)%ncid)
+      CALL netcdf_close (ng, iTLM, ITL(ng)%ncid, ITL(ng)%name, .FALSE.)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
 # if defined I4DVAR || defined BACKGROUND
@@ -694,7 +706,7 @@
 !
 !  Local variable declarations.
 !
-      integer :: i, ifield, itrc, status
+      integer :: i, ifield, itrc, omode, status
 !
       real(dp) :: my_time, scale
 !
@@ -759,6 +771,14 @@
 #  else
         WRITE (stdout,10) string, outer, inner, Tindex, OutRec
 #  endif
+      END IF
+!
+!  If appropriate, open ITL NetCDF for writing.
+!
+      IF (ITL(ng)%pioFile%fh.eq.-1) THEN
+        omode=1
+        CALL pio_netcdf_open (ng, iTLM, ITL(ng)%name, omode,            &
+     &                        ITL(ng)%pioFile)
       END IF
 !
 !  Write out model time (s). Use the "tdays" variable here because of
@@ -1243,11 +1263,16 @@
 #  endif
 !
 !-----------------------------------------------------------------------
-!  Synchronize tangent linear initial NetCDF file to disk to allow other
-!  processes to access data immediately after it is written.
+!  In split 4D-Var and NetCDF4/HDF5 files, it is advantegeous to always
+!  close the tangent linear initial NetCDF file to automatically to
+!  to force buffering and caching and allow other access to data
+!  immediately after it is written. Synchronization with "netcdf_sync"
+!  does not work well with NetCDF4/HDF5 files in various computer
+!  architectures.
 !-----------------------------------------------------------------------
 !
-      CALL pio_netcdf_sync (ng, iTLM, ITL(ng)%name, ITL(ng)%pioFile)
+      CALL pio_netcdf_close (ng, iTLM, ITL(ng)%pioFile, ITL(ng)%name,   &
+     &                       .FALSE.)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 
 #  if defined I4DVAR || defined BACKGROUND

--- a/ROMS/Utility/roms_interp.F
+++ b/ROMS/Utility/roms_interp.F
@@ -1528,10 +1528,15 @@
             CASE (io_pio)
               self%Cvars(i)%pioFile = self%Cvars(1)%pioFile
 #endif
-        END SELECT
-        self%Cvars(i)%IsRomsFile = self%Cvars(1)%IsRomsFile
-        IF (FoundError(assign_string(self%Cvars(i)%ncname, ncname),     &
+          END SELECT
+          self%Cvars(i)%IsRomsFile = self%Cvars(1)%IsRomsFile
+          IF (FoundError(assign_string(self%Cvars(i)%ncname, ncname),   &
      &                 NoError, __LINE__, MyFile)) RETURN
+        ELSE
+          self%Cvars(1)%ncid = -1        ! force open file on first pass
+#if defined PIO_LIB && defined DISTRIBUTE
+          self%Cvars(1)%pioFile%fh = -1
+#endif
         END IF
 !
         CALL self%Cvars(i)%create (ng, tile, kernel, Ctype(i), ncname)

--- a/ROMS/Utility/wrt_ini.F
+++ b/ROMS/Utility/wrt_ini.F
@@ -152,7 +152,7 @@
 !
       logical :: SetFillVal
 !
-      integer :: Fcount, gfactor, gtype, i, itrc, status, varid
+      integer :: Fcount, gfactor, gtype, i, itrc, omode, status, varid
 !
       real(r8) :: Fmin, Fmax
       real(dp) :: my_time, scale
@@ -198,6 +198,14 @@
       END IF
       Fcount=INI(ng)%Fcount
       INI(ng)%Nrec(Fcount)=INI(ng)%Nrec(Fcount)+1
+!
+!  If appropriate, open INI NetCDF for writing.
+!
+      IF (INI(ng)%ncid.eq.-1) THEN
+        omode=1
+        CALL netcdf_open (ng, iNLM, INI(ng)%name, omode, INI(ng)%ncid)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      END IF
 !
 !  Write out model time (s). Use the "tdays" variable here because of
 !  the management of the "time" variable due to nesting.
@@ -516,16 +524,17 @@
 #   endif
 #  endif
 # endif
-# if !(defined OUT_NETCDF4 && defined DELAYED_SYNC_NF90)
 !
 !-----------------------------------------------------------------------
-!  Synchronize initial NetCDF file to disk to allow other processes
-!  to access data immediately after it is written.
+!  In split 4D-Var and NetCDF4/HDF5 files, it is advantegeous to always
+!  close the nonlinear initial NetCDF file to automatically to force
+!  buffering and caching and allow other access to datavimmediately
+!  after it is written. Synchronization with "netcdf_sync" does not
+!  work well with NetCDF4/HDF5 files in various computer architectures.
 !-----------------------------------------------------------------------
 !
-      CALL netcdf_sync (ng, iNLM, INI(ng)%name, INI(ng)%ncid)
+      CALL netcdf_close (ng, iNLM, INI(ng)%ncid, INI(ng)%name, .FALSE.)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-# endif
 !
   10  FORMAT (/,' WRT_INI_NF90 - error while writing variable: ',a,     &
      &        /,16x,'into initial NetCDF file for time record: ',i0)
@@ -560,7 +569,7 @@
 !
       logical :: SetFillVal
 !
-      integer :: Fcount, i, itrc, status
+      integer :: Fcount, i, itrc, omode, status
 !
       real(r8) :: Fmin, Fmax
       real(dp) :: my_time, scale
@@ -599,6 +608,15 @@
       END IF
       Fcount=INI(ng)%Fcount
       INI(ng)%Nrec(Fcount)=INI(ng)%Nrec(Fcount)+1
+!
+!  If appropriate, open INI NetCDF for writing.
+!
+      IF (INI(ng)%pioFile%fh.eq.-1) THEN
+        omode=1
+        CALL pio_netcdf_open (ng, iNLM, INI(ng)%name, omode,            &
+     &                        INI(ng)%pioFile)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      END IF
 !
 !  Write out model time (s). Use the "tdays" variable here because of
 !  the management of the "time" variable due to nesting.
@@ -982,16 +1000,18 @@
 #    endif
 #   endif
 #  endif
-#  ifndef DELAYED_SYNC_PIO
 !
 !-----------------------------------------------------------------------
-!  Synchronize initial NetCDF file to disk to allow other processes
-!  to access data immediately after it is written.
+!  In split 4D-Var and NetCDF4/HDF5 files, it is advantegeous to always
+!  close the nonlinear initial NetCDF file to automatically to force
+!  buffering and caching and allow other access to datavimmediately
+!  after it is written. Synchronization with "pio_netcdf_sync" does not
+!  work well with NetCDF4/HDF5 files in various computer architectures.
 !-----------------------------------------------------------------------
 !
-      CALL pio_netcdf_sync (ng, iNLM, INI(ng)%name, INI(ng)%pioFile)
+      CALL pio_netcdf_close (ng, iNLM, INI(ng)%pioFile, INI(ng)%name,   &
+     &                       .FALSE.)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
-#  endif
 !
   10  FORMAT (/,' WRT_INI_PIO - error while writing variable: ',a,      &
      &        /,15x,'into initial NetCDF file for time record: ',i0)
@@ -1088,7 +1108,7 @@
 !
 !  Local variable declarations.
 !
-      integer :: gfactor, gtype, i, itrc, status
+      integer :: gfactor, gtype, i, itrc, omode, status
 !
       real(dp) :: scale
 !
@@ -1121,6 +1141,14 @@
 #  else
       gfactor=1
 #  endif
+!
+!  If appropriate, open INI NetCDF for writing.
+!
+      IF (INI(ng)%ncid.eq.-1) THEN
+        omode=1
+        CALL netcdf_open (ng, iNLM, INI(ng)%name, omode, INI(ng)%ncid)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      END IF
 
 #  ifdef ADJUST_BOUNDARY
 !
@@ -1345,11 +1373,14 @@
 #  endif
 !
 !-----------------------------------------------------------------------
-!  Synchronize initial NetCDF file to disk to allow other processes
-!  to access data immediately after it is written.
+!  In split 4D-Var and NetCDF4/HDF5 files, it is advantegeous to always
+!  close the nonlinear initial NetCDF file to automatically to force
+!  buffering and caching and allow other access to datavimmediately
+!  after it is written. Synchronization with "netcdf_sync" does not
+!  work well with NetCDF4/HDF5 files in various computer architectures.
 !-----------------------------------------------------------------------
 !
-      CALL netcdf_sync (ng, iNLM, INI(ng)%name, INI(ng)%ncid)
+      CALL netcdf_close (ng, iNLM, INI(ng)%ncid, INI(ng)%name, .FALSE.)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
   10  FORMAT (2x,'WRT_FRC_NF90     - writing forcing  fields',          &
@@ -1388,7 +1419,7 @@
 !
 !  Local variable declarations.
 !
-      integer :: i, ifield, itrc, status
+      integer :: i, ifield, itrc, omode, status
 !
       real(dp) :: scale
 !
@@ -1413,6 +1444,15 @@
 #   else
         WRITE (stdout,10) outer, inner, Tindex, OutRec
 #   endif
+      END IF
+!
+!  If appropriate, open INI NetCDF for writing.
+!
+      IF (INI(ng)%pioFile%fh.eq.-1) THEN
+        omode=1
+        CALL pio_netcdf_open (ng, iNLM, INI(ng)%name, omode,            &
+     &                        INI(ng)%pioFile)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
       END IF
 
 #   ifdef ADJUST_BOUNDARY
@@ -1666,11 +1706,15 @@
 #   endif
 !
 !-----------------------------------------------------------------------
-!  Synchronize initial NetCDF file to disk to allow other processes
-!  to access data immediately after it is written.
+!  In split 4D-Var and NetCDF4/HDF5 files, it is advantegeous to always
+!  close the nonlinear initial NetCDF file to automatically to force
+!  buffering and caching and allow other access to datavimmediately
+!  after it is written. Synchronization with "pio_netcdf_sync" does not
+!  work well with NetCDF4/HDF5 files in various computer architectures.
 !-----------------------------------------------------------------------
 !
-      CALL pio_netcdf_sync (ng, iNLM, INI(ng)%name, INI(ng)%pioFile)
+      CALL pio_netcdf_close (ng, iNLM, INI(ng)%pioFile, INI(ng)%name,   &
+     &                       .FALSE.)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
   10  FORMAT (2x,'WRT_FRC_PIO      - writing forcing  fields',          &
@@ -1767,7 +1811,7 @@
 !
 !  Local variable declarations.
 !
-      integer :: gfactor, gtype, i, itrc, status
+      integer :: gfactor, gtype, i, itrc, omode, status
 !
       real(dp) :: scale
 !
@@ -1800,6 +1844,14 @@
 #  else
       gfactor=1
 #  endif
+!
+!  If appropriate, open INI NetCDF for writing.
+!
+      IF (INI(ng)%ncid.eq.-1) THEN
+        omode=1
+        CALL netcdf_open (ng, iNLM, INI(ng)%name, omode, INI(ng)%ncid)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
+      END IF
 
 #  ifdef ADJUST_BOUNDARY
 !
@@ -2020,11 +2072,14 @@
 #  endif
 !
 !-----------------------------------------------------------------------
-!  Synchronize initial NetCDF file to disk to allow other processes
-!  to access data immediately after it is written.
+!  In split 4D-Var and NetCDF4/HDF5 files, it is advantegeous to always
+!  close the nonlinear initial NetCDF file to automatically to force
+!  buffering and caching and allow other access to datavimmediately
+!  after it is written. Synchronization with "netcdf_sync" does not
+!  work well with NetCDF4/HDF5 files in various computer architectures.
 !-----------------------------------------------------------------------
 !
-      CALL netcdf_sync (ng, iNLM, INI(ng)%name, INI(ng)%ncid)
+      CALL netcdf_close (ng, iNLM, INI(ng)%ncid, INI(ng)%name, .FALSE.)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
   10  FORMAT (2x,'WRT_FRC_AD_NF90  - writing forcing  fields',          &
@@ -2063,7 +2118,7 @@
 !
 !  Local variable declarations.
 !
-      integer :: i, ifield, itrc, status
+      integer :: i, ifield, itrc, omode, status
 !
       real(dp) :: scale
 !
@@ -2088,6 +2143,15 @@
 #  else
         WRITE (stdout,10) outer, inner, Tindex, OutRec
 #  endif
+      END IF
+!
+!  If appropriate, open INI NetCDF for writing.
+!
+      IF (INI(ng)%pioFile%fh.eq.-1) THEN
+        omode=1
+        CALL pio_netcdf_open (ng, iNLM, INI(ng)%name, omode,            &
+     &                        INI(ng)%pioFile)
+        IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
       END IF
 
 #   ifdef ADJUST_BOUNDARY
@@ -2337,11 +2401,15 @@
 #   endif
 !
 !-----------------------------------------------------------------------
-!  Synchronize initial NetCDF file to disk to allow other processes
-!  to access data immediately after it is written.
+!  In split 4D-Var and NetCDF4/HDF5 files, it is advantegeous to always
+!  close the nonlinear initial NetCDF file to automatically to force
+!  buffering and caching and allow other access to datavimmediately
+!  after it is written. Synchronization with "pio_netcdf_sync" does not
+!  work well with NetCDF4/HDF5 files in various computer architectures.
 !-----------------------------------------------------------------------
 !
-      CALL pio_netcdf_sync (ng, iNLM, INI(ng)%name, INI(ng)%pioFile)
+      CALL pio_netcdf_close (ng, iNLM, INI(ng)%pioFile, INI(ng)%name,   &
+     &                       .FALSE.)
       IF (FoundError(exit_flag, NoError, __LINE__, MyFile)) RETURN
 !
   10  FORMAT (2x,'WRT_FRC_AD_PIO   - writing forcing  fields',          &


### PR DESCRIPTION
# Description
In split **4D-Var** with output **NetCDF4/HDF5** files, it is advantageous to always close the nonlinear initial/analysis (**INI**) and tangent linear initial/increments (**ITL**) NetCDF files to automatically enable buffering and caching and allow immediate access to the data after it is written. Synchronization with **`nf90_sync`** or **`PIO_syncfile`** does not work well with **NetCDF4/HDF5** format files in various computer architectures.

The reason why **NetCDF4/HDF5** do not synchronize data (I/O buffering and caching) to disk until the file is closed is primarily to maximize performance by keeping data in memory. Writing to disk is slow; buffering allows multiple write operations to be batched into a single, efficient operation. Data is automatically synchronized when **`nf90_close`** or **`PIO_closefile`** is called.

Updated main **CMakeList.txt** and **Compilers/roms_functions.cmake** files to allow compiling standalone **ROMS** with Spack-Stack. The issue is that nowadays the **NetCDF `nc-config`** and **`nf-config`** scripts are located in different directories.

## Issue(s) addressed
None.

## Impacts
We have been struggling continuously with the split, mixed-resolution 4D-Var data assimilation execution at Rutgers supercomputer Amarel. It was hanging out without any errors in the solution. Finally, we obtained more information from ROMS, and as we suspected, it was due to a failed disk synchronization for immediate access.

## Dependencies
None.

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR
- [x] I have run and tested the changes before creating the PR
