### PR TITLE
Adding INTEL OneAPI Compatability

### DIFF
--- a/Compilers/Linux-ifx.mk
+++ b/Compilers/Linux-ifx.mk
@@ -215,6 +215,8 @@ ifdef USE_MPI
  ifdef USE_MPIF90
   ifeq ($(which_MPI), intel)
                FC := mpiifort
+  else ifeq ($(which_MPI), oneapi)
+               FC := mpiifx
   else
                FC := mpif90
   endif

--- a/Compilers/compiler_flags_IntelLLVM_Fortran.cmake
+++ b/Compilers/compiler_flags_IntelLLVM_Fortran.cmake
@@ -12,8 +12,12 @@
 ###########################################################################
 
 if( MPI )
-  if( ${COMM} MATCHES "intel")
+  if( ${COMM} MATCHES "intel" )
     execute_process( COMMAND which mpiifort
+                     OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
+                     OUTPUT_STRIP_TRAILING_WHITESPACE )
+  elseif( ${COMM} MATCHES "oneapi" )
+    execute_process( COMMAND which mpiifx
                      OUTPUT_VARIABLE CMAKE_Fortran_COMPILER
                      OUTPUT_STRIP_TRAILING_WHITESPACE )
   else()

--- a/ROMS/Bin/build_roms.csh
+++ b/ROMS/Bin/build_roms.csh
@@ -230,6 +230,7 @@ endif
 #setenv which_MPI           mpich       # compile with MPICH library
 #setenv which_MPI           mpich2      # compile with MPICH2 library
 #setenv which_MPI           mvapich2    # compile with MVAPICH2 library
+#setenv which_MPI           oneapi      # compile with mpiifx library
  setenv which_MPI           openmpi     # compile with OpenMPI library
 
 #setenv USE_OpenMP          on          # shared-memory parallelism

--- a/ROMS/Bin/build_roms.sh
+++ b/ROMS/Bin/build_roms.sh
@@ -232,6 +232,7 @@ fi
 #export         which_MPI=mpich         # compile with MPICH library
 #export         which_MPI=mpich2        # compile with MPICH2 library
 #export         which_MPI=mvapich2      # compile with MVAPICH2 library
+#export         which_MPI=oneapi        # compile with mpiifx library
  export         which_MPI=openmpi       # compile with OpenMPI library
 
 #export        USE_OpenMP=on            # shared-memory parallelism

--- a/ROMS/Bin/cbuild_roms.csh
+++ b/ROMS/Bin/cbuild_roms.csh
@@ -253,6 +253,7 @@ endif
 #setenv which_MPI            mpich           # compile with MPICH library
 #setenv which_MPI            mpich2          # compile with MPICH2 library
 #setenv which_MPI            mvapich2        # compile with MVAPICH2 library
+#setenv which_MPI            oneapi          # compile with mpiifx library
  setenv which_MPI            openmpi         # compile with OpenMPI library
 
 #setenv FORT                 ifx

--- a/ROMS/Bin/cbuild_roms.sh
+++ b/ROMS/Bin/cbuild_roms.sh
@@ -251,6 +251,7 @@ fi
 #export         which_MPI=mpich            # compile with MPICH library
 #export         which_MPI=mpich2           # compile with MPICH2 library
 #export         which_MPI=mvapich2         # compile with MVAPICH2 library
+#export         which_MPI=oneapi           # compile with mpiifx library
  export         which_MPI=openmpi          # compile with OpenMPI library
 
 #export              FORT=ifx


### PR DESCRIPTION
# Description
This PR updates the **`build_roms`** and **`cbuild_roms`** scripts to include Intel Compiler OneAPI compatibility in MPI applications. Now, we have more options to choose:

``` d
 export           USE_MPI=on            # distributed-memory parallelism
 export        USE_MPIF90=on            # compile with mpif90 script
#export         which_MPI=intel         # compile with mpiifort library
#export         which_MPI=mpich         # compile with MPICH library
#export         which_MPI=mpich2        # compile with MPICH2 library
#export         which_MPI=mvapich2      # compile with MVAPICH2 library
 export         which_MPI=oneapi        # compile with mpiifx library
#export         which_MPI=openmpi       # compile with OpenMPI library

#export        USE_OpenMP=on            # shared-memory parallelism

 export              FORT=ifx
#export              FORT=ifort
#export              FORT=gfortran
#export              FORT=pgi
```

It also updated a couple of compilation configuration files.

## Issue(s) addressed
None.